### PR TITLE
Use ToggleGroup for the notification bell switcher

### DIFF
--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -5,6 +5,32 @@ an on-brand choice without opening Figma. Rules here are about how the UI
 should look and read. The tooling that enforces them — scripts, generated
 files, commands — lives in `apps/lite/AGENTS.md`.
 
+## Components
+
+**Build from the library.** Every control users touch — a button, a switch, a
+segmented toggle, a popup — already has a component in `ui/src/components/`,
+with a spec in the ⚛️ Lite Core Figma library or a Storybook story. Reach for
+those first, even when hand-styling a primitive in the feature's own CSS module
+would be quicker. The point of a library is that the app reads as one thing;
+each control styled locally is one that will drift, and one more that has to
+be found and reconciled when the design moves.
+
+**If the library lacks it, think twice, then ask.** A missing component is a
+design question before it is an engineering one. Check whether an existing one
+fits with a variant or a prop — a small size, an icon-only mode — and if
+nothing does, ask the designer before building. The answer may be a new
+library component with a spec, or it may be that the surface should use
+something we already have.
+
+**A custom control needs a reason.** Sometimes a one-off is right. When it is,
+the code should say why: what the library could not do, and why that mattered
+here. A custom control with no motivation in the commit or a comment is a bug
+waiting for a redesign, not a decision.
+
+**New components are documented.** Anything that graduates into
+`ui/src/components/` gets a story and, once the designer has drawn it, a
+Figma spec. A component that lives only in code is half a component.
+
 ## Emphasis
 
 **Gray highlights, pop points.** Gray is the workhorse: when a control needs to

--- a/apps/lite/e2e/tests/sidebar.spec.ts
+++ b/apps/lite/e2e/tests/sidebar.spec.ts
@@ -118,35 +118,24 @@ test("keeps unread PR activity off the Workspace tab", async ({ appWindow, elect
 	});
 	await appWindow.reload();
 	await appWindow.getByRole("button", { name: "Notifications, 2 unread" }).click();
-	const humanTab = appWindow.getByRole("tab", { name: "Humans (1)", exact: true });
-	const agentTab = appWindow.getByRole("tab", { name: "Agents (1)", exact: true });
-	const humanPanel = appWindow.getByRole("tabpanel", { name: "Humans (1)", exact: true });
-	const agentPanel = appWindow.getByRole("tabpanel", { name: "Agents (1)", exact: true });
-	await expect(humanTab).toHaveAttribute("aria-selected", "true");
-	await expect(humanPanel).toContainText("Please take a look");
-	await expect(humanPanel).not.toContainText("Bot review");
-	// Keep the outgoing panel mounted long enough to inspect a tab transition.
-	const transitionStyle = await appWindow.addStyleTag({
-		content: `
-		@keyframes hold-panel { from { opacity: 1; } to { opacity: 0.99; } }
-		[role="tabpanel"][data-ending-style] { animation: hold-panel 60s linear; }
-	`,
-	});
-	await humanTab.focus();
+	const switcher = appWindow.getByRole("group", { name: "Notification type" });
+	const humanToggle = switcher.getByRole("button", { name: "Humans (1)", exact: true });
+	const agentToggle = switcher.getByRole("button", { name: "Agents (1)", exact: true });
+	const panel = appWindow.getByRole("dialog").filter({ has: switcher });
+	await expect(humanToggle).toHaveAttribute("aria-pressed", "true");
+	await expect(panel).toContainText("Please take a look");
+	await expect(panel).not.toContainText("Bot review");
+	await humanToggle.focus();
 	await appWindow.keyboard.press("ArrowRight");
-	await expect(agentTab).toBeFocused();
-	await agentTab.click();
-	await expect(agentPanel).toContainText("Bot review");
-	await expect(agentPanel).not.toContainText("Please take a look");
-	await expect(humanPanel).toContainText("Please take a look");
-	await expect(humanPanel).not.toContainText("Bot review");
-	await transitionStyle.evaluate((element) => {
-		element.parentNode?.removeChild(element);
-	});
+	await expect(agentToggle).toBeFocused();
+	await agentToggle.click();
+	await expect(agentToggle).toHaveAttribute("aria-pressed", "true");
+	await expect(panel).toContainText("Bot review");
+	await expect(panel).not.toContainText("Please take a look");
 	await appWindow.getByRole("button", { name: "Mark all read", exact: true }).click();
-	await expect(appWindow.getByRole("tab", { name: "Agents", exact: true })).toBeVisible();
-	await expect(humanTab).toBeVisible();
+	await expect(switcher.getByRole("button", { name: "Agents", exact: true })).toBeVisible();
+	await expect(humanToggle).toBeVisible();
 	await expect(appWindow.getByRole("button", { name: "Notifications, 1 unread" })).toBeVisible();
-	await humanTab.click();
-	await expect(humanPanel).toContainText("Please take a look");
+	await humanToggle.click();
+	await expect(panel).toContainText("Please take a look");
 });

--- a/apps/lite/ui/src/components/ToggleGroup.stories.tsx
+++ b/apps/lite/ui/src/components/ToggleGroup.stories.tsx
@@ -26,6 +26,23 @@ export const Default = meta.story({
 	),
 });
 
+export const Small = meta.story({
+	render: () => (
+		<ToggleGroup
+			render={<ToggleGroupStyles />}
+			defaultValue={["humans"]}
+			aria-label="Notification type"
+		>
+			<Toggle render={<ToggleStyles size="small" />} value="humans">
+				Humans
+			</Toggle>
+			<Toggle render={<ToggleStyles size="small" />} value="agents">
+				Agents
+			</Toggle>
+		</ToggleGroup>
+	),
+});
+
 export const WithIcons = meta.story({
 	render: () => (
 		<ToggleGroup render={<ToggleGroupStyles />} defaultValue={["list"]} aria-label="View mode">

--- a/apps/lite/ui/src/components/ToggleGroup.tsx
+++ b/apps/lite/ui/src/components/ToggleGroup.tsx
@@ -1,5 +1,5 @@
 import { classes } from "#ui/components/classes.ts";
-import { getButtonClassName } from "./Button.tsx";
+import { getButtonClassName, type ButtonSize } from "./Button.tsx";
 import styles from "./ToggleGroup.module.css";
 import type { ComponentProps, FC } from "react";
 
@@ -9,13 +9,12 @@ export const ToggleGroupStyles: FC<ComponentProps<"div">> = (props) => (
 );
 
 /** @public */
-export const ToggleStyles: FC<ComponentProps<"button"> & { iconOnly?: boolean }> = ({
-	iconOnly,
-	...props
-}) => (
+export const ToggleStyles: FC<
+	ComponentProps<"button"> & { iconOnly?: boolean; size?: ButtonSize }
+> = ({ iconOnly, size, ...props }) => (
 	<button
 		{...props}
 		type="button"
-		className={classes(props.className, getButtonClassName({ iconOnly }), styles.item)}
+		className={classes(props.className, getButtonClassName({ iconOnly, size }), styles.item)}
 	/>
 );

--- a/apps/lite/ui/src/review-inbox-bell.module.css
+++ b/apps/lite/ui/src/review-inbox-bell.module.css
@@ -27,9 +27,6 @@
 }
 
 .panelHeader {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
 	padding: 10px 12px;
 	border-bottom: 1px solid var(--border-3);
 }
@@ -49,39 +46,13 @@
 	text-align: center;
 }
 
-.tabs {
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-
-.tabList {
+.switcher {
 	display: flex;
 	flex-shrink: 0;
-	padding: 0 12px;
-	gap: 16px;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 12px;
 	border-bottom: 1px solid var(--border-3);
-}
-
-.tab {
-	padding: 10px 0;
-	border: none;
-	border-bottom: 2px solid transparent;
-	background: none;
-	color: var(--text-3);
-
-	&[data-active] {
-		border-bottom-color: var(--text-1);
-		color: var(--text-1);
-	}
-
-	&:hover {
-		color: var(--text-1);
-	}
-
-	&:focus-visible {
-		outline: var(--focus-ring);
-	}
 }
 
 .list {

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -8,8 +8,9 @@
  */
 
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
-import { Tabs } from "@base-ui/react/tabs";
 import { Icon } from "#ui/components/Icon.tsx";
+import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
+import { Toggle, ToggleGroup } from "@base-ui/react";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import { classes } from "#ui/components/classes.ts";
@@ -30,7 +31,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import styles from "./review-inbox-bell.module.css";
 
-const notificationTypes = ["humans", "agents"] as const;
+type NotificationType = "humans" | "agents";
 
 const kindIcon: Record<InboxKind, IconName> = {
 	comment: "text-block",
@@ -108,7 +109,7 @@ const Entry: FC<{
  */
 export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 	const [open, setOpen] = useState(false);
-	const [tab, setTab] = useState<"humans" | "agents">("humans");
+	const [tab, setTab] = useState<NotificationType>("humans");
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	// Unconditional: behind `&&` the hook count would change mid-mount.
 	const level = usePrNotificationsLevel();
@@ -148,6 +149,23 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 		>
 			<div className={styles.panelHeader}>
 				<span className={classes("text-12", "text-semibold")}>Notifications</span>
+			</div>
+			<div className={styles.switcher}>
+				<ToggleGroup
+					render={<ToggleGroupStyles />}
+					aria-label="Notification type"
+					value={[tab]}
+					onValueChange={([next]) => {
+						if (next !== undefined) setTab(next);
+					}}
+				>
+					<Toggle render={<ToggleStyles />} value={"humans" satisfies NotificationType}>
+						Humans{humanUnseen > 0 && ` (${humanUnseen})`}
+					</Toggle>
+					<Toggle render={<ToggleStyles />} value={"agents" satisfies NotificationType}>
+						Agents{agentUnseen > 0 && ` (${agentUnseen})`}
+					</Toggle>
+				</ToggleGroup>
 				{tabUnseen > 0 && (
 					<button
 						className={classes("text-12", styles.markAll)}
@@ -163,38 +181,23 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 					</button>
 				)}
 			</div>
-			<Tabs.Root value={tab} onValueChange={setTab} className={styles.tabs}>
-				<Tabs.List aria-label="Notification type" className={styles.tabList}>
-					<Tabs.Tab value="humans" className={classes("text-12", styles.tab)}>
-						Humans{humanUnseen > 0 && ` (${humanUnseen})`}
-					</Tabs.Tab>
-					<Tabs.Tab value="agents" className={classes("text-12", styles.tab)}>
-						Agents{agentUnseen > 0 && ` (${agentUnseen})`}
-					</Tabs.Tab>
-				</Tabs.List>
-				{notificationTypes.map((type) => {
-					const panelEntries = type === "humans" ? humanEntries : agentEntries;
-					return (
-						<Tabs.Panel key={type} value={type} className={styles.list}>
-							{panelEntries.length === 0 ? (
-								<div className={classes("text-12", styles.empty)}>
-									{type === "agents" ? "No agent notifications yet" : "No human notifications yet"}
-								</div>
-							) : (
-								panelEntries.map((entry) => (
-									<Entry
-										key={entry.id}
-										projectId={projectId}
-										entry={entry}
-										appliedRefs={appliedRefs}
-										onNavigate={() => setOpen(false)}
-									/>
-								))
-							)}
-						</Tabs.Panel>
-					);
-				})}
-			</Tabs.Root>
+			<div className={styles.list}>
+				{entries.length === 0 ? (
+					<div className={classes("text-12", styles.empty)}>
+						{tab === "agents" ? "No agent notifications yet" : "No human notifications yet"}
+					</div>
+				) : (
+					entries.map((entry) => (
+						<Entry
+							key={entry.id}
+							projectId={projectId}
+							entry={entry}
+							appliedRefs={appliedRefs}
+							onNavigate={() => setOpen(false)}
+						/>
+					))
+				)}
+			</div>
 		</Dropdown>
 	);
 };

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -159,10 +159,16 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 						if (next !== undefined) setTab(next);
 					}}
 				>
-					<Toggle render={<ToggleStyles />} value={"humans" satisfies NotificationType}>
+					<Toggle
+						render={<ToggleStyles size="small" />}
+						value={"humans" satisfies NotificationType}
+					>
 						Humans{humanUnseen > 0 && ` (${humanUnseen})`}
 					</Toggle>
-					<Toggle render={<ToggleStyles />} value={"agents" satisfies NotificationType}>
+					<Toggle
+						render={<ToggleStyles size="small" />}
+						value={"agents" satisfies NotificationType}
+					>
 						Agents{agentUnseen > 0 && ` (${agentUnseen})`}
 					</Toggle>
 				</ToggleGroup>


### PR DESCRIPTION
The Humans / Agents tabs in the bell popover were a custom, undesigned control. This swaps them for the library ToggleGroup so the popover only uses components documented in Lite Core and Storybook.

## Why

The underline tabs were hand-styled in the bell's own CSS and match nothing in Lite Core, so what shipped was not the approved design. One-off controls like this drift from the rest of the UI and have to be hunted down later during a redesign.

The rule, now written into `DESIGN.md`:

- Build from the component library first. Every control has a component with a Figma spec or a Storybook story.
- If the library lacks it, think twice, then ask the designer. Often an existing component fits with a variant or a prop.
- A custom control needs a stated reason in the commit or a comment: what the library could not do, and why it mattered.
- Every new component gets a story and a Figma spec.

We may well bring a Tabs component back, but it should be a properly thought-through addition: where it is used, for what, and how it differs from ToggleGroup, with a spec in Figma and a story. Until then the bell uses the segmented switcher we already have.

## Changes

- Replace the hand-styled Base UI Tabs with `ToggleGroup` / `Toggle`
- Put the switcher on its own row with "Mark all read" beside it
- Render one list for the active type instead of two tab panels
- Add a `size` prop to `ToggleStyles` (the Button scale), with a Storybook story
- Use the small size for the bell switcher
- Update the sidebar e2e test for the new roles
- Add a Components section to `DESIGN.md`: build from the library, ask the designer when it lacks something, motivate any custom control, document every new component

Toggle.Item in ⚛️ Lite Core now has a matching Size property (Regular / Small), mirroring Button Small, plus a Small ToggleGroup example: https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/?node-id=509-849

## Screenshots

Before:

<img width="481" height="233" alt="ADCFBC09-57A9-4E11-8C35-BCF40E653AE5" src="https://github.com/user-attachments/assets/94aac061-5a32-490b-9d5b-e2c16af4820c" />


After:

<img width="441" height="233" alt="FDB6D369-E711-4E6A-AA0A-925403B73737" src="https://github.com/user-attachments/assets/449d05a8-54db-4401-a654-f84b49257af2" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
