### PR TITLE
Put the hand cursor on every control in Lite

### DIFF
--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -61,15 +61,19 @@ over buttons, menus and rows; the hand is a web convention for links out to a
 page. Whoever wants the hand anyway turns it on in Appearance, and the harness
 panel takes it always, being part of a web page. Both go through one property:
 the host sets `--control-cursor` on its root, and `control-cursor.css` puts it
-on buttons, links, `summary` and the button, menu-item and option roles. Don't
-set `cursor: pointer` on a control, and don't pin `cursor: default` on one
-either — both defeat the setting. Don't reintroduce the hand by resetting a
-`<button>`: the browser default for buttons is already the arrow. A clickable
-that is none of those elements (a folded card, a minimap badge) takes
-`cursor: var(--control-cursor)` itself. Interactivity is shown by the hover
-state, not the cursor. The cursors that do change are the ones that describe a
-gesture: `text` over editable text, `grab` and `grabbing` while dragging, the
-resize cursors on a splitter, and `not-allowed` on a disabled control.
+on every control in one rule — buttons, links, `summary`, `select`, a `label`
+that owns a control, and the roles Base UI renders when it draws a control as a
+span or a div: button, checkbox, switch, radio, tab, option and the menu items.
+The same stylesheet gives a disabled control `not-allowed`, so no component
+does. Don't set `cursor: pointer` on a control, and don't pin `cursor: default`
+on one either — both defeat the setting. Don't reintroduce the hand by
+resetting a `<button>`: the browser default for buttons is already the arrow.
+A clickable that is none of those elements (a list row, a folded card, a
+minimap badge, a diff line number) takes `cursor: var(--control-cursor)`
+itself. Interactivity is shown by the hover state, not the cursor. The cursors
+that do change are the ones that describe a gesture: `text` over editable
+text, `grab` and `grabbing` while dragging, and the resize cursors on a
+splitter.
 
 ## Motion
 

--- a/apps/lite/ui/src/components/Checkbox.module.css
+++ b/apps/lite/ui/src/components/Checkbox.module.css
@@ -46,8 +46,6 @@
 
 	&:disabled,
 	&[data-disabled] {
-		cursor: not-allowed;
-
 		&:not([data-checked], [data-indeterminate]) {
 			background-color: color-mix(
 				in srgb,

--- a/apps/lite/ui/src/components/Field.module.css
+++ b/apps/lite/ui/src/components/Field.module.css
@@ -33,7 +33,6 @@
 
 	&:disabled,
 	&[data-disabled] {
-		cursor: not-allowed;
 		opacity: 0.5;
 	}
 }

--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -47,7 +47,6 @@
 	border-radius: var(--radius-button);
 	outline: 0;
 	font-size: 13px;
-	cursor: var(--control-cursor);
 	scroll-margin-block: 4px;
 	user-select: none;
 

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -217,7 +217,6 @@
 	background: none;
 	color: var(--text-1);
 	text-align: start;
-	cursor: var(--control-cursor);
 
 	/* `data-highlighted` is what Base UI's list primitives set as the keyboard walks them, so
 	   pointer and keyboard land on the same tint. */
@@ -228,7 +227,6 @@
 
 	&:disabled,
 	&[data-disabled] {
-		cursor: not-allowed;
 		opacity: var(--opacity-disabled);
 	}
 }

--- a/apps/lite/ui/src/components/ToggleGroup.module.css
+++ b/apps/lite/ui/src/components/ToggleGroup.module.css
@@ -20,11 +20,6 @@
 		outline: var(--focus-ring);
 	}
 
-	&[data-disabled],
-	&:disabled {
-		cursor: not-allowed;
-	}
-
 	&:first-child {
 		border-start-end-radius: 0;
 		border-end-end-radius: 0;

--- a/apps/lite/ui/src/control-cursor.css
+++ b/apps/lite/ui/src/control-cursor.css
@@ -2,12 +2,44 @@
    the hand (DESIGN.md, Cursors), so each host sets --control-cursor on its
    root: the app from the appearance setting, the harness panel to the hand of
    the page it sits in. Imported right after design-core, whose reset gives
-   links the hand. */
-button,
-a,
-summary,
-[role="button"],
-[role="menuitem"],
-[role="option"] {
+   links the hand.
+
+   Every control is listed here, once: the native elements and the roles Base
+   UI renders when it draws a control as a span or a div (a switch, a checkbox,
+   a combobox option, a menu item). A component adds cursor rules only for a
+   clickable that is none of these — a folded card, a minimap badge, a list
+   row — and takes `var(--control-cursor)` there too, never `pointer`.
+
+   Zero specificity, so a gesture cursor a component sets (text, grab, the
+   resize cursors) wins without a fight. */
+:where(
+	button,
+	a,
+	summary,
+	select,
+	input:is([type="checkbox"], [type="radio"]),
+	label[for],
+	[role="button"],
+	[role="checkbox"],
+	[role="menuitem"],
+	[role="menuitemcheckbox"],
+	[role="menuitemradio"],
+	[role="option"],
+	[role="radio"],
+	[role="switch"],
+	[role="tab"]
+) {
 	cursor: var(--control-cursor);
+}
+
+/* A disabled control refuses, whichever cursor the host chose. `data-disabled`
+   and `aria-disabled` are what Base UI sets on a control that is disabled but
+   still focusable. A label wrapping a disabled control refuses with it. */
+:where(button, select, input, textarea, [role]):is(
+	:disabled,
+	[data-disabled],
+	[aria-disabled="true"]
+),
+label:has(:disabled, [data-disabled], [aria-disabled="true"]) {
+	cursor: not-allowed;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/ConflictedFiles.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ConflictedFiles.module.css
@@ -58,7 +58,6 @@
 	}
 
 	&:disabled {
-		cursor: default;
 		opacity: 0.5;
 	}
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1879,7 +1879,7 @@ const DiffContents: FC<{
             --mix-selection-light: 0%;
             --mix-selection-dark: 0%;
 
-            cursor: default;
+            cursor: var(--control-cursor);
           }
 
           [data-column-number][data-selected-line]:is(

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -31,6 +31,8 @@
 /* Square, and edge to edge in every list that has them: a row's fill is a band
    across the panel rather than a chip inside it. */
 .containerInteractive {
+	cursor: var(--control-cursor);
+
 	&:where(:hover) {
 		background-color: var(--list-item-hover-bg);
 	}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Account.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Account.module.css
@@ -19,7 +19,6 @@
 	border: 1px solid var(--border-2);
 	border-radius: var(--radius-card);
 	background-color: var(--bg-2);
-	cursor: default;
 
 	& > * {
 		grid-area: 1 / 1;


### PR DESCRIPTION
Follow-up to #15858: the hand cursor setting only reached buttons and links, since everything Base UI renders as a span or div (switch, checkbox, combobox option) fell through to the arrow. Closes GB-2043.

- `control-cursor.css` names every control once, including `select`, `label[for]`, native checkbox/radio inputs and the checkbox, switch, radio, tab, option and menu-item roles
- disabled controls get `not-allowed` from the same stylesheet, so Button, ConflictedFiles and the account avatar stop disagreeing
- interactive rows and diff line numbers follow the setting too
- the redundant per-component cursor rules are gone, and DESIGN.md's Cursors section describes the contract

Verified over Storybook with Playwright: every control computes `default` with the setting off and `pointer` with it on, disabled ones `not-allowed` in both.