### PR TITLE
Stop re-validating refs the graph resolved itself

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -668,9 +668,8 @@ impl Graph {
     /// * Traversal is seeded from [`Tip`]s. Workspace metadata traversal first
     ///   resolves metadata into tips, then follows the same path as callers
     ///   passing explicit tips.
-    /// * Explicit tips must contain exactly one entrypoint, must not contain
-    ///   duplicate traversal seeds, and any named tip must have a ref that
-    ///   resolves to its commit id. A traversal seed is the commit id, the
+    /// * Explicit tips must contain exactly one entrypoint and must not contain
+    ///   duplicate traversal seeds. A traversal seed is the commit id, the
     ///   traversal role, and whether that tip is the entrypoint; naming,
     ///   metadata, detached presentation, and queue position do not make it
     ///   useful to enqueue the same seed twice.
@@ -852,6 +851,7 @@ impl Graph {
         let tips: Vec<_> = tips.into_iter().collect();
         let worktree_tips = discover_worktree_tips(repo, db, options.worktrees)?;
         let (overlay_repo, overlay_meta, _entrypoint) = Overlay::default().into_parts(repo, meta);
+        validate_explicit_tip_refs(&overlay_repo, &tips)?;
         Graph::traverse_tips_with_overlay(
             &overlay_repo,
             tips,
@@ -878,7 +878,23 @@ impl Graph {
         worktree_tips: Vec<WorktreeTip>,
         entrypoint_ref_override: Option<gix::refs::FullName>,
     ) -> anyhow::Result<Self> {
-        let entrypoint = validate_explicit_tips(repo, &tips, entrypoint_ref_override.as_ref())?;
+        let entrypoint = validate_tips(&tips)?;
+        // A tip carrying the override name already fixes it to a captured commit.
+        // Otherwise the name is discovered from the live ref map during traversal,
+        // so it must still point at the entrypoint.
+        if let Some(ref_name) = entrypoint_ref_override.as_ref()
+            && !entrypoint.is_detached
+            && !tips
+                .iter()
+                .any(|tip| tip.ref_name.as_ref() == Some(ref_name))
+        {
+            validate_tip_ref(
+                repo,
+                ref_name,
+                entrypoint.id,
+                "explicit traversal entrypoint ref",
+            )?;
+        }
         let tip = entrypoint.id;
         let ref_name = if entrypoint.is_detached {
             None
@@ -1250,17 +1266,15 @@ impl Graph {
     }
 }
 
-/// Validate caller-provided traversal tips before they seed graph traversal.
+/// Validate the structure of traversal tips before they seed graph traversal.
 ///
-/// Explicit tips must name exactly one entrypoint, must not contain duplicate
-/// traversal seeds or repeated ref names, must keep detached entrypoints
-/// unnamed, and any supplied ref name must resolve to the same commit id as its
-/// tip.
-fn validate_explicit_tips<'a>(
-    repo: &OverlayRepo<'_>,
-    tips: &'a [Tip],
-    entrypoint_ref_override: Option<&gix::refs::FullName>,
-) -> anyhow::Result<&'a Tip> {
+/// Tips must name exactly one entrypoint, must not contain duplicate traversal
+/// seeds or repeated ref names, and must keep detached entrypoints unnamed.
+///
+/// Ref names are not resolved here: tips derived from workspace metadata were
+/// just read from the repository, and re-reading them would fail whenever a
+/// concurrent fetch or workspace update moves a ref in between.
+fn validate_tips(tips: &[Tip]) -> anyhow::Result<&Tip> {
     let mut entrypoints = tips.iter().filter(|tip| tip.is_entrypoint);
     let entrypoint = entrypoints
         .next()
@@ -1295,22 +1309,22 @@ fn validate_explicit_tips<'a>(
                 seen_names.insert(ref_name),
                 "explicit traversal tips contain duplicate ref name {ref_name}"
             );
+        }
+    }
+    Ok(entrypoint)
+}
+
+/// Require every named caller-provided tip to resolve to its own commit id.
+///
+/// Only [`Graph::from_commit_traversal_tips()`] receives tips the graph did not
+/// resolve itself, so only there can a ref name and id disagree by mistake.
+fn validate_explicit_tip_refs(repo: &OverlayRepo<'_>, tips: &[Tip]) -> anyhow::Result<()> {
+    for tip in tips {
+        if let Some(ref_name) = tip.ref_name.as_ref() {
             validate_tip_ref(repo, ref_name, tip.id, "explicit traversal tip ref")?;
         }
     }
-
-    if !entrypoint.is_detached
-        && let Some(ref_name) = entrypoint_ref_override
-    {
-        validate_tip_ref(
-            repo,
-            ref_name,
-            entrypoint.id,
-            "explicit traversal entrypoint ref",
-        )?;
-    }
-
-    Ok(entrypoint)
+    Ok(())
 }
 
 fn validate_tip_ref(
@@ -1688,40 +1702,33 @@ fn initial_tips_from_workspace_metadata<T: RefMetadata>(
             workspaces.push((workspace_tip, workspace_ref, Default::default()));
         }
     }
-    let tip_ref_matches_ws_ref = workspaces
-        .iter()
-        .find_map(|(ws_tip, ws_rn, _)| (Some(ws_rn) == entrypoint_ref).then_some(ws_tip));
-
     let mut tips = Vec::new();
     let mut workspace_metas = Vec::new();
     let mut additional_target_commits = Vec::new();
     let mut queued_ids = Vec::new();
 
-    match tip_ref_matches_ws_ref {
-        None => {
-            // We don't name the tip of the entrypoint as we want the segment
-            // naming to be handled by tips created from metadata.
-            tips.push(Tip::entrypoint(entrypoint, None));
-            queued_ids.push(entrypoint);
-        }
-        Some(ws_tip) => {
-            ensure!(
-                *ws_tip == entrypoint,
-                format!(
-                    "BUG:: {entrypoint_ref:?} points to {ws_tip}, but the caller claimed it points to {entrypoint}"
-                )
-            );
-        }
+    if !workspaces
+        .iter()
+        .any(|(_, ws_rn, _)| Some(ws_rn) == entrypoint_ref)
+    {
+        // We don't name the tip of the entrypoint as we want the segment
+        // naming to be handled by tips created from metadata.
+        tips.push(Tip::entrypoint(entrypoint, None));
+        queued_ids.push(entrypoint);
     }
 
     for (ws_tip, ws_ref, ws_meta) in workspaces {
+        let is_entrypoint = Some(&ws_ref) == entrypoint_ref;
+        // The caller resolved the entrypoint ref moments ago; use its id instead of
+        // the one re-read above so a ref moving in between can't split the two.
+        let ws_tip = if is_entrypoint { entrypoint } else { ws_tip };
         workspace_metas.push(ws_meta.clone());
         tips.push(
             Tip::new(ws_tip)
                 .with_ref_name(Some(ws_ref.clone()))
                 .with_role(TipRole::Workspace)
                 .with_metadata(SegmentMetadata::Workspace(ws_meta.clone()))
-                .with_is_entrypoint(Some(&ws_ref) == entrypoint_ref),
+                .with_is_entrypoint(is_entrypoint),
         );
 
         let target = append_project_target_tips(

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -912,14 +912,13 @@ fn explicit_traversal_tips_reject_multiple_entrypoints() -> anyhow::Result<()> {
 fn explicit_traversal_tips_reject_duplicate_ref_names() -> anyhow::Result<()> {
     let (repo, meta, mut db) = read_only_in_memory_scenario("four-diamond")?;
     let a_id = id_by_rev(&repo, "A").detach();
-    let c_id = id_by_rev(&repo, "C").detach();
     let a_ref = ref_name("refs/heads/A");
 
     let err = Graph::from_commit_traversal_tips(
         &repo,
         [
             Tip::entrypoint(a_id, Some(a_ref.clone())),
-            Tip::reachable(c_id, Some(a_ref.clone())),
+            Tip::reachable(a_id, Some(a_ref.clone())),
         ],
         &*meta,
         but_core::ref_metadata::ProjectMeta::default(),
@@ -986,6 +985,8 @@ fn explicit_traversal_tips_reject_ref_names_that_point_elsewhere() -> anyhow::Re
 
 #[test]
 fn traversal_entrypoint_ref_override_must_point_to_entrypoint() -> anyhow::Result<()> {
+    // Without a tip carrying the name, the entrypoint is named from the live ref map,
+    // so a stale override cannot be honored.
     let (repo, meta, mut db) = read_only_in_memory_scenario("four-diamond")?;
     let merged_id = id_by_rev(&repo, "merged").detach();
     let a_id = id_by_rev(&repo, "A").detach();
@@ -1006,6 +1007,110 @@ fn traversal_entrypoint_ref_override_must_point_to_entrypoint() -> anyhow::Resul
         format!("explicit traversal entrypoint ref {a_ref} points to {a_id}, not {merged_id}")
     );
     Ok(())
+}
+
+#[test]
+fn stale_workspace_entrypoint_id_is_used_as_captured() -> anyhow::Result<()> {
+    // The caller peeled the workspace ref, then the ref moved before traversal
+    // started. The workspace tip carries the name, so the graph is built from the
+    // captured id instead of re-reading the ref.
+    let (repo, meta, mut db) = read_only_in_memory_scenario("ws/local-target-and-stack")?;
+    let stale = id_by_rev(&repo, "A");
+    let ws_ref = ref_name("refs/heads/gitbutler/workspace");
+    let graph = Graph::from_commit_traversal(
+        stale,
+        Some(ws_ref.clone()),
+        &*meta,
+        default_project_meta(&repo),
+        &mut db,
+        standard_options(),
+    )?
+    .validated()?;
+    let entrypoint = graph.entrypoint()?;
+    assert_eq!(entrypoint.segment.ref_name(), Some(ws_ref.as_ref()));
+    assert_eq!(
+        entrypoint.commit().map(|c| c.id),
+        Some(stale.detach()),
+        "traversal started at the captured commit, not where the ref points now"
+    );
+    Ok(())
+}
+
+#[test]
+fn stale_extra_tip_id_is_used_as_captured() -> anyhow::Result<()> {
+    // Same for tips a caller read just before traversal: they are not re-resolved.
+    let (repo, meta, mut db) = read_only_in_memory_scenario("four-diamond")?;
+    let stale = id_by_rev(&repo, "B").detach();
+    let a_ref = ref_name("refs/heads/A");
+    let graph = Graph::from_commit_traversal_with_extra_tips(
+        id_by_rev(&repo, "merged"),
+        None,
+        [Tip::reachable(stale, Some(a_ref.clone()))],
+        &*meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        &mut db,
+        standard_options(),
+    )?
+    .validated()?;
+    let (_, commit) = graph
+        .segment_and_commit_by_ref_name(a_ref.as_ref())
+        .expect("the tip names a segment");
+    assert_eq!(
+        commit.id, stale,
+        "the named segment sits at the captured commit, not where the ref points now"
+    );
+    Ok(())
+}
+
+#[test]
+fn from_head_tolerates_refs_moving_during_traversal() -> anyhow::Result<()> {
+    // Workspace metadata traversal reads the target ref once and must not fail
+    // when a concurrent fetch moves it before traversal starts.
+    let tmp = but_testsupport::gix_testtools::tempfile::TempDir::new()?;
+    let repo = gix::ThreadSafeRepository::init_opts(
+        tmp.path(),
+        gix::create::Kind::WithWorktree,
+        gix::create::Options::default(),
+        but_testsupport::open_repo_config()?,
+    )?
+    .to_thread_local();
+    let m1 = commit(&repo, "M1")?;
+    let m2 = commit_with_parent(&repo, "M2", m1)?;
+    create_branches(&repo, m1, ["refs/heads/main", "refs/remotes/origin/main"])?;
+    let mut meta = in_memory_meta(tmp.path())?;
+    let project_meta = add_workspace_with_target(&mut meta, m1);
+    let mut db = but_testsupport::project_db(&repo)?;
+
+    // The mover keeps flipping the target ref until every traversal below has run,
+    // so each traversal races an update.
+    let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mover = std::thread::spawn({
+        let path = tmp.path().to_owned();
+        let done = done.clone();
+        move || -> anyhow::Result<()> {
+            let repo = gix::open_opts(path, but_testsupport::open_repo_config()?)?;
+            let mut target = m2;
+            while !done.load(std::sync::atomic::Ordering::Relaxed) {
+                create_branches(&repo, target, ["refs/remotes/origin/main"])?;
+                target = if target == m1 { m2 } else { m1 };
+            }
+            Ok(())
+        }
+    });
+    let traversals = (0..100).try_for_each(|_| {
+        Graph::from_head(
+            &repo,
+            &*meta,
+            project_meta.clone(),
+            &mut db,
+            standard_options(),
+        )?
+        .validated()
+        .map(drop)
+    });
+    done.store(true, std::sync::atomic::Ordering::Relaxed);
+    mover.join().expect("no panic")?;
+    traversals
 }
 
 #[test]
@@ -2470,7 +2575,7 @@ pub use utils::{
     read_only_in_memory_scenario, standard_options,
 };
 
-use crate::init::utils::{default_project_meta, in_memory_meta};
+use crate::init::utils::{add_workspace_with_target, default_project_meta, in_memory_meta};
 
 fn ref_name(name: &str) -> gix::refs::FullName {
     name.try_into().expect("valid full ref name")


### PR DESCRIPTION
Fixes GB-2039

## The problem

Graph-backed queries (`head_info`, branch listing, worktree changes) could fail with

```
explicit traversal tip ref refs/remotes/origin/main points to <new-id>, not <old-id>
```

or, less often, with the sibling `BUG:: refs/heads/gitbutler/workspace points to ..., but the caller claimed it points to ...`.

`Graph::from_head` resolves the workspace ref and the target ref into traversal tips itself, in `initial_tips_from_workspace_metadata`. It then handed those tips to `validate_explicit_tips`, which re-read the same refs from the repository and refused the whole traversal if they had moved in between. Nothing external ever supplied those ids, so the check could only ever fail on a ref that a concurrent `git fetch` or workspace update moved during the microseconds between the two reads. When it did, the query failed instead of returning the state it had already captured.

The same re-read hit the entrypoint override in `from_commit_traversal` and the extra tips in `from_commit_traversal_with_extra_tips`, where every caller had just peeled the ref itself.

## Reproduction

Two of the three paths are deterministic and now covered by tests in `crates/but-graph/tests/graph/init/mod.rs`:

- `stale_workspace_entrypoint_id_is_used_as_captured`: peel the workspace ref, then call `from_commit_traversal` with that id and the ref name after the ref points elsewhere. Previously failed with the `BUG::` variant.
- `stale_extra_tip_id_is_used_as_captured`: same through `from_commit_traversal_with_extra_tips`, the SDK branch-listing path. Previously failed with the "tip ref" variant.

The metadata path has no seam between the two reads, so `from_head_tolerates_refs_moving_during_traversal` runs `from_head` in a loop while another thread moves `refs/remotes/origin/main` back and forth. Before this change roughly a quarter of the calls failed with the message above; it takes well under a second and validates every graph it builds.

## The fix

- The shared traversal path keeps the structural checks only: exactly one entrypoint, no duplicate traversal seeds or ref names.
- Ref-to-id validation runs only in `from_commit_traversal_tips`, the one constructor that receives tips the graph did not resolve itself.
- The entrypoint-override re-read only runs when no tip carries that name. A tip carrying it fixes the name to the captured commit; otherwise the name is discovered from the live ref map during traversal, so it still has to match. Excluding the override from that map instead was tried and breaks entrypoint naming across the suite.
- The workspace tip that matches the entrypoint uses the caller's id instead of a second read, which removes the `BUG::` ensure.

A ref that moves during traversal now yields a graph built from the ids captured at the start, and the next refresh catches up. Successful traversals are unchanged, and each one does a few fewer ref lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
