### PR TITLE
ui(but): move `status` tree status coloring from path to status char

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1472,12 +1472,11 @@ fn print_files(
 
     for file in files {
         let state = status_from_changes(changes, file.path.clone());
-        let path = match &state {
-            Some(state) => path_with_color_ui(state, file.path.to_string()),
-            None => Span::raw(file.path.to_string()),
-        };
-
-        let status = state.as_ref().map(status_letter_ui).unwrap_or_default();
+        let path = Span::raw(file.path.to_string());
+        let status = state
+            .as_ref()
+            .map(status_letter_ui)
+            .unwrap_or_else(|| Span::raw(char::default().to_string()));
 
         let cli_id = &file.short_id;
         let id_padding = " ".repeat(max_id_width.saturating_sub(cli_id.len()) + 1);
@@ -1495,7 +1494,7 @@ fn print_files(
                 Span::styled(cli_id.to_string(), t.cli_id),
                 Span::raw(id_padding),
             ]),
-            status: Vec::from([Span::raw(status.to_string()), Span::raw(" ")]),
+            status: Vec::from([status, Span::raw(" ")]),
             path: Vec::from([path]),
         };
 
@@ -1871,41 +1870,23 @@ fn lookup_cli_id_for_short_id(
     }
 }
 
-fn status_letter(status: &TreeStatus) -> char {
-    match status {
-        TreeStatus::Addition { .. } => 'A',
-        TreeStatus::Deletion { .. } => 'D',
-        TreeStatus::Modification { .. } => 'M',
-        TreeStatus::Rename { .. } => 'R',
-    }
-}
-
-pub fn status_letter_ui(status: &ui::TreeStatus) -> char {
-    match status {
-        ui::TreeStatus::Addition { .. } => 'A',
-        ui::TreeStatus::Deletion { .. } => 'D',
-        ui::TreeStatus::Modification { .. } => 'M',
-        ui::TreeStatus::Rename { .. } => 'R',
-    }
-}
-
-pub fn path_with_color_ui(status: &ui::TreeStatus, path: String) -> Span<'static> {
+fn status_letter(status: &TreeStatus) -> Span<'static> {
     let t = crate::theme::get();
     match status {
-        ui::TreeStatus::Addition { .. } => Span::styled(path, t.addition),
-        ui::TreeStatus::Deletion { .. } => Span::styled(path, t.deletion),
-        ui::TreeStatus::Modification { .. } => Span::styled(path, t.modification),
-        ui::TreeStatus::Rename { .. } => Span::styled(path, t.renaming),
+        TreeStatus::Addition { .. } => Span::styled("A", t.addition),
+        TreeStatus::Deletion { .. } => Span::styled("D", t.deletion),
+        TreeStatus::Modification { .. } => Span::styled("M", t.modification),
+        TreeStatus::Rename { .. } => Span::styled("R", t.renaming),
     }
 }
 
-fn path_with_color(status: &TreeStatus, path: String) -> Span<'static> {
+fn status_letter_ui(status: &ui::TreeStatus) -> Span<'static> {
     let t = crate::theme::get();
     match status {
-        TreeStatus::Addition { .. } => Span::styled(path, t.addition),
-        TreeStatus::Deletion { .. } => Span::styled(path, t.deletion),
-        TreeStatus::Modification { .. } => Span::styled(path, t.modification),
-        TreeStatus::Rename { .. } => Span::styled(path, t.renaming),
+        ui::TreeStatus::Addition { .. } => Span::styled("A", t.addition),
+        ui::TreeStatus::Deletion { .. } => Span::styled("D", t.deletion),
+        ui::TreeStatus::Modification { .. } => Span::styled("M", t.modification),
+        ui::TreeStatus::Rename { .. } => Span::styled("R", t.renaming),
     }
 }
 
@@ -2127,9 +2108,10 @@ fn displayed_file_id(padded_prefix: Option<&str>, short_id: &str) -> String {
 }
 
 fn tree_change_display_cli(change: &but_core::TreeChange) -> (Span<'static>, Span<'static>) {
-    let path = path_with_color(&change.status, change.path.to_string());
-    let status_letter = status_letter(&change.status);
-    (Span::raw(format!("{status_letter} ")), path)
+    let path = Span::raw(change.path.to_string());
+    let mut status = status_letter(&change.status);
+    status.content.to_mut().push(' ');
+    (status, path)
 }
 
 impl CliDisplay for but_core::TreeChange {

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/back_from_details_switched_to_split_unfocuses_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/back_from_details_switched_to_split_unfocuses_details_001.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
@@ -24,12 +24,12 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130" y="114" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="132" style="fill:#AA00AA;">zo</text>
     <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
@@ -38,12 +38,12 @@
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;">zo:q</text>
-    <text x="106" y="150" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146" y="150" style="fill:#00AA00;">four</text>
+    <text x="106" y="150" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#CCCCCC;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;">zo:k</text>
-    <text x="106" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="168" style="fill:#00AA00;">one</text>
+    <text x="106" y="168" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="168" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
@@ -26,12 +26,12 @@
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="98" y="114" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114 122 130" y="114" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="132" style="fill:#AA00AA;opacity:0.75;">zo</text>
     <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
@@ -40,12 +40,12 @@
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:q</text>
-    <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122 130 138 146" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="106" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:k</text>
-    <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122 130 138" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="106" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122 130 138" y="168" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
@@ -26,12 +26,12 @@
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="98" y="114" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114 122 130" y="114" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="132" style="fill:#AA00AA;opacity:0.75;">zo</text>
     <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
@@ -40,12 +40,12 @@
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:q</text>
-    <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122 130 138 146" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="106" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:k</text>
-    <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122 130 138" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="106" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122 130 138" y="168" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
@@ -27,12 +27,12 @@
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130" y="114" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="132" style="fill:#AA00AA;opacity:0.75;">zo</text>
     <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
@@ -41,12 +41,12 @@
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:q</text>
-    <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122 130 138 146" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="106" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:k</text>
-    <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122 130 138" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="106" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122 130 138" y="168" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_final.svg
@@ -12,8 +12,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_showing_global_file_list.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_showing_global_file_list.svg
@@ -12,8 +12,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>
@@ -28,8 +28,8 @@
     <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_001.svg
@@ -47,8 +47,8 @@
     <text x="258" y="168" style="fill:#CCCCCC;opacity:0.75;">}</text>
     <text x="10 18 26" y="186" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">ok</text>
-    <text x="82" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="186" style="fill:#00AA00;opacity:0.75;">wt-file.txt</text>
+    <text x="82" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="186" style="fill:#CCCCCC;opacity:0.75;">wt-file.txt</text>
     <text x="10 18 26 34" y="204" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="204" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="204" style="fill:#FFFFFF;font-weight:bold;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_002.svg
@@ -39,8 +39,8 @@
     <text x="258" y="168" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="186" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="186" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="186" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="186" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="186" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="186" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="204" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="204" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="204" style="fill:#CCCCCC;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/close_split_details_with_escape_closed.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/close_split_details_with_escape_closed.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/close_split_details_with_escape_open.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/close_split_details_with_escape_open.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_all_changes_of_a_worktree_from_its_reference_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_all_changes_of_a_worktree_from_its_reference_001.svg
@@ -32,8 +32,8 @@
     <text x="362" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;opacity:0.75;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;opacity:0.75;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#FFFFFF;font-weight:bold;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_confirm_on_source_is_noop_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_confirm_on_source_is_noop_final.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_list_scopes_cursor_to_files_in_selected_commit_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_list_scopes_cursor_to_files_in_selected_commit_final.svg
@@ -23,8 +23,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_enter_and_escape_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_enter_and_escape_final.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_shows_commit_below_on_commit_rows_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_shows_commit_below_on_commit_rows_final.svg
@@ -17,8 +17,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_one_worktree_file_onto_its_own_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_one_worktree_file_onto_its_own_branch_001.svg
@@ -32,8 +32,8 @@
     <text x="82 90 98 106 114 122" y="114" style="fill:#FFFFFF;">source</text>
     <text x="138 146" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="162 170" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="186" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218 226 234 242 250 258 266 274 282" y="114" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="186" y="114" style="fill:#00AA00;">A</text>
+    <text x="202 210 218 226 234 242 250 258 266 274 282" y="114" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#FFFFFF;font-weight:bold;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_from_a_worktree_area_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_from_a_worktree_area_final.svg
@@ -35,8 +35,8 @@
     <text x="450" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;opacity:0.75;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;opacity:0.75;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#CCCCCC;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_with_marks_is_selectable_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_with_marks_is_selectable_001.svg
@@ -31,13 +31,13 @@
     <text x="170 178 186 194" y="42" style="fill:#000000;font-weight:bold;">noop</text>
     <text x="210 218" y="42" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="234 242" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="274" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="290 298 306" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="274" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="290 298 306" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_without_marks_is_selectable_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_without_marks_is_selectable_001.svg
@@ -27,13 +27,13 @@
     <text x="170 178 186 194" y="42" style="fill:#000000;font-weight:bold;">noop</text>
     <text x="210 218" y="42" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="234 242" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="274" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="290 298 306" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="274" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="290 298 306" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_a_detached_worktree_reference_is_refused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_a_detached_worktree_reference_is_refused.svg
@@ -25,8 +25,8 @@
     <text x="258" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#FFFFFF;font-weight:bold;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_001.svg
@@ -17,12 +17,12 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vn</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;opacity:0.75;">editor.sh</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;opacity:0.75;">editor.sh</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_001.svg
@@ -17,12 +17,12 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vn</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;opacity:0.75;">editor.sh</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;opacity:0.75;">editor.sh</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_001.svg
@@ -17,8 +17,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_002.svg
@@ -17,8 +17,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_003.svg
@@ -17,8 +17,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_with_inline_reword_004.svg
@@ -17,8 +17,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_001.svg
@@ -32,8 +32,8 @@
     <text x="138" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">v:t</text>
-    <text x="98" y="150" style="fill:#CCCCCC;">M</text>
-    <text x="114" y="150" style="fill:#AA5500;">A</text>
+    <text x="98" y="150" style="fill:#AA5500;">M</text>
+    <text x="114" y="150" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="168" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -41,8 +41,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="186" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;">A</text>
+    <text x="98" y="186" style="fill:#00AA00;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_002.svg
@@ -44,8 +44,8 @@
     <text x="242" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">v:t</text>
-    <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">M</text>
-    <text x="114" y="150" style="fill:#AA5500;opacity:0.75;">A</text>
+    <text x="98" y="150" style="fill:#AA5500;opacity:0.75;">M</text>
+    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10" y="168" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="168" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="50 58" y="168" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
@@ -60,8 +60,8 @@
     <text x="306" y="168" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_003.svg
@@ -49,8 +49,8 @@
     <text x="242" y="150" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">v:t</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">M</text>
-    <text x="114" y="168" style="fill:#AA5500;opacity:0.75;">A</text>
+    <text x="98" y="168" style="fill:#AA5500;opacity:0.75;">M</text>
+    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="186" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="186" style="fill:#FFFFFF;">&lt;&lt;</text>
@@ -62,8 +62,8 @@
     <text x="218" y="186" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="204" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="204" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="204" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="204" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="204" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="258" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_004.svg
@@ -23,8 +23,8 @@
     <text x="138" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">u:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">M</text>
-    <text x="114" y="96" style="fill:#AA5500;">A</text>
+    <text x="98" y="96" style="fill:#AA5500;">M</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="114" style="fill:#AA00AA;font-weight:bold;">s</text>
     <text x="58 66" y="114" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
@@ -32,8 +32,8 @@
     <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">s:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="132" style="fill:#00AA00;">A</text>
+    <text x="98" y="132" style="fill:#00AA00;">A</text>
+    <text x="114" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="186" style="fill:#CCCCCC;">┊╭┄</text>
@@ -48,8 +48,8 @@
     <text x="138" y="204" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="222" style="fill:#0000AA;font-weight:bold;">v:t</text>
-    <text x="98" y="222" style="fill:#CCCCCC;">M</text>
-    <text x="114" y="222" style="fill:#AA5500;">A</text>
+    <text x="98" y="222" style="fill:#AA5500;">M</text>
+    <text x="114" y="222" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="240" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="240" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -57,8 +57,8 @@
     <text x="114" y="240" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="258" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="258" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="258" style="fill:#00AA00;">A</text>
+    <text x="98" y="258" style="fill:#00AA00;">A</text>
+    <text x="114" y="258" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="294" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_full_screen_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_full_screen_details_002.svg
@@ -28,8 +28,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
@@ -37,8 +37,8 @@
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490" y="60" style="fill:#555555;">│─────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_split_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_split_details_001.svg
@@ -23,14 +23,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_split_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_split_details_002.svg
@@ -33,8 +33,8 @@
     <text x="170 178 186 194" y="42" style="fill:#000000;font-weight:bold;">noop</text>
     <text x="210 218" y="42" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="234 242" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="274" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="290 298 306" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="274" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="290 298 306" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
@@ -42,8 +42,8 @@
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_full_screen_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_full_screen_details_002.svg
@@ -24,13 +24,13 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490" y="60" style="fill:#555555;">│─────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_full_screen_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_full_screen_details_003.svg
@@ -15,8 +15,8 @@
     <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794 802" y="24" style="fill:#00AAAA;">ee9a59390fd20310665925237de1124c6b7982</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_001.svg
@@ -18,13 +18,13 @@
     <text x="578 586" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_002.svg
@@ -24,13 +24,13 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490" y="60" style="fill:#555555;">│─────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_003.svg
@@ -15,8 +15,8 @@
     <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794 802" y="24" style="fill:#00AAAA;">ee9a59390fd20310665925237de1124c6b7982</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_stay_when_closing_detail_view_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_stay_when_closing_detail_view_001.svg
@@ -24,21 +24,21 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">kl:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_stay_when_closing_full_screen_detail_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_stay_when_closing_full_screen_detail_view_002.svg
@@ -13,17 +13,17 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="114" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_stay_when_leaving_detail_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_stay_when_leaving_detail_mode_001.svg
@@ -22,14 +22,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="42" style="fill:#555555;">│───────────────</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="434" y="60" style="fill:#555555;">┊</text>
     <text x="450" y="60" style="fill:#00AA00;">1</text>
@@ -40,8 +40,8 @@
     <text x="578 586 594" y="60" style="fill:#CDD6F4;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="96" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_use_the_backstack_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_use_the_backstack_001.svg
@@ -19,21 +19,21 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">──────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#FFA500;">▌</text>
     <text x="426 434 442 450" y="78" style="fill:#0000AA;">kl:f</text>
     <text x="466 474 482" y="78" style="fill:#CCCCCC;">one</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_use_the_backstack_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_use_the_backstack_002.svg
@@ -22,14 +22,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="42" style="fill:#555555;">│───────────────</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="434" y="60" style="fill:#555555;">┊</text>
     <text x="450" y="60" style="fill:#00AA00;">1</text>
@@ -40,8 +40,8 @@
     <text x="578 586 594" y="60" style="fill:#CDD6F4;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="96" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_use_the_backstack_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/detail_marks_use_the_backstack_003.svg
@@ -19,20 +19,20 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426 434 442 450" y="78" style="fill:#0000AA;">kl:f</text>
     <text x="466 474 482" y="78" style="fill:#CCCCCC;">one</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_cursor_stays_visible_after_resizing_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_cursor_stays_visible_after_resizing_001.svg
@@ -15,16 +15,16 @@
     <text x="642" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">xz</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130" y="42" style="fill:#00AA00;">alpha.t</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130" y="42" style="fill:#CCCCCC;">alpha.t</text>
     <text x="138" y="42" style="fill:#FFA500;">▌</text>
     <text x="154 162 170 178" y="42" style="fill:#0000AA;">xz:9</text>
     <text x="194 202 210 218 226 234 242 250 258" y="42" style="fill:#CCCCCC;">alpha.txt</text>
     <text x="274" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">vq</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130" y="60" style="fill:#00AA00;">beta.tx</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130" y="60" style="fill:#CCCCCC;">beta.tx</text>
     <text x="138" y="60" style="fill:#FFA500;">▌</text>
     <text x="146 154 162 170 178 186 194 202 210 218 226 234 242 250 258 266 274" y="60" style="fill:#555555;">────────────────╯</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_diff_svg_shows_plus_and_minus_backgrounds_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_diff_svg_shows_plus_and_minus_backgrounds_001.svg
@@ -18,8 +18,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-1</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">tm</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82" y="42" style="fill:#AA5500;">A</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482" y="60" style="fill:#555555;">│────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_highlights_swift_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_highlights_swift_001.svg
@@ -26,8 +26,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">vp</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">AppModel.swift</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">AppModel.swift</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_renders_multiple_hunks_and_files_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_renders_multiple_hunks_and_files_001.svg
@@ -25,14 +25,14 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">xz</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">alpha.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">alpha.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">vq</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">beta.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">beta.txt</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546" y="60" style="fill:#555555;">│────────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_renders_tab_indented_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_renders_tab_indented_file_001.svg
@@ -21,8 +21,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">yk</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226" y="42" style="fill:#00AA00;">tab-indented.svelte</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226" y="42" style="fill:#CCCCCC;">tab-indented.svelte</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626" y="60" style="fill:#555555;">│──────────────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_001.svg
@@ -20,15 +20,15 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586" y="60" style="fill:#555555;">│─────────────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_002.svg
@@ -22,16 +22,16 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586" y="42" style="fill:#555555;">─────────────────────╯</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#FFA500;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_003.svg
@@ -16,16 +16,16 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586" y="42" style="fill:#555555;">─────────────────────╮</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="426 434 442 450" y="60" style="fill:#0000AA;">su:3</text>
     <text x="466 474 482 490 498" y="60" style="fill:#CCCCCC;">first</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_004.svg
@@ -28,9 +28,9 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="434" y="42" style="fill:#555555;">┊</text>
     <text x="466" y="42" style="fill:#00AA00;">5</text>
@@ -39,9 +39,9 @@
     <text x="506 514 522 530 538 546 554 562" y="42" style="fill:#CDD6F4;">line-005</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="434" y="60" style="fill:#555555;">┊</text>
     <text x="466" y="60" style="fill:#00AA00;">6</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_005.svg
@@ -16,16 +16,16 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586" y="42" style="fill:#555555;">─────────────────────╮</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="426 434 442 450" y="60" style="fill:#0000AA;">su:3</text>
     <text x="466 474 482 490 498" y="60" style="fill:#CCCCCC;">first</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_006.svg
@@ -17,9 +17,9 @@
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594" y="24" style="fill:#555555;">──────────────────────╮</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="426 434 442 450" y="42" style="fill:#0000AA;">qr:3</text>
     <text x="466 474 482 490 498 506" y="42" style="fill:#CCCCCC;">second</text>
@@ -27,9 +27,9 @@
     <text x="594" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594" y="60" style="fill:#555555;">──────────────────────╯</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_007.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_supports_scroll_controls_007.svg
@@ -18,9 +18,9 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">su</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">first</text>
-    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">first</text>
+    <text x="130 138 146 154 162 170 178 186" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="426 434 442 450" y="42" style="fill:#0000AA;">su:3</text>
     <text x="466 474 482 490 498" y="42" style="fill:#CCCCCC;">first</text>
@@ -28,9 +28,9 @@
     <text x="586" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">qr</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="60" style="fill:#00AA00;">second</text>
-    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="60" style="fill:#CCCCCC;">second</text>
+    <text x="138 146 154 162 170 178 186 194" y="60" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586" y="60" style="fill:#555555;">─────────────────────╯</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_syntax_highlighting_survives_scrolling_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_syntax_highlighting_survives_scrolling_001.svg
@@ -20,8 +20,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kn</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">syntax.rs</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">syntax.rs</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546" y="60" style="fill:#555555;">│────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_syntax_highlighting_survives_scrolling_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_syntax_highlighting_survives_scrolling_002.svg
@@ -37,8 +37,8 @@
     <text x="802" y="24" style="fill:#CBA6F7;">l</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kn</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">syntax.rs</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">syntax.rs</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="434" y="42" style="fill:#555555;">┊</text>
     <text x="466" y="42" style="fill:#00AA00;">4</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_syntax_highlighting_survives_scrolling_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_syntax_highlighting_survives_scrolling_003.svg
@@ -20,8 +20,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kn</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">syntax.rs</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">syntax.rs</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/dims_unselectable_lines_while_in_command_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/dims_unselectable_lines_while_in_command_mode_001.svg
@@ -14,18 +14,18 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="78" style="fill:#000000;">✔︎</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/dims_unselectable_lines_while_in_details_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/dims_unselectable_lines_while_in_details_mode_001.svg
@@ -25,22 +25,22 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="78" style="fill:#000000;">✔︎</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">kl:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
@@ -10,20 +10,20 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">px</text>
-    <text x="82" y="96" style="fill:#CCCCCC;">M</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#AA5500;">x-file</text>
+    <text x="82" y="96" style="fill:#AA5500;">M</text>
+    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;">x-file</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;">br</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
@@ -10,20 +10,20 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">px</text>
-    <text x="82" y="96" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#AA5500;font-weight:bold;">x-file</text>
+    <text x="82" y="96" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="98 106 114 122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">x-file</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;">br</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
@@ -18,27 +18,27 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-1</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">─────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#FFA500;">▌</text>
     <text x="426 434 442 450" y="78" style="fill:#0000AA;">px:e</text>
     <text x="466 474 482 490 498 506" y="78" style="fill:#CCCCCC;">x-file</text>
     <text x="522" y="78" style="fill:#555555;">│</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">px</text>
-    <text x="82" y="96" style="fill:#CCCCCC;">M</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#AA5500;">x-file</text>
+    <text x="82" y="96" style="fill:#AA5500;">M</text>
+    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;">x-file</text>
     <text x="410" y="96" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="96" style="fill:#555555;">─────────────╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
@@ -19,20 +19,20 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426 434 442 450" y="78" style="fill:#0000AA;">kl:f</text>
     <text x="466 474 482" y="78" style="fill:#CCCCCC;">one</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_001.svg
@@ -18,13 +18,13 @@
     <text x="522 530" y="24" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="42" style="fill:#555555;">│───────────────</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="434" y="60" style="fill:#555555;">┊</text>
     <text x="450" y="60" style="fill:#00AA00;">1</text>
@@ -35,8 +35,8 @@
     <text x="578 586 594" y="60" style="fill:#CDD6F4;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="96" style="fill:#555555;">│────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_002.svg
@@ -19,13 +19,13 @@
     <text x="522 530" y="24" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="42" style="fill:#555555;">│───────────────</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="434" y="60" style="fill:#555555;">┊</text>
     <text x="450" y="60" style="fill:#00AA00;">1</text>
@@ -36,8 +36,8 @@
     <text x="578 586 594" y="60" style="fill:#CDD6F4;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="96" style="fill:#555555;">│────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_003.svg
@@ -18,13 +18,13 @@
     <text x="578 586" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="60" style="fill:#00AA00;">three</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_004.svg
@@ -19,13 +19,13 @@
     <text x="578 586" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="60" style="fill:#00AA00;">three</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_005.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_uncommitted_006.svg
@@ -18,8 +18,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
@@ -24,16 +24,16 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
@@ -30,16 +30,16 @@
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
-    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
-    <text x="234 242 250" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
+    <text x="218" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="150" style="fill:#555555;">╭────────────────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
@@ -24,12 +24,12 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138 146 154" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="114" style="fill:#00AA00;">two</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="114" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
@@ -24,16 +24,16 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
@@ -30,16 +30,16 @@
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
-    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
-    <text x="234 242 250" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
+    <text x="218" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="150" style="fill:#555555;">╭────────────────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
@@ -24,12 +24,12 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138 146 154" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="114" style="fill:#00AA00;">two</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="114" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
@@ -25,12 +25,12 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138 146 154" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="114" style="fill:#00AA00;">two</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="114" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546" y="150" style="fill:#555555;">╭──────────────────────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
@@ -25,8 +25,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
@@ -24,16 +24,16 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
@@ -27,17 +27,17 @@
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
@@ -33,20 +33,20 @@
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;">&gt;&gt;</text>
     <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
-    <text x="218" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="234 242 250" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
+    <text x="218" y="96" style="fill:#00AA00;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#CCCCCC;text-decoration:line-through;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="114" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="114" style="fill:#000000;">discard</text>
     <text x="154 162" y="114" style="fill:#000000;">&gt;&gt;</text>
     <text x="178 186 194 202" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:o</text>
-    <text x="218" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="234 242 250 258 266" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
+    <text x="218" y="114" style="fill:#00AA00;text-decoration:line-through;">A</text>
+    <text x="234 242 250 258 266" y="114" style="fill:#CCCCCC;text-decoration:line-through;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498" y="150" style="fill:#555555;">╭──────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;">two</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="96" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
@@ -24,16 +24,16 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
@@ -27,17 +27,17 @@
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
@@ -33,20 +33,20 @@
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;">&gt;&gt;</text>
     <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
-    <text x="218" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="234 242 250" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
+    <text x="218" y="96" style="fill:#00AA00;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#CCCCCC;text-decoration:line-through;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="114" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="114" style="fill:#000000;">discard</text>
     <text x="154 162" y="114" style="fill:#000000;">&gt;&gt;</text>
     <text x="178 186 194 202" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:o</text>
-    <text x="218" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="234 242 250 258 266" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
+    <text x="218" y="114" style="fill:#00AA00;text-decoration:line-through;">A</text>
+    <text x="234 242 250 258 266" y="114" style="fill:#CCCCCC;text-decoration:line-through;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498" y="150" style="fill:#555555;">╭──────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
-    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="106" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_prompt_can_be_cancelled_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_prompt_can_be_cancelled_final.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_uncommitted_cancel_keeps_changes_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_uncommitted_cancel_keeps_changes_final.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/empty_commit_on_a_worktree_reference_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/empty_commit_on_a_worktree_reference_final.svg
@@ -25,8 +25,8 @@
     <text x="258" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#CCCCCC;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/from_squash_mode_to_commit_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/from_squash_mode_to_commit_mode_001.svg
@@ -15,12 +15,12 @@
     <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/from_squash_mode_to_commit_mode_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/from_squash_mode_to_commit_mode_002.svg
@@ -20,12 +20,12 @@
     <text x="338" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/from_squash_mode_to_commit_mode_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/from_squash_mode_to_commit_mode_003.svg
@@ -15,12 +15,12 @@
     <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_does_not_restrict_cursor_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_does_not_restrict_cursor_final.svg
@@ -23,8 +23,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -39,8 +39,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_discarding_the_last_file_in_a_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_discarding_the_last_file_in_a_commit_001.svg
@@ -23,8 +23,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -39,8 +39,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_discarding_the_last_file_in_a_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_discarding_the_last_file_in_a_commit_002.svg
@@ -37,8 +37,8 @@
     <text x="114" y="150" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;">B</text>
+    <text x="98" y="168" style="fill:#00AA00;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_marking_and_discarding_all_files_in_a_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_marking_and_discarding_all_files_in_a_commit_001.svg
@@ -32,8 +32,8 @@
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">t:t</text>
-    <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
-    <text x="226" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">A</text>
+    <text x="210" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">A</text>
+    <text x="226" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -51,8 +51,8 @@
     <text x="498" y="168" style="fill:#555555;">│</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="314" y="186" style="fill:#555555;">│</text>
     <text x="346 354 362 370 378 386 394 402" y="186" style="fill:#CCCCCC;">Discard?</text>
     <text x="498" y="186" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_marking_and_discarding_all_files_in_a_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_marking_and_discarding_all_files_in_a_commit_002.svg
@@ -37,8 +37,8 @@
     <text x="114" y="150" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;">B</text>
+    <text x="98" y="168" style="fill:#00AA00;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/highlighting_multiline_things_work_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/highlighting_multiline_things_work_001.svg
@@ -23,8 +23,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">sx</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122" y="42" style="fill:#00AA00;">one.py</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122" y="42" style="fill:#CCCCCC;">one.py</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/highlights_exact_matches_when_file_list_is_open_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/highlights_exact_matches_when_file_list_is_open_001.svg
@@ -28,8 +28,8 @@
     <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">t</text>
     <text x="74" y="96" style="fill:#000000;">:</text>
     <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -44,8 +44,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">C</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">x:w</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">C</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">C</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="222" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="222" style="fill:#0000AA;font-weight:bold;opacity:0.75;">i0</text>
@@ -59,8 +59,8 @@
     <text x="114" y="240" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="258" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="258" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="258" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="258" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="258" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="294" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/highlights_exact_matches_when_file_list_is_open_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/highlights_exact_matches_when_file_list_is_open_002.svg
@@ -29,8 +29,8 @@
     <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">t</text>
     <text x="74" y="96" style="fill:#000000;">:</text>
     <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -45,8 +45,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">C</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">x:w</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">C</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">C</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="222" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="222" style="fill:#0000AA;font-weight:bold;opacity:0.75;">i0</text>
@@ -60,8 +60,8 @@
     <text x="114" y="240" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="258" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="258" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="258" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="258" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="258" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="294" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/highlights_exact_matches_when_file_list_is_open_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/highlights_exact_matches_when_file_list_is_open_003.svg
@@ -29,8 +29,8 @@
     <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">t</text>
     <text x="74" y="96" style="fill:#000000;font-weight:bold;">:</text>
     <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -45,8 +45,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">C</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">x:w</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">C</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">C</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="222" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="222" style="fill:#0000AA;font-weight:bold;opacity:0.75;">i0</text>
@@ -60,8 +60,8 @@
     <text x="114" y="240" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="258" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="258" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="258" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="258" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="258" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="294" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jump_from_other_modes_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jump_from_other_modes_001.svg
@@ -15,8 +15,8 @@
     <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jump_from_other_modes_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jump_from_other_modes_002.svg
@@ -21,8 +21,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42" y="42" style="fill:#000000;opacity:0.75;">k</text>
     <text x="50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42" y="78" style="fill:#000000;">g</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jump_from_other_modes_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jump_from_other_modes_003.svg
@@ -16,8 +16,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_001.svg
@@ -24,23 +24,23 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42" y="42" style="fill:#000000;">k</text>
     <text x="50 58" y="42" style="fill:#0000AA;font-weight:bold;">lx</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106" y="42" style="fill:#CCCCCC;">kl</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42" y="60" style="fill:#000000;">k</text>
     <text x="50 58" y="60" style="fill:#0000AA;font-weight:bold;">lz</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42" y="78" style="fill:#000000;">o</text>
     <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">r</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42" y="96" style="fill:#000000;">t</text>
     <text x="50 58 66" y="96" style="fill:#0000AA;font-weight:bold;">wop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42" y="132" style="fill:#000000;">g</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_002.svg
@@ -10,20 +10,20 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58" y="42" style="fill:#0000AA;font-weight:bold;">klx</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106" y="42" style="fill:#CCCCCC;">kl</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58" y="60" style="fill:#0000AA;font-weight:bold;">klz</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="96" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_003.svg
@@ -13,21 +13,21 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
     <text x="58" y="42" style="fill:#000000;">x</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106" y="42" style="fill:#CCCCCC;">kl</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">kl</text>
     <text x="58" y="60" style="fill:#000000;">z</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">or</text>
-    <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_004.svg
@@ -14,21 +14,21 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
     <text x="58" y="42" style="fill:#000000;">x</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106" y="42" style="fill:#CCCCCC;">kl</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">kl</text>
     <text x="58" y="60" style="fill:#000000;font-weight:bold;">z</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">or</text>
-    <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_005.svg
@@ -14,21 +14,21 @@
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
     <text x="58" y="42" style="fill:#000000;font-weight:bold;">x</text>
-    <text x="82" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;font-weight:bold;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">kl</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">kl</text>
     <text x="58" y="60" style="fill:#000000;">z</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">or</text>
-    <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_006.svg
@@ -10,20 +10,20 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58" y="42" style="fill:#0000AA;font-weight:bold;">klx</text>
-    <text x="82" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;font-weight:bold;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">kl</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58" y="60" style="fill:#0000AA;font-weight:bold;">klz</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="96" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_008.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/jumping_around_008.svg
@@ -10,20 +10,20 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58" y="42" style="fill:#0000AA;font-weight:bold;">klx</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106" y="42" style="fill:#00AA00;">kl</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106" y="42" style="fill:#CCCCCC;">kl</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58" y="60" style="fill:#0000AA;font-weight:bold;">klz</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">one</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#00AA00;">three</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;">three</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="96" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="96" style="fill:#00AA00;">two</text>
+    <text x="82" y="96" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="96" style="fill:#CCCCCC;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="132" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/leaving_command_mode_from_details_puts_you_back_in_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/leaving_command_mode_from_details_puts_you_back_in_details_001.svg
@@ -22,21 +22,21 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#0000AA;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">─────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#0000AA;">▌</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">kl:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/manual_reload_does_not_highlight_details_when_status_is_focused_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/manual_reload_does_not_highlight_details_when_status_is_focused_001.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ln</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194" y="42" style="fill:#00AA00;">uncommitted.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194" y="42" style="fill:#CCCCCC;">uncommitted.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594" y="60" style="fill:#555555;">│──────────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/manual_reload_preserves_marks_when_split_details_visible_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/manual_reload_preserves_marks_when_split_details_visible_001.svg
@@ -19,13 +19,13 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="60" style="fill:#555555;">│────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_001.svg
@@ -22,8 +22,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="60" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="42 50" y="60" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
@@ -33,12 +33,12 @@
     <text x="170 178 186 194" y="60" style="fill:#000000;font-weight:bold;">noop</text>
     <text x="210 218" y="60" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="234 242" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="274" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="290 298 306 314 322" y="60" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="274" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="290 298 306 314 322" y="60" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -26,12 +26,12 @@
     <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">w:k</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">one</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130" y="114" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">w:o</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="132" style="fill:#00AA00;">three</text>
+    <text x="98" y="132" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138 146" y="132" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#AA00AA;">tp</text>
     <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;">m</text>
@@ -39,8 +39,8 @@
     <text x="114" y="150" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;">tp:t</text>
-    <text x="106" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="122" y="168" style="fill:#00AA00;">A</text>
+    <text x="106" y="168" style="fill:#00AA00;">A</text>
+    <text x="122" y="168" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_discard_uncommitted_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_discard_uncommitted_files_final.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="78" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_001.svg
@@ -18,8 +18,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_002.svg
@@ -26,8 +26,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_003.svg
@@ -22,8 +22,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">—</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_001.svg
@@ -18,14 +18,14 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="60" style="fill:#555555;">│───────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_002.svg
@@ -25,14 +25,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="60" style="fill:#555555;">│──────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_003.svg
@@ -20,8 +20,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="426" y="42" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="42" style="fill:#0000AA;">qs:d</text>
@@ -29,8 +29,8 @@
     <text x="530" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="60" style="fill:#555555;">│──────────────╯</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_004.svg
@@ -16,16 +16,16 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">—</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="426 434 442 450" y="42" style="fill:#0000AA;">qs:d</text>
     <text x="466 474 482 490" y="42" style="fill:#CCCCCC;">file</text>
     <text x="506" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="60" style="fill:#555555;">│───────────╯</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_005.svg
@@ -18,8 +18,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">—</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="426 434 442 450" y="42" style="fill:#0000AA;">qs:d</text>
     <text x="466 474 482 490" y="42" style="fill:#CCCCCC;">file</text>
@@ -27,8 +27,8 @@
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="60" style="fill:#555555;">│───────────╯</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_001.svg
@@ -26,14 +26,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="60" style="fill:#555555;">│──────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_002.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">new-file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_001.svg
@@ -39,8 +39,8 @@
     <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">n:q</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">M</text>
-    <text x="114 122 130 138" y="168" style="fill:#AA5500;">file</text>
+    <text x="98" y="168" style="fill:#AA5500;">M</text>
+    <text x="114 122 130 138" y="168" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="204" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="204" style="fill:#0000AA;font-weight:bold;">an</text>
@@ -55,8 +55,8 @@
     <text x="170 178 186 194 202 210 218 226" y="222" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="240" style="fill:#0000AA;font-weight:bold;">x:q</text>
-    <text x="98" y="240" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="240" style="fill:#00AA00;">file</text>
+    <text x="98" y="240" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="240" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="276" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="294" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_002.svg
@@ -49,8 +49,8 @@
     <text x="314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498" y="150" style="fill:#555555;">╭──────────────────────╮</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">n:q</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">M</text>
-    <text x="114 122 130 138" y="168" style="fill:#AA5500;opacity:0.75;">file</text>
+    <text x="98" y="168" style="fill:#AA5500;opacity:0.75;">M</text>
+    <text x="114 122 130 138" y="168" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="314" y="168" style="fill:#555555;">│</text>
     <text x="498" y="168" style="fill:#555555;">│</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
@@ -80,8 +80,8 @@
     <text x="498" y="222" style="fill:#555555;">│</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="240" style="fill:#0000AA;font-weight:bold;opacity:0.75;">x:q</text>
-    <text x="98" y="240" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="240" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="98" y="240" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138" y="240" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="314" y="240" style="fill:#555555;">│</text>
     <text x="498" y="240" style="fill:#555555;">│</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_001.svg
@@ -22,20 +22,20 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">kl:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_002.svg
@@ -22,14 +22,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="42" style="fill:#555555;">│───────────────</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="434" y="60" style="fill:#555555;">┊</text>
     <text x="450" y="60" style="fill:#00AA00;">1</text>
@@ -40,8 +40,8 @@
     <text x="578 586 594" y="60" style="fill:#CDD6F4;">one</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="96" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_003.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_uncommitted_hunks_004.svg
@@ -20,8 +20,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#0000AA;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_001.svg
@@ -26,8 +26,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -43,8 +43,8 @@
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="240" style="fill:#CCCCCC;">┊╭┄</text>
@@ -60,8 +60,8 @@
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
-    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="98" y="276" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_002.svg
@@ -27,8 +27,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
@@ -45,8 +45,8 @@
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="240" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -62,8 +62,8 @@
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
-    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="98" y="276" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_003.svg
@@ -29,8 +29,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
@@ -47,8 +47,8 @@
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#FFFFFF;font-weight:bold;">┊</text>
@@ -65,8 +65,8 @@
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
-    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="98" y="276" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_004.svg
@@ -42,8 +42,8 @@
     <text x="426 434 442 450 458 466 474 482" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
@@ -63,8 +63,8 @@
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#CCCCCC;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┊</text>
@@ -84,8 +84,8 @@
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
-    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="98" y="276" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_005.svg
@@ -24,16 +24,16 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">q:k</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">q:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138 146" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">q:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="98" y="132" style="fill:#00AA00;">A</text>
+    <text x="114 122 130" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_in_pick_changes_marks_hunks_in_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_in_pick_changes_marks_hunks_in_details_001.svg
@@ -21,8 +21,8 @@
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="42" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106" y="42" style="fill:#00AA00;font-weight:bold;">file</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="60" style="fill:#555555;">│──────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_001.svg
@@ -26,8 +26,8 @@
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="42" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;font-weight:bold;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_002.svg
@@ -18,8 +18,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;font-weight:bold;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_003.svg
@@ -25,8 +25,8 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">—</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_004.svg
@@ -26,8 +26,8 @@
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="42" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;font-weight:bold;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_005.svg
@@ -18,8 +18,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;font-weight:bold;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_001.svg
@@ -26,15 +26,15 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="60" style="fill:#555555;">│──────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_002.svg
@@ -18,14 +18,14 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">M</text>
-    <text x="82 90 98 106" y="42" style="fill:#AA5500;">file</text>
+    <text x="66" y="42" style="fill:#AA5500;">M</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="60" style="fill:#555555;">│───────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_cleared_when_closing_commit_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_cleared_when_closing_commit_file_list_001.svg
@@ -26,8 +26,8 @@
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_cleared_when_closing_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_cleared_when_closing_global_file_list_001.svg
@@ -26,8 +26,8 @@
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -42,8 +42,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_spanning_worktrees_are_refused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_spanning_worktrees_are_refused.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">nu</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178" y="42" style="fill:#00AA00;">main-file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178" y="42" style="fill:#CCCCCC;">main-file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -27,8 +27,8 @@
     <text x="258" y="114" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="132" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="132" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="132" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="132" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="150" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="150" style="fill:#FFFFFF;font-weight:bold;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_stay_when_going_straight_from_split_to_fullscreen_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_stay_when_going_straight_from_split_to_fullscreen_002.svg
@@ -12,16 +12,16 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="114" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_001.svg
@@ -12,12 +12,12 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_002.svg
@@ -19,13 +19,13 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="60" style="fill:#555555;">│────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_003.svg
@@ -12,12 +12,12 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_004.svg
@@ -19,13 +19,13 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="60" style="fill:#555555;">│────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_005.svg
@@ -19,13 +19,13 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="60" style="fill:#555555;">│────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mode_toggle_key_c_enters_and_leaves_commit_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mode_toggle_key_c_enters_and_leaves_commit_mode_001.svg
@@ -20,8 +20,8 @@
     <text x="338" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">vo</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;opacity:0.75;">test.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;opacity:0.75;">test.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_reference_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_reference_001.svg
@@ -29,8 +29,8 @@
     <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;opacity:0.75;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;opacity:0.75;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#FFFFFF;font-weight:bold;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_reference_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_reference_002.svg
@@ -25,8 +25,8 @@
     <text x="258" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#CCCCCC;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/normal_and_detail_marks_coexist_in_full_screen_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/normal_and_detail_marks_coexist_in_full_screen_details_002.svg
@@ -14,17 +14,17 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="60" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="114" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/normal_and_detail_marks_coexist_in_split_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/normal_and_detail_marks_coexist_in_split_details_001.svg
@@ -19,18 +19,18 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514" y="60" style="fill:#555555;">│────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426 434 442 450" y="78" style="fill:#0000AA;">or:f</text>
     <text x="466 474 482 490 498" y="78" style="fill:#CCCCCC;">three</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/normal_and_detail_marks_coexist_in_split_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/normal_and_detail_marks_coexist_in_split_details_002.svg
@@ -22,20 +22,20 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410" y="60" style="fill:#0000AA;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">───────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#0000AA;">▌</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">or:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_and_focus_details_split_can_be_closed_with_esc_focused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_and_focus_details_split_can_be_closed_with_esc_focused.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_and_focus_details_split_can_be_closed_with_esc_open.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_and_focus_details_split_can_be_closed_with_esc_open.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_001.svg
@@ -35,8 +35,8 @@
     <text x="666" y="78" style="fill:#555555;">│</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="154" y="96" style="fill:#555555;">│</text>
     <text x="162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;">sublime</text>
     <text x="234 242 250 258 266 274 282" y="96" style="fill:#00AAAA;">Sublime</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_002.svg
@@ -34,8 +34,8 @@
     <text x="666" y="78" style="fill:#555555;">│</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="154" y="96" style="fill:#555555;">│</text>
     <text x="666" y="96" style="fill:#555555;">│</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_003.svg
@@ -23,8 +23,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_committed_file_in_program_004.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">rx</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130" y="42" style="fill:#00AA00;opacity:0.75;">A.touch</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130" y="42" style="fill:#CCCCCC;opacity:0.75;">A.touch</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">g0</text>
@@ -25,8 +25,8 @@
     <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_001.svg
@@ -13,8 +13,8 @@
     <text x="154 162 170 178 186 194 202 210 218 226 234 242 250 258 266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666" y="24" style="fill:#555555;">╭───────────────────────────────────────────────────────────────╮</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;font-weight:bold;">open-me.t</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.t</text>
     <text x="154" y="42" style="fill:#555555;">│</text>
     <text x="162" y="42" style="fill:#CCCCCC;">&gt;</text>
     <text x="666" y="42" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_002.svg
@@ -13,8 +13,8 @@
     <text x="154 162 170 178 186 194 202 210 218 226 234 242 250 258 266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666" y="24" style="fill:#555555;">╭───────────────────────────────────────────────────────────────╮</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;font-weight:bold;">open-me.t</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.t</text>
     <text x="154" y="42" style="fill:#555555;">│</text>
     <text x="162" y="42" style="fill:#CCCCCC;">&gt;</text>
     <text x="178 186 194 202 210" y="42" style="fill:#CCCCCC;">touch</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_003.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#00AA00;font-weight:bold;">open-me.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_004.svg
@@ -10,12 +10,12 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#00AA00;font-weight:bold;">open-me.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">wv</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210" y="60" style="fill:#00AA00;">open-me.txt.touch</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210" y="60" style="fill:#CCCCCC;">open-me.txt.touch</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_001.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#00AA00;font-weight:bold;">open-me.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_002.svg
@@ -10,16 +10,16 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">xy</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226 234 242 250 258" y="42" style="fill:#00AA00;">gitbutler/programs.json</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226 234 242 250 258" y="42" style="fill:#CCCCCC;">gitbutler/programs.json</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162" y="60" style="fill:#00AA00;font-weight:bold;">open-me.txt</text>
+    <text x="66" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="60" style="fill:#FFFFFF;font-weight:bold;">open-me.txt</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">wv</text>
-    <text x="66" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210" y="78" style="fill:#00AA00;">open-me.txt.touch</text>
+    <text x="66" y="78" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;">open-me.txt.touch</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_shows_only_programs_that_match_extension.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_shows_only_programs_that_match_extension.svg
@@ -13,8 +13,8 @@
     <text x="154 162 170 178 186 194 202 210 218 226 234 242 250 258 266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666" y="24" style="fill:#555555;">╭───────────────────────────────────────────────────────────────╮</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;font-weight:bold;">open-me.t</text>
+    <text x="66" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.t</text>
     <text x="154" y="42" style="fill:#555555;">│</text>
     <text x="162" y="42" style="fill:#CCCCCC;">&gt;</text>
     <text x="666" y="42" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_with_multiple_hunks_in_program_from_details_view_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_with_multiple_hunks_in_program_from_details_view_004.svg
@@ -10,12 +10,12 @@
     <text x="146" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
-    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#AA5500;font-weight:bold;">open-me.txt</text>
+    <text x="66" y="42" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#FFFFFF;font-weight:bold;">open-me.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">nv</text>
-    <text x="66" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226 234" y="60" style="fill:#00AA00;">open-me.txt.touch.11</text>
+    <text x="66" y="60" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226 234" y="60" style="fill:#CCCCCC;">open-me.txt.touch.11</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/opening_on_uncommitted_hunk_focuses_that_hunk_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/opening_on_uncommitted_hunk_focuses_that_hunk_001.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">pk</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146 154" y="42" style="fill:#00AA00;">target.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154" y="42" style="fill:#CCCCCC;">target.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_and_goto_noop_when_commit_file_list_open_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_and_goto_noop_when_commit_file_list_open_001.svg
@@ -23,8 +23,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_001.svg
@@ -10,12 +10,12 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_002.svg
@@ -12,12 +12,12 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_supports_focusing_details_view_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_supports_focusing_details_view_001.svg
@@ -18,13 +18,13 @@
     <text x="578 586" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/reverse_squash_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/reverse_squash_001.svg
@@ -16,12 +16,12 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -38,8 +38,8 @@
     <text x="210" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">tp:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="106" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/reverse_squash_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/reverse_squash_002.svg
@@ -23,16 +23,16 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">t:tm</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122" y="96" style="fill:#00AA00;">A</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:k</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="114" style="fill:#00AA00;">one</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="114" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">t:tw</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/sibling_worktree_lanes_are_separated_after_uncommitted_files_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/sibling_worktree_lanes_are_separated_after_uncommitted_files_001.svg
@@ -25,8 +25,8 @@
     <text x="258" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#CCCCCC;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_different_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_different_branch_001.svg
@@ -33,8 +33,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -49,8 +49,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_different_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_different_branch_002.svg
@@ -29,8 +29,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -48,8 +48,8 @@
     <text x="218" y="168" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_different_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_different_branch_003.svg
@@ -23,12 +23,12 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;">B</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_001.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">w:q</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="96" style="fill:#00AA00;">file</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="96" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="114" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -33,8 +33,8 @@
     <text x="114" y="114" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="132" style="fill:#00AA00;">A</text>
+    <text x="98" y="132" style="fill:#00AA00;">A</text>
+    <text x="114" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_002.svg
@@ -34,8 +34,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">w:q</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="96" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="114" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -43,8 +43,8 @@
     <text x="114" y="114" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_003.svg
@@ -30,8 +30,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">w:q</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="96" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="114" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#000000;font-weight:bold;">squash</text>
@@ -42,8 +42,8 @@
     <text x="218" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_004.svg
@@ -23,12 +23,12 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:q</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="114" style="fill:#00AA00;">file</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="114" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_001.svg
@@ -33,8 +33,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -57,8 +57,8 @@
     <text x="114" y="186" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="204" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="204" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="204" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="204" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="204" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="258" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_002.svg
@@ -29,8 +29,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -59,8 +59,8 @@
     <text x="114" y="186" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="204" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="204" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="204" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="204" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="204" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="258" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_003.svg
@@ -24,8 +24,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">n:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="114" style="fill:#AA00AA;">l</text>
     <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">rm</text>
@@ -33,8 +33,8 @@
     <text x="114" y="114" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="132" style="fill:#00AA00;">B</text>
+    <text x="98" y="132" style="fill:#00AA00;">A</text>
+    <text x="114" y="132" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_self_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_self_001.svg
@@ -34,8 +34,8 @@
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">w:q</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="96" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="114" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -43,8 +43,8 @@
     <text x="114" y="114" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_self_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_self_002.svg
@@ -23,12 +23,12 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:q</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="114" style="fill:#00AA00;">file</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="114" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_uncommitted_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_uncommitted_003.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">tm</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="78" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_uncommitted_ignores_use_target_message_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_uncommitted_ignores_use_target_message_004.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">tm</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="78" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_into_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_into_commit_001.svg
@@ -28,8 +28,8 @@
     <text x="218" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -44,8 +44,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_into_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_into_commit_002.svg
@@ -32,12 +32,12 @@
     <text x="114" y="132" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="150" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="150" style="fill:#00AA00;">A</text>
+    <text x="98" y="150" style="fill:#00AA00;">A</text>
+    <text x="114" y="150" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;">B</text>
+    <text x="98" y="168" style="fill:#00AA00;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_to_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_to_branch_001.svg
@@ -28,8 +28,8 @@
     <text x="218" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -44,8 +44,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_to_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_to_branch_002.svg
@@ -29,8 +29,8 @@
     <text x="218" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -51,8 +51,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_to_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_commit_to_branch_003.svg
@@ -32,12 +32,12 @@
     <text x="114" y="132" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="150" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="150" style="fill:#00AA00;">A</text>
+    <text x="98" y="150" style="fill:#00AA00;">A</text>
+    <text x="114" y="150" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;">B</text>
+    <text x="98" y="168" style="fill:#00AA00;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_branch_001.svg
@@ -28,8 +28,8 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="202" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="218" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -44,8 +44,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_branch_002.svg
@@ -29,8 +29,8 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218" y="96" style="fill:#00AA00;">A</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -51,8 +51,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_branch_003.svg
@@ -37,12 +37,12 @@
     <text x="114" y="150" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;">A</text>
+    <text x="98" y="168" style="fill:#00AA00;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_commit_001.svg
@@ -28,8 +28,8 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="202" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="218" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -44,8 +44,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_commit_002.svg
@@ -29,8 +29,8 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218" y="96" style="fill:#00AA00;">A</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -51,8 +51,8 @@
     <text x="370" y="168" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_committed_file_to_commit_003.svg
@@ -37,12 +37,12 @@
     <text x="114" y="150" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">l:t</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;">A</text>
+    <text x="98" y="168" style="fill:#00AA00;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_001.svg
@@ -34,8 +34,8 @@
     <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">n:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
@@ -48,8 +48,8 @@
     <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:k</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="150" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="150" style="fill:#000000;font-weight:bold;">squash</text>
@@ -60,8 +60,8 @@
     <text x="218" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_002.svg
@@ -34,8 +34,8 @@
     <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">n:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
@@ -48,8 +48,8 @@
     <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:k</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="150" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="150" style="fill:#000000;font-weight:bold;">squash</text>
@@ -63,8 +63,8 @@
     <text x="370" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="168" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_003.svg
@@ -23,16 +23,16 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">t:tm</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122" y="96" style="fill:#00AA00;">A</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:k</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="114" style="fill:#00AA00;">one</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="114" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">t:tw</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_001.svg
@@ -34,16 +34,16 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">r:k</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218 226 234" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10" y="114" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="114" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74" y="114" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">r:t</text>
-    <text x="202" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="218 226 234" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="202" y="114" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="218 226 234" y="114" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="132" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -51,8 +51,8 @@
     <text x="114" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_002.svg
@@ -34,16 +34,16 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">r:k</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218 226 234" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">r:t</text>
-    <text x="202" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="218 226 234" y="114" style="fill:#00AA00;">two</text>
+    <text x="202" y="114" style="fill:#00AA00;">A</text>
+    <text x="218 226 234" y="114" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="132" style="fill:#000000;font-weight:bold;">squash</text>
@@ -57,8 +57,8 @@
     <text x="370" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="150" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_003.svg
@@ -31,16 +31,16 @@
     <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">t:tm</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122" y="114" style="fill:#00AA00;">A</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122" y="114" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">t:k</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">one</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;">t:tw</text>
-    <text x="106" y="150" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="150" style="fill:#00AA00;">two</text>
+    <text x="106" y="150" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="150" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_001.svg
@@ -34,20 +34,20 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">o:k</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218 226 234" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10" y="114" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="114" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74" y="114" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">o:o</text>
-    <text x="202" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="218 226 234 242 250" y="114" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="202" y="114" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="218 226 234 242 250" y="114" style="fill:#FFFFFF;font-weight:bold;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="150" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="150" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_002.svg
@@ -34,20 +34,20 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">o:k</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218 226 234" y="96" style="fill:#CCCCCC;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">o:o</text>
-    <text x="202" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="218 226 234 242 250" y="114" style="fill:#00AA00;">three</text>
+    <text x="202" y="114" style="fill:#00AA00;">A</text>
+    <text x="218 226 234 242 250" y="114" style="fill:#CCCCCC;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="98" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="150" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="150" style="fill:#000000;font-weight:bold;">squash</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_uncommitted_files_to_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_uncommitted_files_to_commit_001.svg
@@ -20,16 +20,16 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="60" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="42 50" y="60" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -43,8 +43,8 @@
     <text x="114" y="114" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">tp:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="106" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_uncommitted_files_to_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_uncommitted_files_to_commit_002.svg
@@ -20,16 +20,16 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="60" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="60" style="fill:#CCCCCC;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -49,8 +49,8 @@
     <text x="362" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">tp:t</text>
-    <text x="106" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="122" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="106" y="132" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="122" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_uncommitted_files_to_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_uncommitted_files_to_commit_003.svg
@@ -23,16 +23,16 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">t:tm</text>
-    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="122" y="96" style="fill:#00AA00;">A</text>
+    <text x="106" y="96" style="fill:#00AA00;">A</text>
+    <text x="122" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:k</text>
-    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="114" style="fill:#00AA00;">one</text>
+    <text x="106" y="114" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="114" style="fill:#CCCCCC;">one</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">t:tw</text>
-    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
+    <text x="106" y="132" style="fill:#00AA00;">A</text>
+    <text x="122 130 138" y="132" style="fill:#CCCCCC;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_with_marks_is_selectable_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_with_marks_is_selectable_001.svg
@@ -26,13 +26,13 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_with_partial_marks_is_selectable_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_with_partial_marks_is_selectable_001.svg
@@ -30,14 +30,14 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="170" y="42" style="fill:#FFFFFF;font-weight:bold;">M</text>
-    <text x="186 194 202 210" y="42" style="fill:#AA5500;font-weight:bold;">file</text>
+    <text x="170" y="42" style="fill:#AA5500;font-weight:bold;">M</text>
+    <text x="186 194 202 210" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">tw</text>
-    <text x="66" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">new-file</text>
+    <text x="66" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="60" style="fill:#CCCCCC;opacity:0.75;">new-file</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="60" style="fill:#555555;">│──────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_without_marks_is_selectable_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_without_marks_is_selectable_001.svg
@@ -22,13 +22,13 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_commit_001.svg
@@ -28,8 +28,8 @@
     <text x="218" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_commit_002.svg
@@ -32,8 +32,8 @@
     <text x="218" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_commit_003.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">tm</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_committed_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_committed_file_001.svg
@@ -28,8 +28,8 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="202" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="218" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202" y="96" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_committed_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_committed_file_002.svg
@@ -32,8 +32,8 @@
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="202" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="218" y="96" style="fill:#00AA00;">A</text>
+    <text x="202" y="96" style="fill:#00AA00;">A</text>
+    <text x="218" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_committed_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommit_committed_file_003.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">tm</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_branch_001.svg
@@ -15,8 +15,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="170" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="186 194 202 210" y="42" style="fill:#00AA00;font-weight:bold;">file</text>
+    <text x="170" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="186 194 202 210" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -30,8 +30,8 @@
     <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_branch_002.svg
@@ -16,8 +16,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="170" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="186 194 202 210" y="42" style="fill:#00AA00;">file</text>
+    <text x="170" y="42" style="fill:#00AA00;">A</text>
+    <text x="186 194 202 210" y="42" style="fill:#CCCCCC;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
@@ -37,8 +37,8 @@
     <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_branch_003.svg
@@ -23,12 +23,12 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:q</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="114" style="fill:#00AA00;">file</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="114" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_commit_001.svg
@@ -15,8 +15,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="170" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="186 194 202 210" y="42" style="fill:#00AA00;font-weight:bold;">file</text>
+    <text x="170" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="186 194 202 210" y="42" style="fill:#FFFFFF;font-weight:bold;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -30,8 +30,8 @@
     <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_commit_002.svg
@@ -16,8 +16,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="170" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="186 194 202 210" y="42" style="fill:#00AA00;">file</text>
+    <text x="170" y="42" style="fill:#00AA00;">A</text>
+    <text x="186 194 202 210" y="42" style="fill:#CCCCCC;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -37,8 +37,8 @@
     <text x="362" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_hunk_to_commit_003.svg
@@ -23,12 +23,12 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:q</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="114" style="fill:#00AA00;">file</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="114" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_001.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106" y="42" style="fill:#00AA00;">file</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -25,8 +25,8 @@
     <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_002.svg
@@ -15,8 +15,8 @@
     <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106" y="42" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -30,8 +30,8 @@
     <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_003.svg
@@ -16,8 +16,8 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">qs</text>
-    <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="82 90 98 106" y="42" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="66" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="82 90 98 106" y="42" style="fill:#CCCCCC;opacity:0.75;">file</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -34,8 +34,8 @@
     <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_into_commit_004.svg
@@ -23,12 +23,12 @@
     <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:q</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="114" style="fill:#00AA00;">file</text>
+    <text x="98" y="114" style="fill:#00AA00;">A</text>
+    <text x="114 122 130 138" y="114" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_to_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_to_branch_001.svg
@@ -15,12 +15,12 @@
     <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_to_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_uncommitted_to_branch_002.svg
@@ -16,12 +16,12 @@
     <text x="250" y="24" style="fill:#CCCCCC;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;opacity:0.75;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;opacity:0.75;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="96" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
     <text x="42 50" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_with_target_message_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_with_target_message_001.svg
@@ -36,8 +36,8 @@
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -52,8 +52,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_with_target_message_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_with_target_message_002.svg
@@ -32,8 +32,8 @@
     <text x="218" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -48,8 +48,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_with_target_message_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_with_target_message_003.svg
@@ -35,8 +35,8 @@
     <text x="370" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">t:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98" y="96" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>
@@ -51,8 +51,8 @@
     <text x="114" y="168" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">l:p</text>
-    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114" y="186" style="fill:#00AA00;opacity:0.75;">B</text>
+    <text x="98" y="186" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">B</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_full_screen_details_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_full_screen_details_view_002.svg
@@ -28,8 +28,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="60" style="fill:#000000;font-weight:bold;">✔︎</text>
@@ -37,8 +37,8 @@
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_full_screen_details_view_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_full_screen_details_view_003.svg
@@ -25,8 +25,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
@@ -37,8 +37,8 @@
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466" y="60" style="fill:#CCCCCC;">Author:</text>
     <text x="506 514 522 530 538 546" y="60" style="fill:#FFFF55;">author</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_split_details_view_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_split_details_view_001.svg
@@ -22,14 +22,14 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="60" style="fill:#000000;">✔︎</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_split_details_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_split_details_view_002.svg
@@ -28,8 +28,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="60" style="fill:#000000;font-weight:bold;">✔︎</text>
@@ -37,8 +37,8 @@
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_split_details_view_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_marks_from_split_details_view_003.svg
@@ -25,8 +25,8 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
@@ -37,8 +37,8 @@
     <text x="66 74 82 90 98 106" y="60" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="60" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154 162 170" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="186" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="60" style="fill:#00AA00;">two</text>
+    <text x="186" y="60" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466" y="60" style="fill:#CCCCCC;">Author:</text>
     <text x="506 514 522 530 538 546" y="60" style="fill:#FFFF55;">author</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_full_screen_details_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_full_screen_details_view_002.svg
@@ -22,13 +22,13 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_full_screen_details_view_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_full_screen_details_view_003.svg
@@ -21,16 +21,16 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
     <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754" y="42" style="fill:#AA00AA;">tpmktkqkknswxzyszlkxlrzoqorvpmur</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466" y="60" style="fill:#CCCCCC;">Author:</text>
     <text x="506 514 522 530 538 546" y="60" style="fill:#FFFF55;">author</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_full_screen_details_view_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_full_screen_details_view_004.svg
@@ -16,8 +16,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_001.svg
@@ -17,13 +17,13 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="410" y="60" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_002.svg
@@ -22,13 +22,13 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="202 210 218" y="42" style="fill:#FFFFFF;font-weight:bold;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498" y="60" style="fill:#555555;">│──────────╮</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_003.svg
@@ -21,16 +21,16 @@
     <text x="66 74 82 90 98 106" y="42" style="fill:#FFFFFF;">source</text>
     <text x="122 130" y="42" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="146 154" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="186" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="202 210 218" y="42" style="fill:#00AA00;">one</text>
+    <text x="186" y="42" style="fill:#00AA00;">A</text>
+    <text x="202 210 218" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
     <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754" y="42" style="fill:#AA00AA;">tpmktkqkknswxzyszlkxlrzoqorvpmur</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;opacity:0.75;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;opacity:0.75;">two</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466" y="60" style="fill:#CCCCCC;">Author:</text>
     <text x="506 514 522 530 538 546" y="60" style="fill:#FFFF55;">author</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squashing_selection_from_split_details_view_004.svg
@@ -16,8 +16,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">two</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">two</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stack_highlighting_with_a_nested_worktree_lane_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stack_highlighting_with_a_nested_worktree_lane_001.svg
@@ -37,8 +37,8 @@
     <text x="258" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">}</text>
     <text x="10 18 26" y="114" style="fill:#FFFFFF;font-weight:bold;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">ok</text>
-    <text x="82" y="114" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;font-weight:bold;opacity:0.75;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;font-weight:bold;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#FFFFFF;font-weight:bold;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">wt</text>
     <text x="74" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_001.svg
@@ -10,12 +10,12 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="60" style="fill:#CCCCCC;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_002.svg
@@ -12,12 +12,12 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_004.svg
@@ -12,12 +12,12 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="42 50 58 66" y="60" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="98 106 114" y="60" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="82" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
+    <text x="98 106 114" y="60" style="fill:#FFFFFF;font-weight:bold;">two</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="96" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/switch_full_screen_details_to_split_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/switch_full_screen_details_to_split_001.svg
@@ -22,20 +22,20 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">kl:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/switch_full_screen_details_to_split_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/switch_full_screen_details_to_split_002.svg
@@ -22,20 +22,20 @@
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="42" style="fill:#000000;">✔︎</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kl</text>
-    <text x="82" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="42" style="fill:#00AA00;">one</text>
+    <text x="82" y="42" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="42" style="fill:#CCCCCC;">one</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">or</text>
-    <text x="82" y="60" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130" y="60" style="fill:#00AA00;">three</text>
+    <text x="82" y="60" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130" y="60" style="fill:#CCCCCC;">three</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522" y="60" style="fill:#555555;">│─────────────╮</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="78" style="fill:#0000AA;font-weight:bold;">twop</text>
-    <text x="82" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114" y="78" style="fill:#00AA00;">two</text>
+    <text x="82" y="78" style="fill:#00AA00;">A</text>
+    <text x="98 106 114" y="78" style="fill:#CCCCCC;">two</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="426" y="78" style="fill:#000000;">✔︎</text>
     <text x="450 458 466 474" y="78" style="fill:#0000AA;">kl:f</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_003_shift_d_closes_full_screen.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_003_shift_d_closes_full_screen.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_005_escape_closes_full_screen.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_005_escape_closes_full_screen.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_007_d_closes_full_screen.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_007_d_closes_full_screen.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_008_split_details.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_008_split_details.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_010_escape_closes_from_split.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_010_escape_closes_from_split.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_011_split_details.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_011_split_details.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_012_split_details_mode.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_012_split_details_mode.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_014_escape_closes_from_details_mode.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_014_escape_closes_from_details_mode.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_closed_full_screen_details.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggle_full_screen_details_view_for_commit_closed_full_screen_details.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_001.svg
@@ -20,8 +20,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">mv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">large.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">large.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546" y="60" style="fill:#555555;">│────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_002.svg
@@ -27,8 +27,8 @@
     <text x="498 506 514 522 530 538 546 554" y="24" style="fill:#CDD6F4;">line-003</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">mv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">large.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">large.txt</text>
     <text x="410" y="42" style="fill:#FFA500;">▌</text>
     <text x="434" y="42" style="fill:#555555;">┊</text>
     <text x="458" y="42" style="fill:#00AA00;">4</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_003.svg
@@ -10,8 +10,8 @@
     <text x="146" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">mv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">large.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">large.txt</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/toggling_details_off_and_on_resets_scroll_position_004.svg
@@ -20,8 +20,8 @@
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">mv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;">large.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#CCCCCC;">large.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546" y="60" style="fill:#555555;">│────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/uncommit_a_worktree_commit_into_its_own_area_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/uncommit_a_worktree_commit_into_its_own_area_001.svg
@@ -31,8 +31,8 @@
     <text x="378" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;opacity:0.75;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;opacity:0.75;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;opacity:0.75;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;opacity:0.75;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">wt</text>
     <text x="74" y="132" style="fill:#CCCCCC;opacity:0.75;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/uncommit_a_worktree_commit_into_its_own_area_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/uncommit_a_worktree_commit_into_its_own_area_002.svg
@@ -25,12 +25,12 @@
     <text x="258" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">wu</text>
-    <text x="82" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="98" y="114" style="fill:#00AA00;">W</text>
+    <text x="82" y="114" style="fill:#00AA00;">A</text>
+    <text x="98" y="114" style="fill:#CCCCCC;">W</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="132" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="132" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="132" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="132" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="150" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="150" style="fill:#CCCCCC;">{</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/unfocusing_split_details_with_escape_focused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/unfocusing_split_details_with_escape_focused.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/unfocusing_split_details_with_escape_unfocused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/unfocusing_split_details_with_escape_unfocused.svg
@@ -17,8 +17,8 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">uv</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#00AA00;">file.txt</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114 122 130 138" y="42" style="fill:#CCCCCC;">file.txt</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="60" style="fill:#555555;">│───────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/viewing_empty_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/viewing_empty_file_001.svg
@@ -16,9 +16,9 @@
     <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">kw</text>
-    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
-    <text x="82 90 98 106 114" y="42" style="fill:#00AA00;">empty</text>
-    <text x="130 138 146 154" y="42" style="fill:#00AA00;">file</text>
+    <text x="66" y="42" style="fill:#00AA00;">A</text>
+    <text x="82 90 98 106 114" y="42" style="fill:#CCCCCC;">empty</text>
+    <text x="130 138 146 154" y="42" style="fill:#CCCCCC;">file</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554" y="60" style="fill:#555555;">│─────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/worktree_lane_is_navigable_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/worktree_lane_is_navigable_final.svg
@@ -25,8 +25,8 @@
     <text x="258" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
-    <text x="82" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
+    <text x="82" y="114" style="fill:#00AA00;">A</text>
+    <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#CCCCCC;">wt-file.txt</text>
     <text x="10 18 26 34" y="132" style="fill:#CCCCCC;">┊┊├┄</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">wt</text>
     <text x="74" y="132" style="fill:#CCCCCC;">{</text>

--- a/crates/but/tests/but/command/snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg
@@ -24,7 +24,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan>╭┄ </tspan><tspan class="fg-blue bold">@</tspan><tspan> [</tspan><tspan class="fg-cyan">uncommitted</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊   </tspan><tspan class="fg-blue bold">xk</tspan><tspan> A </tspan><tspan class="fg-green">new-file.txt</tspan>
+    <tspan x="10px" y="46px"><tspan>┊   </tspan><tspan class="fg-blue bold">xk</tspan><tspan> </tspan><tspan class="fg-green">A</tspan><tspan> new-file.txt</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
@@ -24,11 +24,11 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan>╭┄ </tspan><tspan class="fg-blue bold">@</tspan><tspan> [</tspan><tspan class="fg-cyan">uncommitted</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊   </tspan><tspan class="fg-blue bold">yr</tspan><tspan>  A </tspan><tspan class="fg-green">foo1</tspan>
+    <tspan x="10px" y="46px"><tspan>┊   </tspan><tspan class="fg-blue bold">yr</tspan><tspan>  </tspan><tspan class="fg-green">A</tspan><tspan> foo1</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpr</tspan><tspan> A </tspan><tspan class="fg-green">foo23</tspan>
+    <tspan x="10px" y="64px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpr</tspan><tspan> </tspan><tspan class="fg-green">A</tspan><tspan> foo23</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpo</tspan><tspan> A </tspan><tspan class="fg-green">foo242</tspan>
+    <tspan x="10px" y="82px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpo</tspan><tspan> </tspan><tspan class="fg-green">A</tspan><tspan> foo242</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
@@ -41,13 +41,13 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">2</tspan><tspan class="dimmed">8baf9a</tspan><tspan class="dimmed"> add only-on-remote</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊│     A </tspan><tspan class="fg-green">only-on-remote</tspan>
+    <tspan x="10px" y="190px"><tspan>┊│     </tspan><tspan class="fg-green">A </tspan><tspan>only-on-remote</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊-</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-magenta">s</tspan><tspan class="dimmed">mn</tspan><tspan> add only-on-local</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊│     </tspan><tspan class="fg-blue bold">smn:t</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
+    <tspan x="10px" y="244px"><tspan>┊│     </tspan><tspan class="fg-blue bold">smn:t</tspan><tspan> </tspan><tspan class="fg-green">A </tspan><tspan>only-on-local</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>├╯</tspan>
 </tspan>


### PR DESCRIPTION
This is also the style we're going with for `but diff` when tree status is reintroduced there.

According to credible sources, this greatly decreases the rainbow barf effect of the status output.

**Before:**
<img width="324" height="203" alt="current_status" src="https://github.com/user-attachments/assets/e029d54c-d49a-4b42-93e7-8d53f1de3665" />

**After:**
<img width="325" height="199" alt="new_status" src="https://github.com/user-attachments/assets/5a9679a4-a356-4d56-aa68-ee1463a22daa" />
