### PR TITLE
Can push worktree references

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -69,7 +69,11 @@ import { insertBlankCommitMenuItem } from "./insertBlankCommitMenuItem.ts";
 import { ItemRow } from "./ItemRow.tsx";
 import { useStackMenuItems } from "./useStackMenuItems.ts";
 import { ciChecksSummaryUrl, type AggregateCIChecks } from "#ui/ci.ts";
-import { type DownstackPushStatus, downstackPushStatusDisabled } from "#ui/segment.ts";
+import {
+	type DownstackPushStatus,
+	downstackPushLabel,
+	downstackPushStatusDisabled,
+} from "#ui/segment.ts";
 
 export type PushActivity = "idle" | "blocked" | "pushing";
 
@@ -333,13 +337,7 @@ export const BranchRow: FC<
 	const workspaceBranchAndAncestorsPushDisabled =
 		pushActivity !== "idle" || downstackPushStatusDisabled(downstackPushStatus);
 
-	const pushMenuLabel = pushesMultipleBranches
-		? downstackPushStatus.anyPushRequiresForce
-			? "Force Push With Branches Below"
-			: "Push With Branches Below"
-		: downstackPushStatus.anyPushRequiresForce
-			? "Force Push Branch"
-			: "Push Branch";
+	const pushMenuLabel = downstackPushLabel(downstackPushStatus);
 
 	const foldLabel = isFolded ? "Unfold commits" : "Fold commits";
 	const incomingExpanded = useAppSelector((state) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -494,6 +494,7 @@ const BranchSegment: FC<{
 					projectId={projectId}
 					segment={segment}
 					stackId={stack.id}
+					downstackPushStatus={downstackPushStatus}
 					behind={behind}
 					worktrees={worktrees}
 					checkCommit={checkCommit}
@@ -559,6 +560,8 @@ const SegmentContent: FC<{
 	setSize: number;
 	behind: number;
 	worktrees: WorktreePlacement;
+	/** What a push from this segment covers, which a worktree resting on one of its commits pushes too. */
+	downstackPushStatus: DownstackPushStatus;
 }> = ({
 	projectId,
 	segment,
@@ -578,6 +581,7 @@ const SegmentContent: FC<{
 	setSize,
 	behind,
 	worktrees,
+	downstackPushStatus,
 }) => {
 	const getCommitKey = useCallback(
 		(index: number) => segment.commits[index]?.id ?? index,
@@ -664,6 +668,7 @@ const SegmentContent: FC<{
 					worktree={worktree}
 					worktrees={worktrees}
 					behind={behind + 1}
+					beneath={downstackPushStatus}
 				/>
 			));
 	}
@@ -693,6 +698,7 @@ const SegmentContent: FC<{
 						below={next === undefined ? "LocalOnly" : commitGraphStatus(next)}
 						behind={behind}
 						lanes={lanesOn(commit, virtualRow.index)}
+						beneath={downstackPushStatus}
 						worktrees={worktrees}
 						projectId={projectId}
 						stackId={stackId}
@@ -725,6 +731,8 @@ const CommitItem: FC<{
 	behind: number;
 	/** The worktree lanes drawn above this commit, resting on it. */
 	lanes: ReadonlyArray<Worktree>;
+	/** What those lanes push beneath themselves: this commit's segment and below. */
+	beneath: DownstackPushStatus;
 	worktrees: WorktreePlacement;
 	projectId: string;
 	stackId: string | null;
@@ -742,6 +750,7 @@ const CommitItem: FC<{
 	below,
 	behind,
 	lanes,
+	beneath,
 	worktrees,
 	projectId,
 	stackId,
@@ -775,6 +784,7 @@ const CommitItem: FC<{
 					worktree={worktree}
 					worktrees={worktrees}
 					behind={behind + 1}
+					beneath={beneath}
 				/>
 			))}
 			<TreeItem
@@ -947,6 +957,7 @@ const StackC: FC<
 						worktree={worktree}
 						worktrees={worktrees}
 						behind={behind}
+						beneath={assert(downstackPushStatuses[0])}
 					/>
 				))}
 				{stack.segments.map((segment, index) => {
@@ -1010,6 +1021,7 @@ const StackC: FC<
 										projectId={projectId}
 										segment={segment}
 										stackId={stack.id}
+										downstackPushStatus={downstackPushStatus}
 										checkCommit={checkCommit}
 										onAmendCommit={onAmendCommit}
 										canAmendCommit={canAmendCommit}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
@@ -15,7 +15,12 @@ import {
 	worktreeChangesFileParent,
 	type FileParent,
 } from "#ui/addresses.ts";
-import { useWorktreeRemove, useWorktreeSetArchived } from "#ui/api/mutations.ts";
+import {
+	useWorkspaceBranchAndAncestorsPush,
+	useWorktreeRemove,
+	useWorktreeSetArchived,
+} from "#ui/api/mutations.ts";
+import { assert } from "#ui/assert.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import {
 	forgeInfoOptions,
@@ -40,12 +45,19 @@ import {
 } from "#ui/native-menu.ts";
 import { prForgeUrl } from "#ui/pr.ts";
 import { defaultSettings } from "#ui/settings.ts";
+import {
+	downstackPushLabel,
+	downstackPushStatusDisabled,
+	downstackPushStatusesFromSegments,
+	emptyDownstackPushStatus,
+	type DownstackPushStatus,
+} from "#ui/segment.ts";
 import { setCursor, useIsCursorAt } from "#ui/use-cursor.ts";
 import { addressSpaceIncludes } from "#ui/workspace/address-space.ts";
 import type { BranchReference, TreeChange, Worktree } from "@gitbutler/but-sdk";
 import { Toolbar, Tooltip } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
-import { Fragment, useState, type ComponentProps, type FC } from "react";
+import { Fragment, useMemo, useState, type ComponentProps, type FC } from "react";
 import { CommitRow } from "./CommitRow.tsx";
 import { useAddressSpace } from "./context.tsx";
 import { ItemRow } from "./ItemRow.tsx";
@@ -286,10 +298,14 @@ const WorktreeBranchRow: FC<
 	{
 		projectId: string;
 		refName: BranchReference;
+		/** What a push from this branch covers: it, the branches below it, and what the lane rests on. */
+		downstackPushStatus: DownstackPushStatus;
 		behind: number;
 	} & ComponentProps<typeof Row>
-> = ({ projectId, refName, behind, ...props }) => {
+> = ({ projectId, refName, downstackPushStatus, behind, ...props }) => {
 	const address = branchAddress({ branchRef: refName.fullNameBytes });
+	const { mutate: workspaceBranchAndAncestorsPush, isPending: isPushing } =
+		useWorkspaceBranchAndAncestorsPush(projectId);
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	// Only this branch's number: the listing refetches on a timer, and a row
 	// should re-render only when its own pull request changes.
@@ -301,7 +317,24 @@ const WorktreeBranchRow: FC<
 	});
 	const forgeUrl = pullRequest !== null && forgeInfo ? prForgeUrl(pullRequest, forgeInfo) : null;
 
+	const pushBranch = () => {
+		workspaceBranchAndAncestorsPush({
+			projectId,
+			branch: decodeBytes(refName.fullNameBytes),
+			withForce: downstackPushStatus.anyPushRequiresForce,
+			skipForcePushProtection: false,
+			runHooks: true,
+			pushOpts: [],
+		});
+	};
+
 	const menuItems: Array<NativeMenuItem> = [
+		nativeMenuItem({
+			label: downstackPushLabel(downstackPushStatus),
+			enabled: !isPushing && !downstackPushStatusDisabled(downstackPushStatus),
+			onSelect: pushBranch,
+		}),
+		nativeMenuSeparator,
 		nativeMenuItem({
 			label: "Copy Branch Name",
 			onSelect: () => window.lite.clipboardWriteText(refName.displayName),
@@ -360,7 +393,15 @@ const WorktreeRows: FC<{
 	behind: number;
 	/** The lane's rail starts at its uncommitted files; on the trunk, the trunk runs on through. */
 	startsRail: boolean;
-}> = ({ projectId, worktree, worktrees, behind, startsRail }) => {
+	/** What the lane rests on, which a push of any of its branches also pushes. */
+	beneath: DownstackPushStatus;
+}> = ({ projectId, worktree, worktrees, behind, startsRail, beneath }) => {
+	// Manual memo: the compiler folds this into the props scope, where it is rebuilt
+	// on every render and hands each branch row a fresh status.
+	const downstackPushStatuses = useMemo(
+		() => downstackPushStatusesFromSegments(worktree.segments, beneath),
+		[worktree.segments, beneath],
+	);
 	// The rail under a commit takes the colour of the next commit, across segments.
 	const commits = worktree.segments.flatMap((segment) => segment.commits);
 	const below = new Map(
@@ -375,7 +416,8 @@ const WorktreeRows: FC<{
 				behind={behind}
 				startsRail={startsRail}
 			/>
-			{worktree.segments.map((segment) => {
+			{worktree.segments.map((segment, index) => {
+				const downstackPushStatus = assert(downstackPushStatuses[index]);
 				// A detached HEAD's first segment has no branch to show a row for.
 				const branch =
 					segment.refName === null
@@ -402,6 +444,7 @@ const WorktreeRows: FC<{
 											<WorktreeBranchRow
 												projectId={projectId}
 												refName={segment.refName}
+												downstackPushStatus={downstackPushStatus}
 												behind={behind}
 											/>
 										}
@@ -420,6 +463,7 @@ const WorktreeRows: FC<{
 											worktree={nested}
 											worktrees={worktrees}
 											behind={behind + 1}
+											beneath={downstackPushStatus}
 										/>
 									))}
 									<TreeItem
@@ -469,7 +513,9 @@ export const WorktreeLane: FC<{
 	worktrees: WorktreePlacement;
 	/** Columns behind the lane's rail: the rail it rests on is the last of them. */
 	behind: number;
-}> = ({ projectId, worktree, worktrees, behind }) => (
+	/** What the commit the lane rests on pushes with itself. */
+	beneath: DownstackPushStatus;
+}> = ({ projectId, worktree, worktrees, behind, beneath }) => (
 	<>
 		<WorktreeRows
 			projectId={projectId}
@@ -477,6 +523,7 @@ export const WorktreeLane: FC<{
 			worktrees={worktrees}
 			behind={behind}
 			startsRail
+			beneath={beneath}
 		/>
 		<GraphGap height={LEG_GAP} bend="LocalOnly" behind={behind - 1} />
 	</>
@@ -493,7 +540,9 @@ export const WorktreeOnTip: FC<{
 	worktree: Worktree;
 	worktrees: WorktreePlacement;
 	behind: number;
-}> = ({ projectId, worktree, worktrees, behind }) => (
+	/** What the top branch it sits on pushes with itself. */
+	beneath: DownstackPushStatus;
+}> = ({ projectId, worktree, worktrees, behind, beneath }) => (
 	<>
 		<WorktreeRows
 			projectId={projectId}
@@ -501,6 +550,7 @@ export const WorktreeOnTip: FC<{
 			worktrees={worktrees}
 			behind={behind}
 			startsRail
+			beneath={beneath}
 		/>
 		<GraphGap height={TIP_GAP} behind={behind} />
 	</>
@@ -526,6 +576,7 @@ export const WorktreeCard: FC<{
 				worktrees={worktrees}
 				behind={1}
 				startsRail
+				beneath={emptyDownstackPushStatus}
 			/>
 			<Row interactive={false} className={sectionStyles.stub}>
 				<GraphSegment glyph="parent" status="LocalOnly" behind={1} />

--- a/apps/lite/ui/src/segment.ts
+++ b/apps/lite/ui/src/segment.ts
@@ -27,7 +27,7 @@ export type DownstackPushStatus = {
 	downstackBranches: number;
 };
 
-const emptyDownstackPushStatus: DownstackPushStatus = {
+export const emptyDownstackPushStatus: DownstackPushStatus = {
 	anyRequiresPush: false,
 	anyPushRequiresForce: false,
 	anyHasConflicts: false,
@@ -49,12 +49,16 @@ const concatDownstackPushStatus = (
 	downstackBranches: x.downstackBranches + y.downstackBranches,
 });
 
-const toDownstackPushStatus = (segment: Segment): DownstackPushStatus => ({
-	anyRequiresPush: pushStatusRequiresPush(segment.pushStatus),
-	anyPushRequiresForce: segment.pushStatus === "unpushedCommitsRequiringForce",
-	anyHasConflicts: segment.commits.some((commit) => commit.hasConflicts),
-	downstackBranches: segment.refName ? 1 : 0,
-});
+// Nothing pushes a segment without a branch, so it adds nothing to what rests on it.
+const toDownstackPushStatus = (segment: Segment): DownstackPushStatus =>
+	segment.refName === null
+		? emptyDownstackPushStatus
+		: {
+				anyRequiresPush: pushStatusRequiresPush(segment.pushStatus),
+				anyPushRequiresForce: segment.pushStatus === "unpushedCommitsRequiringForce",
+				anyHasConflicts: segment.commits.some((commit) => commit.hasConflicts),
+				downstackBranches: 1,
+			};
 
 export const downstackPushStatusDisabled = (dps: DownstackPushStatus): boolean =>
 	!dps.anyRequiresPush || dps.anyHasConflicts;
@@ -65,13 +69,25 @@ export const downstackPushStatusFromSegments = (segments: Array<Segment>): Downs
 		emptyDownstackPushStatus,
 	);
 
+/**
+ * Per segment, what a push from it covers: itself, the segments below, and
+ * `beneath`, which is what the last segment rests on. A stack rests on the
+ * target, a worktree lane on a commit of another lane whose push it also makes.
+ */
 export const downstackPushStatusesFromSegments = (
 	segments: Array<Segment>,
+	beneath: DownstackPushStatus = emptyDownstackPushStatus,
 ): Array<DownstackPushStatus> =>
 	segments.reduceRight((acc, segment, idx) => {
-		acc[idx] = concatDownstackPushStatus(
-			acc[idx + 1] ?? emptyDownstackPushStatus,
-			toDownstackPushStatus(segment),
-		);
+		acc[idx] = concatDownstackPushStatus(acc[idx + 1] ?? beneath, toDownstackPushStatus(segment));
 		return acc;
 	}, [] as Array<DownstackPushStatus>);
+
+export const downstackPushLabel = (dps: DownstackPushStatus): string =>
+	dps.downstackBranches > 1
+		? dps.anyPushRequiresForce
+			? "Force Push With Branches Below"
+			: "Push With Branches Below"
+		: dps.anyPushRequiresForce
+			? "Force Push Branch"
+			: "Push Branch";

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -616,7 +616,7 @@ mod tests {
         ];
 
         assert!(
-            review_target_flattening_plan(&reviews).is_none(),
+            review_target_flattening_plan(&reviews, "main").is_none(),
             "an ordinary push should not contact the forge before pushing"
         );
     }
@@ -640,9 +640,8 @@ mod tests {
             ),
         ];
 
-        let (trunk, reviews_to_flatten) =
-            review_target_flattening_plan(&reviews).expect("the reviewed stack was reordered");
-        assert_eq!(trunk, "main");
+        let reviews_to_flatten = review_target_flattening_plan(&reviews, "main")
+            .expect("the reviewed stack was reordered");
         assert_eq!(
             reviews_to_flatten,
             std::collections::HashSet::from([1]),
@@ -670,7 +669,7 @@ mod tests {
         ];
 
         assert!(
-            review_target_flattening_plan(&reviews).is_none(),
+            review_target_flattening_plan(&reviews, "main").is_none(),
             "missing cache data must not cause remote mutations before a push"
         );
     }
@@ -1650,9 +1649,10 @@ pub(crate) struct ReviewTargetFlattening {
 /// desired stacked targets.
 pub(crate) async fn flatten_review_targets_before_push(
     ctx: ThreadSafeContext,
+    trunk: String,
     reviews: &[(but_forge::ForgeReviewTargetUpdate, Option<String>)],
 ) -> Result<Option<ReviewTargetFlattening>> {
-    let Some((trunk, reviews_to_flatten)) = review_target_flattening_plan(reviews) else {
+    let Some(reviews_to_flatten) = review_target_flattening_plan(reviews, &trunk) else {
         return Ok(None);
     };
 
@@ -1771,7 +1771,8 @@ pub(crate) async fn restore_review_targets(
 
 fn review_target_flattening_plan(
     reviews: &[(but_forge::ForgeReviewTargetUpdate, Option<String>)],
-) -> Option<(String, std::collections::HashSet<i64>)> {
+    trunk: &str,
+) -> Option<std::collections::HashSet<i64>> {
     if reviews.iter().any(|(_, current)| current.is_none()) {
         return None;
     }
@@ -1781,14 +1782,13 @@ fn review_target_flattening_plan(
     if !targets_changed {
         return None;
     }
-
-    let trunk = reviews.first()?.0.target_branch.clone();
-    let reviews_to_flatten = reviews
-        .iter()
-        .filter(|(_, current)| current.as_deref() != Some(trunk.as_str()))
-        .map(|(review, _)| review.number)
-        .collect();
-    Some((trunk, reviews_to_flatten))
+    Some(
+        reviews
+            .iter()
+            .filter(|(_, current)| current.as_deref() != Some(trunk))
+            .map(|(review, _)| review.number)
+            .collect(),
+    )
 }
 
 /// Synchronize every review in the workspace stack containing `branch`.

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -596,6 +596,144 @@ mod tests {
         Ok(())
     }
 
+    fn open_review(number: i64, source_branch: &str) -> but_forge::ForgeReview {
+        but_forge::ForgeReview {
+            html_url: String::new(),
+            number,
+            title: String::new(),
+            body: None,
+            author: None,
+            labels: Vec::new(),
+            draft: false,
+            source_branch: source_branch.into(),
+            target_branch: "main".into(),
+            sha: String::new(),
+            integration_commit_shas: Vec::new(),
+            created_at: None,
+            modified_at: None,
+            merged_at: None,
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            head_repo_is_fork: false,
+            auto_merge_enabled: false,
+            reviewers: Vec::new(),
+            unit_symbol: "#".into(),
+            last_sync_at: Default::default(),
+        }
+    }
+
+    /// `C` checked out over `B` over `A`, with a linked worktree on branch `W` resting on `B`,
+    /// and open reviews #1 on `A`, #2 on `B` and #3 on `W`.
+    fn context_with_worktree_on_reviewed_stack() -> Result<(Context, tempfile::TempDir)> {
+        let tmp = tempfile::tempdir()?;
+        let git = |args: &[&str]| git_at_dir(tmp.path()).args(args).run();
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.name", "GitButler"]);
+        git(&["config", "user.email", "gitbutler@example.com"]);
+        git(&["commit", "--allow-empty", "-m", "base"]);
+        git(&["config", "remote.origin.url", "../origin"]);
+        git(&["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        for branch in ["A", "B", "C"] {
+            git(&["checkout", "-b", branch]);
+            git(&["commit", "--allow-empty", "-m", branch]);
+        }
+        let worktree = tmp.path().join("worktrees").join("W");
+        git_at_dir(tmp.path())
+            .args(["worktree", "add", "-b", "W"])
+            .arg(&worktree)
+            .arg("B")
+            .run();
+        git_at_dir(&worktree)
+            .args(["commit", "--allow-empty", "-m", "W"])
+            .run();
+        // Pushed as they are: a review associates through the branch's remote-tracking ref.
+        for branch in ["A", "B", "W"] {
+            git(&[
+                "update-ref",
+                &format!("refs/remotes/origin/{branch}"),
+                branch,
+            ]);
+        }
+
+        let repo = open_repo(tmp.path())?;
+        ProjectMeta {
+            target_ref: Some("refs/remotes/origin/main".try_into()?),
+            target_commit_id: Some(repo.rev_parse_single("refs/remotes/origin/main")?.detach()),
+            push_remote: Some("origin".into()),
+        }
+        .persist(&repo)?;
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+        ctx.settings.feature_flags.worktree_manipulation = true;
+        let reviews = [(1, "A"), (2, "B"), (3, "W")];
+        {
+            let mut db = ctx.db.get_cache_mut()?;
+            // Adoption already ran, so the worktree on disk counts as active.
+            db.worktree_meta_mut().mark_adopted()?;
+            for (number, branch) in reviews {
+                but_forge::cache_review(&mut db, &open_review(number, branch))?;
+            }
+        }
+        for (number, branch) in reviews {
+            let branch = gix::refs::Category::LocalBranch.to_full_name(branch)?;
+            persist_review_association(&ctx, branch.as_ref(), number as usize)?;
+        }
+        Ok((ctx, tmp))
+    }
+
+    fn numbered_targets(
+        groups: Vec<Vec<but_forge::ForgeReviewUpdate>>,
+    ) -> Vec<Vec<(i64, Option<String>)>> {
+        groups
+            .into_iter()
+            .map(|group| {
+                group
+                    .into_iter()
+                    .map(|update| (update.number, update.target_branch))
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_worktree_on_a_reviewed_stack_syncs_alone_while_the_stack_stays_one_group() -> Result<()> {
+        let (ctx, _tmp) = context_with_worktree_on_reviewed_stack()?;
+        let w: gix::refs::FullName = "refs/heads/W".try_into()?;
+        let b: gix::refs::FullName = "refs/heads/B".try_into()?;
+
+        assert_eq!(
+            numbered_targets(review_update_groups_for_branch(&ctx, w.as_ref())?),
+            [
+                vec![(3, Some("B".into()))],
+                vec![(1, Some("main".into())), (2, Some("A".into()))],
+            ],
+            "the worktree review targets the nearest reviewed branch beneath it but joins no stack, while the stack it rests on is synced whole"
+        );
+        assert_eq!(
+            numbered_targets(review_update_groups_for_branch(&ctx, b.as_ref())?),
+            [vec![(1, Some("main".into())), (2, Some("A".into()))]],
+            "a stack branch does not drag the worktree resting on it into its sync"
+        );
+        assert_eq!(
+            review_target_updates_for_branch(&ctx, w.as_ref())?
+                .iter()
+                .map(|(update, current)| (
+                    update.number,
+                    update.target_branch.as_str(),
+                    current.as_deref()
+                ))
+                .collect::<Vec<_>>(),
+            [
+                (3, "B", Some("main")),
+                (1, "main", Some("main")),
+                (2, "A", Some("main")),
+            ],
+            "pre-push flattening sees every review along the chain with its cached target"
+        );
+        Ok(())
+    }
+
     #[test]
     fn unchanged_review_targets_do_not_need_pre_push_flattening() {
         let reviews = [
@@ -1800,18 +1938,11 @@ pub async fn sync_review_stack_for_branch(
     ctx: ThreadSafeContext,
     branch: gix::refs::FullName,
 ) -> but_forge::ReviewSyncOutcome {
-    let updates = {
+    let update_groups = {
         let ctx = ctx.clone().into_thread_local();
-        review_updates_for_branch(&ctx, branch.as_ref())
+        review_update_groups_for_branch(&ctx, branch.as_ref())
     };
-    sync_review_updates(ctx, updates).await
-}
-
-async fn sync_review_updates(
-    ctx: ThreadSafeContext,
-    updates: Result<Vec<but_forge::ForgeReviewUpdate>>,
-) -> but_forge::ReviewSyncOutcome {
-    sync_review_update_groups(ctx, updates.map(|updates| vec![updates])).await
+    sync_review_update_groups(ctx, update_groups).await
 }
 
 async fn sync_review_update_groups(
@@ -1897,35 +2028,16 @@ fn review_updates_after_push(
     pushed_branches: &[(String, String, String)],
 ) -> Result<Vec<Vec<but_forge::ForgeReviewUpdate>>> {
     let info = crate::legacy::workspace::head_info(ctx)?;
-    let selected_stack_index = info
-        .stacks
-        .iter()
-        .position(|stack| {
-            stack.segments.iter().any(|segment| {
-                segment
-                    .ref_info
-                    .as_ref()
-                    .is_some_and(|ref_info| ref_info.ref_name == branch)
-            })
-        })
-        .with_context(|| {
-            format!(
-                "Branch `{}` is not part of the current workspace",
-                branch.shorten()
-            )
-        })?;
+    let chain = lane_chain_for_branch(&info, branch)?;
 
     let open_reviews = open_review_numbers(ctx)?;
     let reviewed_branches = info
-        .stacks
-        .iter()
-        .flat_map(|stack| &stack.segments)
+        .lanes()
+        .flat_map(|lane| lane.segments)
         .filter(|segment| review_number(segment, &open_reviews).is_some())
         .filter_map(|segment| {
             segment
-                .ref_info
-                .as_ref()?
-                .ref_name
+                .ref_name()?
                 .shorten()
                 .to_str()
                 .ok()
@@ -1945,9 +2057,12 @@ fn review_updates_after_push(
     }
 
     let repo = ctx.repo.get()?;
-    let mut affected_stack_indices = std::collections::BTreeSet::from([selected_stack_index]);
-    for (stack_index, stack) in info.stacks.iter().enumerate() {
-        'segments: for segment in &stack.segments {
+    let mut affected_lanes = chain.iter().map(|(lane, _)| *lane).collect::<Vec<_>>();
+    for lane in info.lanes() {
+        if affected_lanes.contains(&lane) {
+            continue;
+        }
+        'segments: for segment in lane.segments {
             if review_number(segment, &open_reviews).is_none() {
                 continue;
             }
@@ -1958,7 +2073,7 @@ fn review_updates_after_push(
                 if remote_contains(&repo, *previous_tip, head.remote_tip)?
                     || remote_contains(&repo, head.remote_tip, *previous_tip)?
                 {
-                    affected_stack_indices.insert(stack_index);
+                    affected_lanes.push(lane);
                     break 'segments;
                 }
             }
@@ -1966,83 +2081,101 @@ fn review_updates_after_push(
     }
 
     let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
-    Ok(affected_stack_indices
+    Ok(affected_lanes
         .into_iter()
-        .map(|index| {
-            review_updates_for_stack(&info.stacks[index], &base_branch, &open_reviews)
-                .into_iter()
-                .map(|(_, update)| update.into())
-                .collect()
-        })
+        .flat_map(|lane| review_update_groups_for_lane(&info, lane, &base_branch, &open_reviews))
+        .map(|group| group.into_iter().map(|(_, update)| update.into()).collect())
         .collect())
 }
 
-fn review_updates_for_branch(
+/// One update group per GitHub stack across every lane in the chain beneath `branch`.
+fn review_update_groups_for_branch(
     ctx: &Context,
     branch: &gix::refs::FullNameRef,
-) -> Result<Vec<but_forge::ForgeReviewUpdate>> {
+) -> Result<Vec<Vec<but_forge::ForgeReviewUpdate>>> {
     let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
     let info = crate::legacy::workspace::head_info(ctx)?;
-    let (stack, _) = stack_and_segment_for_branch(&info, branch)?;
+    let chain = lane_chain_for_branch(&info, branch)?;
     let open_reviews = open_review_numbers(ctx)?;
-    Ok(review_updates_for_stack(stack, &base_branch, &open_reviews)
+    Ok(chain
         .into_iter()
-        .map(|(_, update)| update.into())
+        .flat_map(|(lane, _)| {
+            review_update_groups_for_lane(&info, lane, &base_branch, &open_reviews)
+        })
+        .map(|group| group.into_iter().map(|(_, update)| update.into()).collect())
         .collect())
 }
 
+/// The desired target of every reviewed segment in the chain beneath `branch`, along with the
+/// target the forge cache currently records.
 pub(crate) fn review_target_updates_for_branch(
     ctx: &Context,
     branch: &gix::refs::FullNameRef,
-) -> Result<
-    Vec<(
-        gix::refs::FullName,
-        but_forge::ForgeReviewTargetUpdate,
-        Option<String>,
-    )>,
-> {
+) -> Result<Vec<(but_forge::ForgeReviewTargetUpdate, Option<String>)>> {
     let info = crate::legacy::workspace::head_info(ctx)?;
-    let (stack, _) = stack_and_segment_for_branch(&info, branch)?;
+    let chain = lane_chain_for_branch(&info, branch)?;
     let open_reviews = open_review_numbers(ctx)?;
-    if !stack
-        .segments
+    let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
+    let updates = chain
         .iter()
-        .any(|segment| review_number(segment, &open_reviews).is_some())
-    {
+        .flat_map(|(lane, _)| {
+            review_update_groups_for_lane(&info, *lane, &base_branch, &open_reviews)
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+    if updates.is_empty() {
         return Ok(Vec::new());
     }
-    let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
     let db = ctx.db.get_cache()?;
     let cached_targets = but_forge::list_cached_forge_reviews(&db)?
         .into_iter()
         .map(|review| (review.number, review.target_branch))
         .collect::<std::collections::HashMap<_, _>>();
-    Ok(review_updates_for_stack(stack, &base_branch, &open_reviews)
+    Ok(updates
         .into_iter()
-        .map(|(branch, update)| {
+        .map(|(_, update)| {
             let current_target = cached_targets.get(&update.number).cloned();
-            (branch, update, current_target)
+            (update, current_target)
         })
         .collect())
 }
 
-/// One `(branch ref, target update)` pair per reviewed active segment,
-/// bottom-to-top. Refs and updates are derived from one pass over the same
-/// segments, so they cannot fall out of alignment; segments without an
-/// active review (via [`review_number`] — integrated ones included) are
-/// inert for target computation and contribute nothing.
-fn review_updates_for_stack(
-    stack: &but_workspace::branch::Stack,
+/// The `(branch ref, target update)` pairs of `lane`'s reviewed segments, bottom-to-top,
+/// grouped per GitHub stack.
+///
+/// A lane resting on the target is one linear stack. A lane resting on another lane would make
+/// the stack a tree, which GitHub cannot represent, so each of its reviews stands alone with the
+/// nearest reviewed segment beneath it as target. Refs and updates are derived from one pass
+/// over the same segments, so they cannot fall out of alignment; segments without an active
+/// review (via [`review_number`] — integrated ones included) are inert for target computation
+/// and contribute nothing.
+fn review_update_groups_for_lane(
+    info: &but_workspace::RefInfo,
+    lane: but_workspace::ref_info::Lane<'_>,
     base_branch: &str,
     open_reviews: &std::collections::HashSet<i64>,
-) -> Vec<(gix::refs::FullName, but_forge::ForgeReviewTargetUpdate)> {
-    let reviewed = stack
+) -> Vec<Vec<(gix::refs::FullName, but_forge::ForgeReviewTargetUpdate)>> {
+    let nearest_reviewed_beneath = info
+        .lanes_beneath(lane)
+        .into_iter()
+        .flat_map(|(lane, index)| &lane.segments[index..])
+        .find_map(|segment| {
+            review_number(segment, open_reviews)?;
+            segment
+                .ref_name()?
+                .shorten()
+                .to_str()
+                .ok()
+                .map(ToOwned::to_owned)
+        });
+    let bottom_target = nearest_reviewed_beneath.as_deref().unwrap_or(base_branch);
+    let reviewed = lane
         .segments
         .iter()
         .rev()
         .filter_map(|segment| {
             let number = review_number(segment, open_reviews)?;
-            let ref_name = segment.ref_info.as_ref()?.ref_name.clone();
+            let ref_name = segment.ref_name()?.to_owned();
             let short = ref_name.shorten().to_str().ok()?.to_owned();
             Some((ref_name, short, number))
         })
@@ -2051,27 +2184,36 @@ fn review_updates_for_stack(
         .iter()
         .map(|(_, short, number)| (short.clone(), Some(*number)))
         .collect::<Vec<_>>();
-    let updates = but_forge::compute_review_target_updates(&heads, base_branch);
-    reviewed
+    let updates = but_forge::compute_review_target_updates(&heads, bottom_target);
+    let updates = reviewed
         .into_iter()
         .map(|(ref_name, _, _)| ref_name)
         .zip(updates)
-        .collect()
+        .collect::<Vec<_>>();
+    if lane.rests_on.is_some() {
+        updates.into_iter().map(|update| vec![update]).collect()
+    } else {
+        vec![updates]
+    }
 }
 
 fn review_creation_target(ctx: &Context, branch: &gix::refs::FullNameRef) -> Result<String> {
     let info = crate::legacy::workspace::head_info(ctx)?;
-    let (stack, selected_index) = stack_and_segment_for_branch(&info, branch)?;
+    let chain = lane_chain_for_branch(&info, branch)?;
     let repo = ctx.repo.get()?;
 
     let open_reviews = open_review_numbers(ctx)?;
-    let mut reviewed_ancestors = stack.segments[selected_index + 1..]
-        .iter()
-        .rev()
+    let ((lane, selected_index), beneath) = chain
+        .split_first()
+        .expect("a non-empty chain starts with the branch's own lane");
+    let mut reviewed_ancestors = std::iter::once((*lane, selected_index + 1))
+        .chain(beneath.iter().copied())
+        .flat_map(|(lane, index)| &lane.segments[index..])
         .filter(|segment| review_number(segment, &open_reviews).is_some())
         .map(|segment| remote_head(&repo, segment))
         .collect::<Result<Vec<_>>>()?;
-    let selected = remote_head(&repo, &stack.segments[selected_index])?;
+    reviewed_ancestors.reverse();
+    let selected = remote_head(&repo, &lane.segments[*selected_index])?;
 
     for pair in reviewed_ancestors
         .iter()
@@ -2100,30 +2242,18 @@ struct RemoteHead {
     remote_tip: gix::ObjectId,
 }
 
-fn stack_and_segment_for_branch<'a>(
+fn lane_chain_for_branch<'a>(
     info: &'a but_workspace::RefInfo,
     branch: &gix::refs::FullNameRef,
-) -> Result<(&'a but_workspace::branch::Stack, usize)> {
-    info.stacks
-        .iter()
-        .find_map(|stack| {
-            stack
-                .segments
-                .iter()
-                .position(|segment| {
-                    segment
-                        .ref_info
-                        .as_ref()
-                        .is_some_and(|ref_info| ref_info.ref_name == branch)
-                })
-                .map(|index| (stack, index))
-        })
-        .with_context(|| {
-            format!(
-                "Branch `{}` is not part of the current workspace",
-                branch.shorten()
-            )
-        })
+) -> Result<Vec<(but_workspace::ref_info::Lane<'a>, usize)>> {
+    let chain = info.lane_chain(branch);
+    if chain.is_empty() {
+        anyhow::bail!(
+            "Branch `{}` is not part of the current workspace",
+            branch.shorten()
+        );
+    }
+    Ok(chain)
 }
 
 /// The numbers of reviews the forge cache currently knows as open.
@@ -2206,17 +2336,13 @@ fn remote_contains(
 fn local_branch_for_review(ctx: &Context, wanted: i64) -> Result<gix::refs::FullName> {
     let info = crate::legacy::workspace::head_info(ctx)?;
     let open_reviews = open_review_numbers(ctx)?;
-    info.stacks
-        .iter()
-        .flat_map(|stack| &stack.segments)
+    info.lanes()
+        .flat_map(|lane| lane.segments)
         .find_map(|segment| {
             // Via review_number so a settled review's number cannot resolve
             // into review-sync targets.
             if review_number(segment, &open_reviews)? == wanted {
-                segment
-                    .ref_info
-                    .as_ref()
-                    .map(|ref_info| ref_info.ref_name.clone())
+                segment.ref_name().map(ToOwned::to_owned)
             } else {
                 None
             }
@@ -2270,11 +2396,7 @@ pub fn warm_ci_checks_cache(ctx: &Context) -> Result<()> {
     let mut current_refs = std::collections::HashSet::new();
 
     // Process each branch that has a PR
-    for segment in workspace
-        .stacks
-        .iter()
-        .flat_map(|stack| stack.segments.iter())
-    {
+    for segment in workspace.lanes().flat_map(|lane| lane.segments) {
         let has_pull_request = segment
             .metadata
             .as_ref()

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -344,17 +344,25 @@ pub async fn workspace_branch_and_ancestors_push(
 ) -> Result<WorkspaceBranchAndAncestorsPushOutcome> {
     let branch: gix::refs::FullName = branch.try_into()?;
     let sync_ctx = ctx.clone();
-    let review_target_updates = {
+    let (trunk, review_target_updates) = {
         let ctx = ctx.clone().into_thread_local();
-        crate::legacy::forge::review_target_updates_for_branch(&ctx, branch.as_ref())?
+        let trunk =
+            crate::legacy::forge::target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
+        (
+            trunk,
+            crate::legacy::forge::review_target_updates_for_branch(&ctx, branch.as_ref())?,
+        )
     };
     let review_targets = review_target_updates
         .iter()
         .map(|(_, desired, current)| (desired.clone(), current.clone()))
         .collect::<Vec<_>>();
-    let flattened_review_targets =
-        crate::legacy::forge::flatten_review_targets_before_push(sync_ctx.clone(), &review_targets)
-            .await?;
+    let flattened_review_targets = crate::legacy::forge::flatten_review_targets_before_push(
+        sync_ctx.clone(),
+        trunk,
+        &review_targets,
+    )
+    .await?;
     let push_branch = branch.clone();
     // This API also awaits forge synchronization, but the Git push remains synchronous and may
     // perform network I/O, hooks, and credential handling. Keep it off Tokio's async worker pool.

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -344,7 +344,7 @@ pub async fn workspace_branch_and_ancestors_push(
 ) -> Result<WorkspaceBranchAndAncestorsPushOutcome> {
     let branch: gix::refs::FullName = branch.try_into()?;
     let sync_ctx = ctx.clone();
-    let (trunk, review_target_updates) = {
+    let (trunk, review_targets) = {
         let ctx = ctx.clone().into_thread_local();
         let trunk =
             crate::legacy::forge::target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
@@ -353,10 +353,6 @@ pub async fn workspace_branch_and_ancestors_push(
             crate::legacy::forge::review_target_updates_for_branch(&ctx, branch.as_ref())?,
         )
     };
-    let review_targets = review_target_updates
-        .iter()
-        .map(|(_, desired, current)| (desired.clone(), current.clone()))
-        .collect::<Vec<_>>();
     let flattened_review_targets = crate::legacy::forge::flatten_review_targets_before_push(
         sync_ctx.clone(),
         trunk,

--- a/crates/but-workspace/src/legacy/push.rs
+++ b/crates/but-workspace/src/legacy/push.rs
@@ -157,7 +157,7 @@ pub fn branch_and_ancestor_segments<'a>(
     ref_info
         .lane_chain(branch)
         .into_iter()
-        .flat_map(|(lane, index)| &lane.segments[index..])
+        .flat_map(|(lane, index)| lane.segments_from(index))
         .filter(|segment| {
             segment
                 .ref_name()

--- a/crates/but-workspace/src/legacy/push.rs
+++ b/crates/but-workspace/src/legacy/push.rs
@@ -58,8 +58,10 @@ pub fn workspace_branch_and_ancestors_push(
     };
 
     for (sidx, segment) in to_push.iter().rev() {
-        // this will always be set
-        let Some(ref_name) = segment.ref_info.as_ref().map(|r| r.ref_name.as_ref()) else {
+        let Some(ref_name) = segment
+            .ref_name()
+            .filter(|name| name.category() == Some(Category::LocalBranch))
+        else {
             continue;
         };
 
@@ -144,12 +146,13 @@ pub fn workspace_branch_and_ancestors_push(
     Ok(result)
 }
 
-/// Return the selected local branch and its ancestors in top-to-base order, crossing into the
-/// lane a worktree rests on.
+/// Return the segment of the selected local branch and every segment beneath it in top-to-base
+/// order, crossing into the lane a worktree rests on.
 ///
-/// This is the logical scope of a push operation. It includes ancestors that are already current
-/// on the remote, even though [`workspace_branch_and_ancestors_push()`] will skip transferring
-/// those refs.
+/// This is the logical scope of a push operation: every commit the push transfers sits in one of
+/// these segments, whether or not a branch names it. Only segments named by a local branch are
+/// pushed as refs, and [`workspace_branch_and_ancestors_push()`] skips those already current on
+/// the remote.
 pub fn branch_and_ancestor_segments<'a>(
     ref_info: &'a RefInfo,
     branch: &gix::refs::FullNameRef,
@@ -158,11 +161,6 @@ pub fn branch_and_ancestor_segments<'a>(
         .lane_chain(branch)
         .into_iter()
         .flat_map(|(lane, index)| lane.segments_from(index))
-        .filter(|segment| {
-            segment
-                .ref_name()
-                .is_some_and(|name| name.category() == Some(Category::LocalBranch))
-        })
         .map(|segment| (segment.id, segment))
         .collect()
 }

--- a/crates/but-workspace/src/legacy/push.rs
+++ b/crates/but-workspace/src/legacy/push.rs
@@ -144,7 +144,8 @@ pub fn workspace_branch_and_ancestors_push(
     Ok(result)
 }
 
-/// Return the selected local branch and its ancestors in top-to-base order.
+/// Return the selected local branch and its ancestors in top-to-base order, crossing into the
+/// lane a worktree rests on.
 ///
 /// This is the logical scope of a push operation. It includes ancestors that are already current
 /// on the remote, even though [`workspace_branch_and_ancestors_push()`] will skip transferring
@@ -153,28 +154,17 @@ pub fn branch_and_ancestor_segments<'a>(
     ref_info: &'a RefInfo,
     branch: &gix::refs::FullNameRef,
 ) -> IndexMap<but_graph::SegmentIndex, &'a Segment> {
-    let mut selected = IndexMap::new();
-    for stack in &ref_info.stacks {
-        let mut refname_found = false;
-        for segment in &stack.segments {
-            let Some(ref_name) = segment.ref_info.as_ref().map(|r| r.ref_name.as_ref()) else {
-                continue;
-            };
-
-            if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
-                continue;
-            }
-
-            if ref_name == branch {
-                refname_found = true;
-            }
-
-            if refname_found {
-                selected.insert(segment.id, segment);
-            }
-        }
-    }
-    selected
+    ref_info
+        .lane_chain(branch)
+        .into_iter()
+        .flat_map(|(lane, index)| &lane.segments[index..])
+        .filter(|segment| {
+            segment
+                .ref_name()
+                .is_some_and(|name| name.category() == Some(Category::LocalBranch))
+        })
+        .map(|segment| (segment.id, segment))
+        .collect()
 }
 
 struct GerritPushArgs {

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -343,7 +343,7 @@ impl Segment {
 ///
 /// Stacks rest on the target, as do worktrees based outside the workspace or on unrelated history,
 /// so only a worktree based inside the workspace has `rests_on` set.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Lane<'a> {
     /// The segments from tip to base, never empty.
     pub segments: &'a [Segment],
@@ -712,15 +712,28 @@ impl RefInfo {
     /// The commit rested on may sit in the middle of that segment. The chain is empty if `branch`
     /// names no segment of any lane.
     pub fn lane_chain(&self, branch: &gix::refs::FullNameRef) -> Vec<(Lane<'_>, usize)> {
-        let mut chain = Vec::new();
-        let mut next = self.lane_and_segment(|segment| segment.ref_name() == Some(branch));
-        while let Some((lane, index)) = next {
-            chain.push((lane, index));
-            next = lane.rests_on.and_then(|id| {
-                self.lane_and_segment(|segment| segment.commits.iter().any(|c| c.id == id))
-            });
-        }
+        let Some((lane, index)) =
+            self.lane_and_segment(|segment| segment.ref_name() == Some(branch))
+        else {
+            return Vec::new();
+        };
+        let mut chain = vec![(lane, index)];
+        chain.extend(self.lanes_beneath(lane));
         chain
+    }
+
+    /// The lanes `lane` rests on, nearest first, each along with the index of the segment owning
+    /// the commit rested on.
+    pub fn lanes_beneath(&self, lane: Lane<'_>) -> Vec<(Lane<'_>, usize)> {
+        let mut beneath = Vec::new();
+        let mut rests_on = lane.rests_on;
+        while let Some((lane, index)) = rests_on.and_then(|id| {
+            self.lane_and_segment(|segment| segment.commits.iter().any(|c| c.id == id))
+        }) {
+            beneath.push((lane, index));
+            rests_on = lane.rests_on;
+        }
+        beneath
     }
 
     fn lane_and_segment(&self, matches: impl Fn(&Segment) -> bool) -> Option<(Lane<'_>, usize)> {

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -331,6 +331,30 @@ impl Segment {
     pub fn tip(&self) -> Option<gix::ObjectId> {
         self.commits.first().map(|commit| commit.id)
     }
+
+    /// Return the name of the branch at the tip of the segment, if present.
+    pub fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
+        self.ref_info.as_ref().map(|ri| ri.ref_name.as_ref())
+    }
+}
+
+/// A stack or a worktree as the push and review machinery sees it: its segments from tip to base,
+/// and the commit owned by another lane that the bottom segment rests on, if any.
+///
+/// Stacks rest on the target, as do worktrees based outside the workspace or on unrelated history,
+/// so only a worktree based inside the workspace has `rests_on` set.
+#[derive(Debug, Clone, Copy)]
+pub struct Lane<'a> {
+    /// The segments from tip to base, never empty.
+    pub segments: &'a [Segment],
+    /// The commit in another lane that the last segment rests on.
+    pub rests_on: Option<gix::ObjectId>,
+}
+
+impl Lane<'_> {
+    fn segment_index(&self, matches: impl Fn(&Segment) -> bool) -> Option<usize> {
+        self.segments.iter().position(matches)
+    }
 }
 
 impl std::fmt::Debug for Segment {
@@ -662,6 +686,48 @@ fn forge_review_for_branch(
 }
 
 impl RefInfo {
+    /// Every lane, i.e. each stack followed by each worktree in tip order.
+    ///
+    /// A lane can only rest on a lane listed before it, so following [`Lane::rests_on`] always
+    /// terminates.
+    pub fn lanes(&self) -> impl Iterator<Item = Lane<'_>> {
+        self.stacks
+            .iter()
+            .map(|stack| Lane {
+                segments: &stack.segments,
+                rests_on: None,
+            })
+            .chain(self.worktrees.iter().map(|wt| Lane {
+                segments: &wt.segments,
+                rests_on: match wt.base {
+                    Some(crate::worktrees::WorktreeBase::InWorkspace(id)) => Some(id),
+                    Some(crate::worktrees::WorktreeBase::Outside(_)) | None => None,
+                },
+            }))
+    }
+
+    /// The lane holding `branch` along with the index of the branch's segment, followed by each
+    /// lane it rests on along with the index of the segment owning the commit rested on.
+    ///
+    /// The commit rested on may sit in the middle of that segment. The chain is empty if `branch`
+    /// names no segment of any lane.
+    pub fn lane_chain(&self, branch: &gix::refs::FullNameRef) -> Vec<(Lane<'_>, usize)> {
+        let mut chain = Vec::new();
+        let mut next = self.lane_and_segment(|segment| segment.ref_name() == Some(branch));
+        while let Some((lane, index)) = next {
+            chain.push((lane, index));
+            next = lane.rests_on.and_then(|id| {
+                self.lane_and_segment(|segment| segment.commits.iter().any(|c| c.id == id))
+            });
+        }
+        chain
+    }
+
+    fn lane_and_segment(&self, matches: impl Fn(&Segment) -> bool) -> Option<(Lane<'_>, usize)> {
+        self.lanes()
+            .find_map(|lane| lane.segment_index(&matches).map(|index| (lane, index)))
+    }
+
     /// The segments of every lane, i.e. of each stack and each worktree.
     pub(crate) fn lane_segments_mut(&mut self) -> impl Iterator<Item = &mut Vec<Segment>> {
         self.stacks

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -351,7 +351,12 @@ pub struct Lane<'a> {
     pub rests_on: Option<gix::ObjectId>,
 }
 
-impl Lane<'_> {
+impl<'a> Lane<'a> {
+    /// The segments from `index` down to the base.
+    pub fn segments_from(self, index: usize) -> &'a [Segment] {
+        self.segments.get(index..).unwrap_or_default()
+    }
+
     fn segment_index(&self, matches: impl Fn(&Segment) -> bool) -> Option<usize> {
         self.segments.iter().position(matches)
     }

--- a/crates/but-workspace/tests/fixtures/scenario/push-worktree.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/push-worktree.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init --bare remote.git
+git init
+commit M
+git remote add origin ./remote.git
+git push --quiet -u origin main
+
+git checkout -b bottom main
+commit bottom
+git checkout -b middle
+commit middle
+git checkout -b top
+commit top
+
+create_workspace_commit_once top
+
+# A two-branch stack of its own, based on the target.
+git worktree add -b wt-bottom wt-solo main
+(cd wt-solo
+  commit wt-bottom
+  git checkout -b wt-top
+  commit wt-top
+)
+
+# Rests on `middle`, a branch of the workspace stack.
+git worktree add -b wt-on-middle wt-on-middle middle
+(cd wt-on-middle
+  commit wt-on-middle
+)

--- a/crates/but-workspace/tests/workspace/push.rs
+++ b/crates/but-workspace/tests/workspace/push.rs
@@ -46,12 +46,19 @@ fn head_info(
     repo: &gix::Repository,
     meta: &but_meta::VirtualBranchesTomlMetadata,
 ) -> anyhow::Result<(RefInfo, but_graph::Workspace)> {
+    let mut db = but_testsupport::project_db(repo)?;
+    // Adoption already ran, so the fixture worktrees count as active.
+    db.worktree_meta_mut().mark_adopted()?;
     but_workspace::head_info_and_workspace(
         repo,
         meta,
-        &mut but_testsupport::project_db(repo)?,
+        &mut db,
         Options {
             project_meta: project_meta(repo)?,
+            traversal: but_graph::init::Options {
+                worktrees: true,
+                ..Default::default()
+            },
             expensive_commit_info: true,
             ..Default::default()
         },
@@ -107,9 +114,8 @@ fn apply_remote_tracking_updates(
 }
 
 fn status(info: &RefInfo, branch: &str) -> but_workspace::ui::PushStatus {
-    info.stacks
-        .iter()
-        .flat_map(|stack| &stack.segments)
+    info.lanes()
+        .flat_map(|lane| lane.segments)
         .find(|segment| {
             segment
                 .ref_info
@@ -149,6 +155,80 @@ fn logical_push_scope_is_selected_branch_plus_ancestors() -> anyhow::Result<()> 
         "an unrelated stack must not enter the selected scope"
     );
 
+    Ok(())
+}
+
+fn pushed_branches(result: &gitbutler_git::PushResult) -> Vec<&str> {
+    result
+        .branch_to_remote
+        .iter()
+        .map(|(branch, _, _)| branch.as_str())
+        .collect()
+}
+
+#[test]
+fn logical_push_scope_crosses_into_the_lane_a_worktree_rests_on() -> anyhow::Result<()> {
+    let (_tmp, repo, meta) = fixture("push-worktree")?;
+    let (info, _) = head_info(&repo, &meta)?;
+
+    assert_eq!(
+        logical_scope(&info, "wt-on-middle"),
+        ["wt-on-middle", "middle", "bottom"],
+        "a worktree resting on a stack branch continues into that branch and its ancestors"
+    );
+    assert_eq!(
+        logical_scope(&info, "wt-top"),
+        ["wt-top", "wt-bottom"],
+        "a worktree based on the target is a stack of its own"
+    );
+    assert_eq!(
+        logical_scope(&info, "top"),
+        ["top", "middle", "bottom"],
+        "a worktree resting on the stack does not enter the stack's own scope"
+    );
+    Ok(())
+}
+
+#[test]
+fn pushing_a_worktree_branch_pushes_the_stack_branches_beneath_it() -> anyhow::Result<()> {
+    let (_tmp, repo, meta) = fixture("push-worktree")?;
+
+    let result = push(
+        &repo,
+        &meta,
+        r("refs/heads/wt-on-middle"),
+        false,
+        false,
+        false,
+    )?;
+    assert_eq!(
+        pushed_branches(&result),
+        ["bottom", "middle", "wt-on-middle"],
+        "the stack branches beneath the worktree go first, bottom-up"
+    );
+
+    apply_remote_tracking_updates(&repo, &result)?;
+    let (info, _) = head_info(&repo, &meta)?;
+    assert_eq!(status(&info, "bottom"), NothingToPush);
+    assert_eq!(status(&info, "middle"), NothingToPush);
+    assert_eq!(status(&info, "wt-on-middle"), NothingToPush);
+    assert_eq!(
+        status(&info, "top"),
+        CompletelyUnpushed,
+        "the stack branch above the base is not beneath the worktree"
+    );
+    assert_eq!(
+        status(&info, "wt-bottom"),
+        CompletelyUnpushed,
+        "an unrelated worktree is untouched"
+    );
+
+    let result = push(&repo, &meta, r("refs/heads/wt-top"), false, false, false)?;
+    assert_eq!(
+        pushed_branches(&result),
+        ["wt-bottom", "wt-top"],
+        "an independent worktree stack pushes like a workspace stack"
+    );
     Ok(())
 }
 

--- a/crates/but-workspace/tests/workspace/push.rs
+++ b/crates/but-workspace/tests/workspace/push.rs
@@ -132,11 +132,10 @@ fn logical_scope(info: &RefInfo, branch: &str) -> Vec<String> {
         .expect("valid fixture branch name");
     but_workspace::legacy::push::branch_and_ancestor_segments(info, branch.as_ref())
         .values()
-        .filter_map(|segment| {
+        .map(|segment| {
             segment
-                .ref_info
-                .as_ref()
-                .map(|ref_info| ref_info.ref_name.shorten().to_string())
+                .ref_name()
+                .map_or("<anon>".to_string(), |name| name.shorten().to_string())
         })
         .collect()
 }

--- a/crates/but-workspace/tests/workspace/worktrees.rs
+++ b/crates/but-workspace/tests/workspace/worktrees.rs
@@ -250,7 +250,7 @@ fn lane_chains_follow_what_worktrees_rest_on() -> Result<()> {
         info.lane_chain(branch.as_ref())
             .into_iter()
             .map(|(lane, index)| {
-                lane.segments[index..]
+                lane.segments_from(index)
                     .iter()
                     .map(|segment| {
                         segment

--- a/crates/but-workspace/tests/workspace/worktrees.rs
+++ b/crates/but-workspace/tests/workspace/worktrees.rs
@@ -233,6 +233,75 @@ fn worktrees_are_projected_onto_the_workspace() -> Result<()> {
 }
 
 #[test]
+fn lane_chains_follow_what_worktrees_rest_on() -> Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("worktree-workspace");
+    let mut meta = but_meta::VirtualBranchesTomlMetadata::from_path(
+        repo.path().join("should-never-be-written.toml"),
+    )?;
+    add_workspace(&mut meta);
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let info = ref_info_with_worktree_tips(&repo, &meta)?;
+
+    let chain = |branch: &str| -> Vec<Vec<String>> {
+        let branch = gix::refs::Category::LocalBranch
+            .to_full_name(branch)
+            .expect("valid fixture branch name");
+        info.lane_chain(branch.as_ref())
+            .into_iter()
+            .map(|(lane, index)| {
+                lane.segments[index..]
+                    .iter()
+                    .map(|segment| {
+                        segment
+                            .ref_name()
+                            .map_or("<anon>".to_string(), |name| name.shorten().to_string())
+                    })
+                    .collect()
+            })
+            .collect()
+    };
+    let lanes = |lanes: &[&[&str]]| -> Vec<Vec<String>> {
+        lanes
+            .iter()
+            .map(|lane| lane.iter().map(|s| s.to_string()).collect())
+            .collect()
+    };
+
+    assert_eq!(chain("A"), lanes(&[&["A"]]), "a stack rests on the target");
+    assert_eq!(
+        chain("wt-outside"),
+        lanes(&[&["wt-outside"]]),
+        "a worktree based on the target rests on nothing"
+    );
+    assert_eq!(
+        chain("disjoint"),
+        lanes(&[&["disjoint"]]),
+        "unrelated history has nothing beneath it"
+    );
+    assert_eq!(
+        chain("wt-stacked"),
+        lanes(&[&["wt-stacked"], &["wt-inside"], &["A"]]),
+        "a worktree on a worktree on a stack walks through both"
+    );
+    assert_eq!(
+        chain("top"),
+        lanes(&[&["top", "mid"], &["<anon>"], &["A"]]),
+        "the chain enters the detached worktree at its anonymous segment"
+    );
+    assert_eq!(
+        chain("mid"),
+        lanes(&[&["mid"], &["<anon>"], &["A"]]),
+        "a lower branch of a worktree stack starts its chain at its own segment"
+    );
+    assert!(
+        chain("nope").is_empty(),
+        "a branch outside every lane has no chain"
+    );
+    Ok(())
+}
+
+#[test]
 fn worktrees_are_empty_without_seeded_tips() -> Result<()> {
     let mut db = but_testsupport::in_memory_db();
     let (repo, _tmp) = writable_scenario_slow("worktree-workspace");

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1223,20 +1223,19 @@ fn gerrit_review_ref(
 }
 
 /// Check if a push of this branch would include any conflicted commits.
-/// The push covers the branch and its stack ancestors, so those are checked
-/// too. Returns an error if conflicted commits are found.
+/// The push covers the branch and everything beneath it, named by a branch
+/// or not, so all of that is checked. Returns an error if conflicted commits
+/// are found.
 fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Result<()> {
     let branch = gix::refs::Category::LocalBranch.to_full_name(branch_name)?;
-    let scope =
-        crate::legacy::workspace::push_scope_with_expensive_commit_info(ctx, branch.as_ref())?;
-    if scope.is_empty() {
-        // Branch not found - this shouldn't happen as we validate earlier
+    let Some(commits) =
+        crate::legacy::workspace::push_scope_with_expensive_commit_info(ctx, branch.as_ref())?
+    else {
         anyhow::bail!("Branch '{branch_name}' not found when checking for conflicts");
-    }
+    };
 
-    let conflicted: Vec<gix::ObjectId> = scope
+    let conflicted: Vec<gix::ObjectId> = commits
         .iter()
-        .flat_map(|branch| &branch.commits)
         .filter(|c| c.has_conflicts)
         .map(|c| c.id)
         .collect();

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -214,7 +214,7 @@ fn handle_dry_run(
     // Get detailed information for each branch
     let mut dry_run_infos = Vec::new();
 
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let lanes = crate::legacy::workspace::applied_lanes_with_expensive_commit_info(ctx)?;
 
     // Limit the shared lock to target resolution before continuing with dry-run analysis.
     let fallback_remote = {
@@ -231,11 +231,9 @@ fn handle_dry_run(
     let repo = ctx.repo.get()?.clone().for_commit_shortening();
     let remote_names = repo.remote_names();
     for (branch_name, unpushed_count, stack_name) in &branches_to_show {
-        // Find the stack containing this branch
-        for stack_entry in &stacks {
-            if stack_entry.id.is_some()
-                && let Some(branch_detail) = stack_entry.branch(branch_name)
-            {
+        // Find the lane containing this branch
+        for stack_entry in &lanes {
+            if let Some(branch_detail) = stack_entry.branch(branch_name) {
                 let remote_ref = match repo
                     .branch_remote_tracking_ref_name(
                         branch_detail.reference.as_ref(),
@@ -949,15 +947,13 @@ struct PushCandidate {
     includes: Vec<String>,
 }
 
-/// Returns one push candidate per stack that has unpushed commits.
+/// Returns one push candidate per lane that has unpushed commits. Lanes come stacks first,
+/// then worktrees in tip order, so whatever a worktree rests on is pushed before it.
 fn get_push_candidates(ctx: &Context) -> anyhow::Result<Vec<PushCandidate>> {
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let lanes = crate::legacy::workspace::applied_lanes_with_expensive_commit_info(ctx)?;
 
     let mut candidates = Vec::new();
-    for stack in &stacks {
-        if stack.id.is_none() {
-            continue;
-        }
+    for stack in &lanes {
         // Branches are ordered topmost-first; the first one with unpushed
         // commits is the candidate, everything below it comes along.
         let mut unpushed = stack.branches.iter().filter_map(|branch| {
@@ -1007,25 +1003,23 @@ fn branch_unpushed_count(branch: &crate::legacy::workspace::HeadInfoBranch) -> u
 }
 
 fn get_branches_with_unpushed_info(ctx: &Context) -> anyhow::Result<Vec<(String, usize, String)>> {
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let lanes = crate::legacy::workspace::applied_lanes_with_expensive_commit_info(ctx)?;
 
     let mut branches_info = Vec::new();
 
-    for stack in stacks {
-        if stack.id.is_some() {
-            let stack_name = stack
-                .top_branch_name()
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| "unnamed".to_string());
+    for stack in lanes {
+        let stack_name = stack
+            .top_branch_name()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| "unnamed".to_string());
 
-            // Get branch names from the heads
-            for branch in &stack.branches {
-                branches_info.push((
-                    branch.name.clone(),
-                    branch_unpushed_count(branch),
-                    stack_name.clone(),
-                ));
-            }
+        // Get branch names from the heads
+        for branch in &stack.branches {
+            branches_info.push((
+                branch.name.clone(),
+                branch_unpushed_count(branch),
+                stack_name.clone(),
+            ));
         }
     }
 
@@ -1146,10 +1140,10 @@ fn resolve_branch_name(
 }
 
 fn get_available_branch_names(ctx: &Context) -> anyhow::Result<Vec<String>> {
-    let stacks = crate::legacy::workspace::applied_stacks(ctx)?;
+    let lanes = crate::legacy::workspace::applied_lanes_with_expensive_commit_info(ctx)?;
     let mut branch_names = Vec::new();
 
-    for stack in stacks {
+    for stack in lanes {
         for branch in &stack.branches {
             branch_names.push(branch.name.clone());
         }
@@ -1227,60 +1221,48 @@ fn gerrit_review_ref(
 /// The push covers the branch and its stack ancestors, so those are checked
 /// too. Returns an error if conflicted commits are found.
 fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Result<()> {
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
-
-    let repo = ctx.repo.get()?.clone().for_commit_shortening();
-    // Find the stack containing this branch.
-    for stack in &stacks {
-        if stack.id.is_some()
-            && let Some(position) = stack.branches.iter().position(|b| b.name == branch_name)
-        {
-            // Branches are ordered topmost-first; the push includes the
-            // branch and everything below it.
-            let conflicted: Vec<gix::ObjectId> = stack.branches[position..]
-                .iter()
-                .flat_map(|branch| &branch.commits)
-                .filter(|c| c.has_conflicts)
-                .map(|c| c.id)
-                .collect();
-            // Only pay for the map when the error actually prints.
-            let id_map = (!conflicted.is_empty())
-                .then(|| crate::IdMap::legacy_new_from_context(ctx).ok())
-                .flatten();
-            let conflicted_commits: Vec<String> = conflicted
-                .iter()
-                .map(|id| {
-                    id_map
-                        .as_ref()
-                        .and_then(|id_map| id_map.change_id_ref(*id))
-                        .map(|change_id| change_id.padded_short_id())
-                        .unwrap_or_else(|| shorten_object_id(&repo, *id))
-                })
-                .collect();
-
-            if !conflicted_commits.is_empty() {
-                return Err(anyhow::anyhow!(
-                    "Cannot push branch '{}': the push would include {} conflicted commit{}.\n\
-                         Conflicted commits: {}\n\
-                         Please resolve conflicts before pushing using 'but resolve <commit>'.",
-                    branch_name,
-                    conflicted_commits.len(),
-                    if conflicted_commits.len() == 1 {
-                        ""
-                    } else {
-                        "s"
-                    },
-                    conflicted_commits.join(", ")
-                ));
-            }
-
-            return Ok(());
-        }
+    let branch = gix::refs::Category::LocalBranch.to_full_name(branch_name)?;
+    let scope =
+        crate::legacy::workspace::push_scope_with_expensive_commit_info(ctx, branch.as_ref())?;
+    if scope.is_empty() {
+        // Branch not found - this shouldn't happen as we validate earlier
+        anyhow::bail!("Branch '{branch_name}' not found when checking for conflicts");
     }
 
-    // Branch not found - this shouldn't happen as we validate earlier
+    let conflicted: Vec<gix::ObjectId> = scope
+        .iter()
+        .flat_map(|branch| &branch.commits)
+        .filter(|c| c.has_conflicts)
+        .map(|c| c.id)
+        .collect();
+    if conflicted.is_empty() {
+        return Ok(());
+    }
+    let repo = ctx.repo.get()?.clone().for_commit_shortening();
+    // Only pay for the map when the error actually prints.
+    let id_map = crate::IdMap::legacy_new_from_context(ctx).ok();
+    let conflicted_commits: Vec<String> = conflicted
+        .iter()
+        .map(|id| {
+            id_map
+                .as_ref()
+                .and_then(|id_map| id_map.change_id_ref(*id))
+                .map(|change_id| change_id.padded_short_id())
+                .unwrap_or_else(|| shorten_object_id(&repo, *id))
+        })
+        .collect();
     Err(anyhow::anyhow!(
-        "Branch '{branch_name}' not found when checking for conflicts"
+        "Cannot push branch '{}': the push would include {} conflicted commit{}.\n\
+             Conflicted commits: {}\n\
+             Please resolve conflicts before pushing using 'but resolve <commit>'.",
+        branch_name,
+        conflicted_commits.len(),
+        if conflicted_commits.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        conflicted_commits.join(", ")
     ))
 }
 

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1132,6 +1132,11 @@ fn resolve_branch_name(
 
     match &cli_ids[0] {
         CliId::Branch(branch) => Ok(branch.name.clone()),
+        CliId::Worktree { name, .. } => {
+            let repo = ctx.repo.get()?;
+            let branch = crate::utils::worktrees::worktree_branch(&repo, name.as_ref())?;
+            Ok(branch.shorten().to_string())
+        }
         _ => Err(anyhow::anyhow!(
             "Expected branch identifier, got {}. Please use a branch name or branch CLI ID.",
             cli_ids[0].kind_for_humans()

--- a/crates/but/src/legacy/workspace.rs
+++ b/crates/but/src/legacy/workspace.rs
@@ -146,11 +146,52 @@ fn applied_stacks_with_options(
     let metadata = workspace_metadata(&ctx.meta()?)?;
     let (info, object_hash) = head_info(ctx, expensive_commit_info)?;
     Ok(head_info_stacks(
-        info,
+        &info,
         metadata.as_ref(),
         object_hash.null(),
         ctx.settings.feature_flags.single_branch,
     ))
+}
+
+/// Every lane as the push command sees it: each stack, then each linked worktree in tip order
+/// without an id. Segments without a ref are left out, as nothing can push them.
+pub fn applied_lanes_with_expensive_commit_info(
+    ctx: &Context,
+) -> anyhow::Result<Vec<HeadInfoStack>> {
+    let metadata = workspace_metadata(&ctx.meta()?)?;
+    let (info, object_hash) = head_info(ctx, true)?;
+    let null_id = object_hash.null();
+    let mut lanes = head_info_stacks(
+        &info,
+        metadata.as_ref(),
+        null_id,
+        ctx.settings.feature_flags.single_branch,
+    );
+    for worktree in &info.worktrees {
+        lanes.push(HeadInfoStack {
+            id: None,
+            branches: worktree
+                .segments
+                .iter()
+                .filter(|segment| segment.ref_info.is_some())
+                .map(|segment| head_info_branch(segment, null_id))
+                .collect::<Result<_, _>>()?,
+        });
+    }
+    Ok(lanes)
+}
+
+/// The branch and everything the push of it covers, top-to-base, following the lane chain
+/// beneath a worktree.
+pub fn push_scope_with_expensive_commit_info(
+    ctx: &Context,
+    branch: &gix::refs::FullNameRef,
+) -> anyhow::Result<Vec<HeadInfoBranch>> {
+    let (info, object_hash) = head_info(ctx, true)?;
+    but_workspace::legacy::push::branch_and_ancestor_segments(&info, branch)
+        .values()
+        .map(|segment| head_info_branch(segment, object_hash.null()))
+        .collect()
 }
 
 pub fn applied_stack_with_expensive_commit_info(
@@ -185,7 +226,7 @@ fn workspace_metadata(meta: &impl but_core::RefMetadata) -> anyhow::Result<Optio
 }
 
 fn head_info_stacks(
-    info: RefInfo,
+    info: &RefInfo,
     metadata: Option<&Workspace>,
     null_id: gix::ObjectId,
     retain_single_branch_id: bool,

--- a/crates/but/src/legacy/workspace.rs
+++ b/crates/but/src/legacy/workspace.rs
@@ -181,17 +181,21 @@ pub fn applied_lanes_with_expensive_commit_info(
     Ok(lanes)
 }
 
-/// The branch and everything the push of it covers, top-to-base, following the lane chain
-/// beneath a worktree.
+/// Every commit a push of `branch` transfers, top-to-base, following the lane chain beneath a
+/// worktree and including commits no branch names. `None` if `branch` is in no lane.
 pub fn push_scope_with_expensive_commit_info(
     ctx: &Context,
     branch: &gix::refs::FullNameRef,
-) -> anyhow::Result<Vec<HeadInfoBranch>> {
-    let (info, object_hash) = head_info(ctx, true)?;
-    but_workspace::legacy::push::branch_and_ancestor_segments(&info, branch)
-        .values()
-        .map(|segment| head_info_branch(segment, object_hash.null()))
-        .collect()
+) -> anyhow::Result<Option<Vec<ui::Commit>>> {
+    let (info, _) = head_info(ctx, true)?;
+    let segments = but_workspace::legacy::push::branch_and_ancestor_segments(&info, branch);
+    Ok((!segments.is_empty()).then(|| {
+        segments
+            .values()
+            .flat_map(|segment| &segment.commits)
+            .map(Into::into)
+            .collect()
+    }))
 }
 
 pub fn applied_stack_with_expensive_commit_info(

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -353,6 +353,22 @@ Please resolve conflicts before pushing using 'but resolve <commit>'.
 }
 
 #[test]
+fn push_refuses_conflicted_commits_in_anonymous_segments_beneath_a_worktree() {
+    let env = sandbox_with_conflicted_commit();
+    enable_worktree_manipulation(&env);
+    env.but("worktree list").assert().success();
+    add_worktree_with_commit(&env, "W", "A");
+    env.invoke_git("update-ref refs/heads/A A~1");
+
+    env.but("push W").assert().failure().stderr_eq(str![[r#"
+Error: Cannot push branch 'W': the push would include 1 conflicted commit.
+Conflicted commits: [..]
+Please resolve conflicts before pushing using 'but resolve <commit>'.
+
+"#]]);
+}
+
+#[test]
 fn push_rejects_merged_upstream_branch() {
     let env =
         Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -1,6 +1,8 @@
 use snapbox::str;
 
-use super::util::sandbox_with_conflicted_commit;
+use super::util::{
+    add_worktree_with_commit, enable_worktree_manipulation, sandbox_with_conflicted_commit,
+};
 use crate::utils::{CommandExt, Sandbox};
 
 fn repo_with_unpushed_branch() -> Sandbox {
@@ -22,6 +24,33 @@ fn repo_with_unpushed_branch() -> Sandbox {
         .success();
 
     env
+}
+
+/// [`repo_with_unpushed_branch()`] with the worktree flag on and a linked worktree on the new
+/// branch `wt`, with one commit of its own, resting on the unpushed `branchB`.
+fn repo_with_worktree_on_unpushed_branch() -> Sandbox {
+    let env = repo_with_unpushed_branch();
+    enable_worktree_manipulation(&env);
+    // Worktrees that predate the first flag-on read are adopted as archived.
+    env.but("worktree list").assert().success();
+    add_worktree_with_commit(&env, "wt", "branchB");
+    env
+}
+
+#[test]
+fn bare_push_includes_worktree_lanes() {
+    let env = repo_with_worktree_on_unpushed_branch();
+
+    // Stacks push before worktrees, so `wt` finds `branchB` already current.
+    env.but("push").assert().success().stdout_eq(str![[r#"
+
+✓ Successfully pushed 3 commits
+
+  branchB -> origin/branchB ((new branch) -> 7566fe0)
+  A -> origin/A ((new branch) -> 9477ae7)
+  wt -> origin/wt ((new branch) -> 9da8421)
+
+"#]]);
 }
 
 fn shell_quote_path(path: &std::path::Path) -> String {

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -38,6 +38,20 @@ fn repo_with_worktree_on_unpushed_branch() -> Sandbox {
 }
 
 #[test]
+fn pushing_a_worktree_branch_pushes_what_it_rests_on_first() {
+    let env = repo_with_worktree_on_unpushed_branch();
+
+    env.but("push wt").assert().success().stdout_eq(str![[r#"
+
+✓ Push completed successfully
+
+  branchB -> origin/branchB ((new branch) -> 7566fe0)
+  wt -> origin/wt ((new branch) -> 9da8421)
+
+"#]]);
+}
+
+#[test]
 fn bare_push_includes_worktree_lanes() {
     let env = repo_with_worktree_on_unpushed_branch();
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -29,7 +29,7 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 /**
  * Add the caller's reaction to one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:950}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1087}
  */
 export declare function addCommentReaction(projectId: string, commentId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -44,21 +44,21 @@ export declare function addProject(path: string): Promise<AddProjectOutcome>
 /**
  * Add labels to a review; returns the resulting label set.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1078}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1215}
  */
 export declare function addReviewLabels(projectId: string, reviewId: number, labels: Array<string>): Promise<Array<ForgeReviewLabel>>
 
 /**
  * Add the caller's reaction to a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:870}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1007}
  */
 export declare function addReviewReaction(projectId: string, reviewId: number, kind: string): Promise<ForgeReviewReaction>
 
 /**
  * Add the caller's reaction to one submitted review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:908}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1045}
  */
 export declare function addSubmissionReaction(projectId: string, reviewId: number, submissionId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -586,14 +586,14 @@ export declare function commitUncommitChangesFromCommits(projectId: string, sour
 /**
  * Post a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1164}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1301}
  */
 export declare function createReviewComment(projectId: string, reviewId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Reply into one of a review's diff-anchored comment threads.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:822}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:959}
  */
 export declare function createReviewThreadReply(projectId: string, threadId: string, body: string): Promise<ForgeReviewThreadComment>
 
@@ -601,7 +601,7 @@ export declare function createReviewThreadReply(projectId: string, threadId: str
  * The login this project's forge calls authenticate as, if any account is
  * configured. Resolved from stored accounts; no network.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1051}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1188}
  */
 export declare function currentForgeLogin(projectId: string): Promise<string | null>
 
@@ -618,7 +618,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 /**
  * Delete a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1036}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1173}
  */
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
@@ -845,22 +845,22 @@ export declare function getLoginToken(): Promise<LoginToken>
 export declare function getRedoTargetSnapshot(projectId: string): Promise<Snapshot | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1219}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1356}
  */
 export declare function getRepoInfo(projectId: string): Promise<RepoInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1193}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1330}
  */
 export declare function getReview(projectId: string, reviewId: number): Promise<ForgeReview>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:761}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:898}
  */
 export declare function getReviewBaseRepoUrl(projectId: string, reviewId: number): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1182}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1319}
  */
 export declare function getReviewMergeStatus(projectId: string, reviewId: number): Promise<ReviewMergeStatus>
 
@@ -982,14 +982,14 @@ export declare function listAvailableReviewTemplates(projectId: string): Promise
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1242}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1379}
  */
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
 /**
  * List the individual reactions (with who reacted) on one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:853}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:990}
  */
 export declare function listCommentReactions(projectId: string, commentId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1057,28 +1057,28 @@ export declare function listProjectsStateless(): Promise<Array<ProjectForFronten
 /**
  * List the labels defined on the repository backing this project's reviews.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1070}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1207}
  */
 export declare function listRepoLabels(projectId: string): Promise<Array<ForgeReviewLabel>>
 
 /**
  * List the top-level conversation comments on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:778}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:915}
  */
 export declare function listReviewComments(projectId: string, reviewId: number): Promise<Array<ForgeReviewComment>>
 
 /**
  * List users who can be requested to review on this project's repository.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1116}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1253}
  */
 export declare function listReviewerCandidates(projectId: string): Promise<Array<ForgeReviewUser>>
 
 /**
  * List the individual reactions (with who reacted) on a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:841}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:978}
  */
 export declare function listReviewReactions(projectId: string, reviewId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1088,28 +1088,28 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2229}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2355}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
 /**
  * List the submitted reviews (approvals, change requests) on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1005}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1142}
  */
 export declare function listReviewSubmissions(projectId: string, reviewId: number): Promise<Array<ForgeReviewSubmission>>
 
 /**
  * List the diff-anchored comment threads on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:790}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:927}
  */
 export declare function listReviewThreads(projectId: string, reviewId: number): Promise<Array<ForgeReviewThread>>
 
 /**
  * List the pushed commits and review requests on a review's timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:988}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1125}
  */
 export declare function listReviewTimelineEvents(projectId: string, reviewId: number): Promise<Array<ForgeReviewTimelineEvent>>
 
@@ -1142,7 +1142,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1403}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1540}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1267,7 +1267,7 @@ export declare const enum ProgramCategory {
 }
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1280}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1417}
  */
 export declare function publishReview(projectId: string, params: PublishReviewInput): Promise<PublishReviewOutcome>
 
@@ -1287,35 +1287,35 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 /**
  * Remove one of the caller's reactions from one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:969}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1106}
  */
 export declare function removeCommentReaction(projectId: string, commentId: number, reactionId: number): Promise<void>
 
 /**
  * Remove one label from a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1097}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1234}
  */
 export declare function removeReviewLabel(projectId: string, reviewId: number, label: string): Promise<void>
 
 /**
  * Remove one of the caller's reactions from a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:889}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1026}
  */
 export declare function removeReviewReaction(projectId: string, reviewId: number, reactionId: number): Promise<void>
 
 /**
  * Remove the caller's reaction of one kind from one submitted review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:929}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1066}
  */
 export declare function removeSubmissionReaction(projectId: string, reviewId: number, submissionId: number, kind: string): Promise<void>
 
 /**
  * Request reviews from the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1126}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1263}
  */
 export declare function requestReview(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1405,14 +1405,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1423}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1560}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1443}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1580}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1428,7 +1428,7 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  * Set a review conversation's resolution on the forge.
  * This remote operation is outside the local repository snapshot timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:803}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:940}
  */
 export declare function setReviewThreadResolved(projectId: string, threadId: string, resolved: boolean): Promise<void>
 
@@ -1579,21 +1579,21 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1475}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1612}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
 /**
  * Edit a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1017}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1154}
  */
 export declare function updateReviewComment(projectId: string, commentId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1499}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1636}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1615,14 +1615,14 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2263}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2389}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
 /**
  * Withdraw review requests for the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1145}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1282}
  */
 export declare function withdrawReviewRequest(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -29,7 +29,7 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 /**
  * Add the caller's reaction to one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:950}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1087}
  */
 export declare function addCommentReaction(projectId: string, commentId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -44,21 +44,21 @@ export declare function addProject(path: string): Promise<AddProjectOutcome>
 /**
  * Add labels to a review; returns the resulting label set.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1078}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1215}
  */
 export declare function addReviewLabels(projectId: string, reviewId: number, labels: Array<string>): Promise<Array<ForgeReviewLabel>>
 
 /**
  * Add the caller's reaction to a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:870}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1007}
  */
 export declare function addReviewReaction(projectId: string, reviewId: number, kind: string): Promise<ForgeReviewReaction>
 
 /**
  * Add the caller's reaction to one submitted review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:908}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1045}
  */
 export declare function addSubmissionReaction(projectId: string, reviewId: number, submissionId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -586,14 +586,14 @@ export declare function commitUncommitChangesFromCommits(projectId: string, sour
 /**
  * Post a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1164}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1301}
  */
 export declare function createReviewComment(projectId: string, reviewId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Reply into one of a review's diff-anchored comment threads.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:822}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:959}
  */
 export declare function createReviewThreadReply(projectId: string, threadId: string, body: string): Promise<ForgeReviewThreadComment>
 
@@ -601,7 +601,7 @@ export declare function createReviewThreadReply(projectId: string, threadId: str
  * The login this project's forge calls authenticate as, if any account is
  * configured. Resolved from stored accounts; no network.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1051}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1188}
  */
 export declare function currentForgeLogin(projectId: string): Promise<string | null>
 
@@ -618,7 +618,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 /**
  * Delete a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1036}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1173}
  */
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
@@ -845,22 +845,22 @@ export declare function getLoginToken(): Promise<LoginToken>
 export declare function getRedoTargetSnapshot(projectId: string): Promise<Snapshot | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1219}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1356}
  */
 export declare function getRepoInfo(projectId: string): Promise<RepoInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1193}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1330}
  */
 export declare function getReview(projectId: string, reviewId: number): Promise<ForgeReview>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:761}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:898}
  */
 export declare function getReviewBaseRepoUrl(projectId: string, reviewId: number): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1182}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1319}
  */
 export declare function getReviewMergeStatus(projectId: string, reviewId: number): Promise<ReviewMergeStatus>
 
@@ -982,14 +982,14 @@ export declare function listAvailableReviewTemplates(projectId: string): Promise
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1242}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1379}
  */
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
 /**
  * List the individual reactions (with who reacted) on one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:853}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:990}
  */
 export declare function listCommentReactions(projectId: string, commentId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1057,28 +1057,28 @@ export declare function listProjectsStateless(): Promise<Array<ProjectForFronten
 /**
  * List the labels defined on the repository backing this project's reviews.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1070}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1207}
  */
 export declare function listRepoLabels(projectId: string): Promise<Array<ForgeReviewLabel>>
 
 /**
  * List the top-level conversation comments on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:778}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:915}
  */
 export declare function listReviewComments(projectId: string, reviewId: number): Promise<Array<ForgeReviewComment>>
 
 /**
  * List users who can be requested to review on this project's repository.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1116}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1253}
  */
 export declare function listReviewerCandidates(projectId: string): Promise<Array<ForgeReviewUser>>
 
 /**
  * List the individual reactions (with who reacted) on a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:841}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:978}
  */
 export declare function listReviewReactions(projectId: string, reviewId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1088,28 +1088,28 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2229}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2355}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
 /**
  * List the submitted reviews (approvals, change requests) on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1005}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1142}
  */
 export declare function listReviewSubmissions(projectId: string, reviewId: number): Promise<Array<ForgeReviewSubmission>>
 
 /**
  * List the diff-anchored comment threads on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:790}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:927}
  */
 export declare function listReviewThreads(projectId: string, reviewId: number): Promise<Array<ForgeReviewThread>>
 
 /**
  * List the pushed commits and review requests on a review's timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:988}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1125}
  */
 export declare function listReviewTimelineEvents(projectId: string, reviewId: number): Promise<Array<ForgeReviewTimelineEvent>>
 
@@ -1142,7 +1142,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1403}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1540}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1267,7 +1267,7 @@ export declare const enum ProgramCategory {
 }
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1280}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1417}
  */
 export declare function publishReview(projectId: string, params: PublishReviewInput): Promise<PublishReviewOutcome>
 
@@ -1287,35 +1287,35 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 /**
  * Remove one of the caller's reactions from one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:969}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1106}
  */
 export declare function removeCommentReaction(projectId: string, commentId: number, reactionId: number): Promise<void>
 
 /**
  * Remove one label from a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1097}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1234}
  */
 export declare function removeReviewLabel(projectId: string, reviewId: number, label: string): Promise<void>
 
 /**
  * Remove one of the caller's reactions from a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:889}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1026}
  */
 export declare function removeReviewReaction(projectId: string, reviewId: number, reactionId: number): Promise<void>
 
 /**
  * Remove the caller's reaction of one kind from one submitted review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:929}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1066}
  */
 export declare function removeSubmissionReaction(projectId: string, reviewId: number, submissionId: number, kind: string): Promise<void>
 
 /**
  * Request reviews from the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1126}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1263}
  */
 export declare function requestReview(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1405,14 +1405,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1423}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1560}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1443}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1580}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1428,7 +1428,7 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  * Set a review conversation's resolution on the forge.
  * This remote operation is outside the local repository snapshot timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:803}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:940}
  */
 export declare function setReviewThreadResolved(projectId: string, threadId: string, resolved: boolean): Promise<void>
 
@@ -1579,21 +1579,21 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1475}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1612}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
 /**
  * Edit a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1017}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1154}
  */
 export declare function updateReviewComment(projectId: string, commentId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1499}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1636}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1615,14 +1615,14 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2263}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2389}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
 /**
  * Withdraw review requests for the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1145}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1282}
  */
 export declare function withdrawReviewRequest(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 


### PR DESCRIPTION
Worktrees can be based off stacks in the workspace.

With our apps general rule, if I push a reference at the top of a stack, we also push it's dependants. This avoids inconsistent remote state that users almost never want.

With a worktree that is based off of a stack, IE:

```
* GitButler Workspace Commit
* refs/heads/foo
* a
| * refs/heads/wt
| * x
|/
* refs/heads/bar
* b
```

If I were to push `wt`, we would want to have both `wt` and `bar` pushed.

The first thing to solve this is to have the concept of a `lane` which is the segments of either a stack or worktree along with where it's based.

The next is to have the concept of a lane chain, a vector of Lanes with an additional index to tell us where to start traversing.

In the example, there are two lanes:

Lane 1: `[(refs/heads/foo; commits [a]), (refs/heads/bar; commits [b])]`
Lane 2: `[(refs/heads/wt; commits [x])]`

The chain from the worktree would be `[(Lane 2, 0), (Lane 1, 1)]` since we want all segments of lane 2, followed by the second segment of lane 1.

With the lanes, we can find the push dependencies.

---

Forges

I needed to touch a little bit on forges because this is equally relevant.

I needed to make some decision about how stacks are handled. As an insane person, I would say that we shouldn't have PR stacks. Instead, we should have PR DAGs. However, the likely far more sane people at GitHub declared that stacks _must_ be linear.

Since we at the very least have something tree-like now, we have to make an exception somewhere.

As such, I decided that:
- If a worktree is based on a commit in an applied stack: We don't try and tell GH the PRs are stacked
- If a worktree is based on `target_commit_id` or somewhere beneath it: We tell GH it's a stack (if there are multiple branches of course)

You could have a scenario where a worktree makes up the top most section of the rest of a stack, in which case it would still be linear, but  then you might have to disrupt the stack if you put another segment on in the main workspace, so I decided that it was best not to try and handle all of that.