### PR TITLE
PostHog error tracking

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -73,6 +73,8 @@ jobs:
           CARGO_NET_OFFLINE: "true"
         run: pnpm --filter @gitbutler/but-sdk build:release
       - name: Build Lite
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
         run: pnpm --filter @gitbutler/lite build
       - name: Prepare askpass
         env:

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -1,3 +1,4 @@
+import { posthogHost, reportTelemetryInDev } from "./telemetry.js";
 import { checkForUpdates, registerUpdater, setAutoUpdateEnabled } from "./updater.js";
 import WatcherManager from "./watcher.js";
 import * as sdk from "@gitbutler/but-sdk";
@@ -46,7 +47,13 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { initLogging } from "./logging.js";
 import { type GUISettings, readSettings, writeSettings } from "./settings.js";
-import { initMetrics, metricsOnLogin, shutdownMetrics, withApiCommandCapture } from "./metrics.js";
+import {
+	initMetrics,
+	metricsOnLogin,
+	reportError,
+	shutdownMetrics,
+	withApiCommandCapture,
+} from "./metrics.js";
 import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
 
 const isHeadless = process.env.GITBUTLER_LITE_HEADLESS === "true";
@@ -175,8 +182,7 @@ const configureAskpass = (): void => {
 	try {
 		askpassInit((err, event) => {
 			if (err) {
-				// oxlint-disable-next-line no-console
-				console.error(`Error encountered while initializing askpass:\n${err}`);
+				reportError(err, "Failed to initialize askpass");
 				return;
 			}
 
@@ -187,8 +193,7 @@ const configureAskpass = (): void => {
 				window.webContents.send("askpassPrompt", event);
 		});
 	} catch (err) {
-		// oxlint-disable-next-line no-console
-		console.error(`Error encountered while configuring askpass:\n${String(err)}`);
+		reportError(err, "Failed to configure askpass");
 	}
 };
 
@@ -475,8 +480,7 @@ const completeLogin = async (url: URL): Promise<boolean> => {
 		const profile = await sdk.loginAndPersist(accessToken);
 		void metricsOnLogin(profile);
 	} catch (error) {
-		// oxlint-disable-next-line no-console
-		console.error("Failed to sign in from a login link", error);
+		reportError(error, "Failed to sign in from a login link");
 	}
 	return true;
 };
@@ -618,15 +622,14 @@ export const start = async (shellEnvironment: Promise<Record<string, string>>): 
 	void session.defaultSession;
 	initLogging();
 	Object.assign(process.env, await shellEnvironment);
-	applyGUISettings(await readSettings());
 	await initApplicationNamespace(null);
+	if (app.isPackaged || reportTelemetryInDev)
+		await initMetrics(app.getVersion(), app.isPackaged ? "production" : "development");
+
+	applyGUISettings(await readSettings());
 	configureAskpass();
 
 	if (app.isPackaged) {
-		// Packaged-only so dev builds send nothing, and awaited so the client
-		// exists before the IPC handlers and the launch-link login below run.
-		await initMetrics(app.getVersion());
-
 		registerLiteProtocolHandler();
 
 		// Basic non-Strict CSP based on https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#basic-non-strict-csp-policy
@@ -635,7 +638,7 @@ export const start = async (shellEnvironment: Promise<Record<string, string>>): 
 			"script-src 'self' 'wasm-unsafe-eval';" +
 			"style-src 'self' 'unsafe-inline';" +
 			"font-src 'self';" +
-			"connect-src 'self';" +
+			`connect-src 'self' ${posthogHost};` +
 			"object-src 'none';" +
 			"base-uri 'none';" +
 			"frame-ancestors 'none';" +
@@ -671,7 +674,7 @@ export const start = async (shellEnvironment: Promise<Record<string, string>>): 
 			"style-src 'self' 'unsafe-inline';" +
 			"font-src 'self';" +
 			// ws source for HMR
-			"connect-src 'self' ws://127.0.0.1:5173;" +
+			`connect-src 'self' ws://127.0.0.1:5173 ${posthogHost};` +
 			"object-src 'none';" +
 			"base-uri 'none';" +
 			"frame-ancestors 'none';" +

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -614,6 +614,8 @@ if (!app.requestSingleInstanceLock()) {
 
 export const start = async (shellEnvironment: Promise<Record<string, string>>): Promise<void> => {
 	await app.whenReady();
+	// Creating the default session lets Electron prewarm the first renderer while startup continues.
+	void session.defaultSession;
 	initLogging();
 	Object.assign(process.env, await shellEnvironment);
 	applyGUISettings(await readSettings());

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -1,16 +1,17 @@
 import { getAppSettings, getUserProfileLocal, updateTelemetryDistinctId } from "@gitbutler/but-sdk";
 import type { UserProfile } from "@gitbutler/but-sdk";
 import { PostHog } from "posthog-node";
+import { getPosthogProjectToken, posthogHost } from "./telemetry.js";
 import { randomUUID } from "node:crypto";
 import { apiCommandFailureLimitConfig, createApiCommandSampler } from "./api-command-sampling.js";
 
 /**
- * Product metrics for the main process. Events go to the same PostHog
+ * Product metrics and uncaught exceptions for the main process. Events go to the same PostHog
  * project as the desktop app, the web app, and the CLI; the `appName` and
  * `container` properties tell the surfaces apart. Conventions shared with
- * those senders: snake_case event names, camelCase properties, and only
- * counts, enums, and booleans as values — never message text, paths, or
- * anything else a user typed.
+ * those senders: snake_case event names and camelCase properties. Product
+ * metrics contain only counts, enums, and booleans — never message text,
+ * paths, or anything else a user typed. Exceptions include error details.
  *
  * The distinct id is the one every surface shares through the settings file
  * (`telemetry.appDistinctId`): `user_<id>` once any surface has seen a login,
@@ -24,9 +25,6 @@ import { apiCommandFailureLimitConfig, createApiCommandSampler } from "./api-com
  * still describes only the retained call.
  */
 
-// The same publishable project key the desktop app and the web app use.
-const POSTHOG_API_KEY = "phc_yJx46mXv6kA5KTuM2eEQ6IwNTgl5YW3feKV5gi7mfGG";
-const POSTHOG_HOST = "https://eu.i.posthog.com";
 const APP_NAME = "gitbutler-lite";
 const CONTAINER = "electron";
 const SHUTDOWN_TIMEOUT_MS = 2000;
@@ -38,6 +36,8 @@ const FAILURE_LIMIT_CONFIG_TIMEOUT_MS = 1_000;
 let client: PostHog | null = null;
 let distinctId = "";
 let appVersion = "";
+let metricsEnabled = false;
+let errorsEnabled = false;
 let failureLimit = apiCommandFailureLimitConfig(undefined);
 let apiCommandSampler = createApiCommandSampler({ failureLimit });
 let shutdownPromise: Promise<void> | null = null;
@@ -81,24 +81,46 @@ const configureFailureLimit = async (metricsClient: PostHog): Promise<void> => {
 };
 
 /**
- * Reads the shared app settings and starts the client. A no-op when metrics
- * are disabled. Never throws: the app must start even when metrics cannot.
+ * Reads the shared app settings and starts the client when metrics or error
+ * reporting is enabled. Never throws: telemetry must not prevent startup.
  *
  * Await this before registering IPC handlers, so the first commands of the
  * session are captured and a launch via a login link cannot race the
  * identity below.
  */
-export const initMetrics = async (version: string): Promise<void> => {
+export const initMetrics = async (
+	version: string,
+	environment: "development" | "production",
+): Promise<void> => {
 	try {
 		const telemetry = (await getAppSettings()).telemetry;
-		if (!telemetry.appMetricsEnabled) return;
+		metricsEnabled = telemetry.appMetricsEnabled;
+		errorsEnabled = telemetry.appErrorReportingEnabled;
+		if (!metricsEnabled && !telemetry.appErrorReportingEnabled) return;
 
 		appVersion = version;
 		// The client exists from here on even if resolving the identity below
 		// fails; a session then captures under the stored or fresh id.
 		setDistinctId(telemetry.appDistinctId ?? randomUUID());
-		client = new PostHog(POSTHOG_API_KEY, {
-			host: POSTHOG_HOST,
+		client = new PostHog(getPosthogProjectToken(environment), {
+			host: posthogHost,
+			enableExceptionAutocapture: telemetry.appErrorReportingEnabled,
+			before_send: (event) => {
+				if (event?.event !== "$exception") return event;
+				return {
+					...event,
+					distinctId,
+					properties: {
+						...event.properties,
+						appName: APP_NAME,
+						appVersion,
+						container: CONTAINER,
+						process: "main",
+						environment,
+						$process_person_profile: distinctId.startsWith("user_"),
+					},
+				};
+			},
 			featureFlagsRequestTimeoutMs: FAILURE_LIMIT_CONFIG_TIMEOUT_MS,
 		});
 
@@ -107,11 +129,20 @@ export const initMetrics = async (version: string): Promise<void> => {
 		else if (distinctId !== telemetry.appDistinctId) await updateTelemetryDistinctId(distinctId);
 		// Not awaited: the window must not wait for PostHog. The built-in
 		// default applies until the remote limit lands.
-		void configureFailureLimit(client);
+		if (metricsEnabled) void configureFailureLimit(client);
 	} catch (error) {
 		// oxlint-disable-next-line no-console
 		console.error("Failed to initialize metrics", error);
 	}
+};
+
+export const reportError = (error: unknown, context: string): void => {
+	if (error instanceof Error && error.name === "AbortError") return;
+
+	// oxlint-disable-next-line no-console
+	console.error(context, error);
+	if (errorsEnabled && shutdownPromise === null)
+		client?.captureException(error, distinctId, { context });
 };
 
 const capture = (event: string, properties: Record<string, unknown>): void => {
@@ -139,7 +170,8 @@ export const withApiCommandCapture =
 	(command: string, handler: (params: unknown) => unknown) =>
 	async (params: unknown): Promise<unknown> => {
 		const metricsClient = client;
-		if (metricsClient === null || shutdownPromise !== null) return handler(params);
+		if (!metricsEnabled || metricsClient === null || shutdownPromise !== null)
+			return handler(params);
 		const start = performance.now();
 		const record = (failure: boolean) => {
 			if (client !== metricsClient) return;

--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -7,6 +7,7 @@
  */
 
 import { app } from "electron";
+import { reportError } from "./metrics.js";
 import { type Type, type } from "arktype";
 import { readFile, writeFile } from "atomically";
 import path from "node:path";
@@ -79,8 +80,13 @@ export const readSettings = async (): Promise<GUISettings> => {
 
 		return cfg;
 	} catch (e) {
-		// oxlint-disable-next-line no-console
-		console.warn(e);
+		if (e instanceof Error && "code" in e && e.code === "ENOENT") {
+			// A fresh install has no GUI settings file yet.
+			// oxlint-disable-next-line no-console
+			console.warn(e);
+		} else {
+			reportError(e, "Failed to read GUI settings");
+		}
 
 		return emptySettings;
 	}

--- a/apps/lite/electron/src/telemetry.ts
+++ b/apps/lite/electron/src/telemetry.ts
@@ -1,0 +1,10 @@
+export const posthogHost = "https://eu.i.posthog.com";
+
+export const getPosthogProjectToken = (environment: "development" | "production"): string =>
+	environment === "development"
+		? "phc_t7VDC9pQELnYep9IiDTxrq2HLseY5wyT7pn0EpHM7rr"
+		: "phc_yJx46mXv6kA5KTuM2eEQ6IwNTgl5YW3feKV5gi7mfGG";
+
+/** Flip this to send metrics and errors to the dev project, for example during QA. */
+// oxlint-disable-next-line typescript/no-inferrable-types
+export const reportTelemetryInDev: boolean = false;

--- a/apps/lite/electron/src/updater.ts
+++ b/apps/lite/electron/src/updater.ts
@@ -1,7 +1,7 @@
 import { app, type BrowserWindow, dialog } from "electron";
 import electronUpdater, { type AppUpdater, type UpdateDownloadedEvent } from "electron-updater";
 import { env } from "node:process";
-import { shutdownMetrics } from "./metrics.js";
+import { reportError, shutdownMetrics } from "./metrics.js";
 
 let updaterWindow: BrowserWindow | null = null;
 let updaterRegistered = false;
@@ -51,13 +51,11 @@ export const registerUpdater = (mainWindow: BrowserWindow): void => {
 	autoUpdater.autoInstallOnAppQuit = true;
 	autoUpdater.on("update-downloaded", (event) => {
 		void showUpdateDownloadedDialog(event).catch((error) => {
-			// oxlint-disable-next-line no-console
-			console.error("Failed to show update dialog", error);
+			reportError(error, "Failed to show update dialog");
 		});
 	});
 	autoUpdater.on("error", (error) => {
-		// oxlint-disable-next-line no-console
-		console.error("Update error", error);
+		reportError(error, "Update error");
 	});
 };
 
@@ -85,7 +83,6 @@ export const checkForUpdates = (): void => {
 		return;
 
 	void updater.checkForUpdates().catch((error) => {
-		// oxlint-disable-next-line no-console
-		console.error("Failed to check for updates", error);
+		reportError(error, "Failed to check for updates");
 	});
 };

--- a/apps/lite/electron/src/watcher.ts
+++ b/apps/lite/electron/src/watcher.ts
@@ -1,3 +1,4 @@
+import { reportError } from "./metrics.js";
 import { type WatcherEvent, type WatcherHandle, watcherStart } from "@gitbutler/but-sdk";
 import { randomUUID } from "node:crypto";
 
@@ -134,8 +135,7 @@ export default class WatcherManager {
 				try {
 					projectWatcher.handle.stop();
 				} catch (error) {
-					// oxlint-disable-next-line no-console
-					console.warn("Failed to stop project watcher", error);
+					reportError(error, "Failed to stop project watcher");
 				}
 				this.projectWatchers.delete(subscription.projectId);
 			}
@@ -208,8 +208,7 @@ export default class WatcherManager {
 		// Create a watcher.
 		const creation = watcherStart(projectId, (err, event) => {
 			if (err) {
-				// oxlint-disable-next-line no-console
-				console.warn("Watcher callback failed", err);
+				reportError(err, "Watcher callback failed");
 				return;
 			}
 			this.forwardWatcherEvent(projectId, event);
@@ -237,12 +236,11 @@ export default class WatcherManager {
 	stopAllWatchersForShutdown(): number {
 		const stopped = this.watcherSubscriptions.size;
 
-		for (const [projectId, projectWatcher] of this.projectWatchers) {
+		for (const projectWatcher of this.projectWatchers.values()) {
 			try {
 				projectWatcher.handle.stop();
 			} catch (error) {
-				// oxlint-disable-next-line no-console
-				console.warn(`Failed to stop project watcher for ${projectId}`, error);
+				reportError(error, "Failed to stop project watcher during shutdown");
 			}
 		}
 
@@ -292,8 +290,7 @@ export default class WatcherManager {
 			this.stopAllWatchersForShutdown();
 			WatcherManager.instance = null;
 		} catch (error) {
-			// oxlint-disable-next-line no-console
-			console.warn("Failed to stop project watchers during shutdown", error);
+			reportError(error, "Failed to stop project watchers during shutdown");
 		}
 	}
 }

--- a/apps/lite/electron/vite.main.config.ts
+++ b/apps/lite/electron/vite.main.config.ts
@@ -1,3 +1,6 @@
+/* oxlint-disable typescript/strict-boolean-expressions */
+
+import posthogRollupPlugin from "@posthog/rollup-plugin";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
@@ -11,6 +14,30 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * (see "files" in package.json).
  */
 export default defineConfig({
+	plugins: [
+		{
+			name: "prod-env-warning",
+			apply: "build",
+			buildStart() {
+				if (!process.env.POSTHOG_PERSONAL_API_KEY)
+					this.warn("Missing $POSTHOG_PERSONAL_API_KEY, disabling PostHog source-map uploads.");
+
+				if (!process.env.VERSION)
+					this.warn('Missing $VERSION, defaulting PostHog release version to "dev".');
+			},
+		},
+		!!process.env.POSTHOG_PERSONAL_API_KEY &&
+			posthogRollupPlugin({
+				personalApiKey: process.env.POSTHOG_PERSONAL_API_KEY,
+				projectId: "2812",
+				host: "https://eu.posthog.com",
+				sourcemaps: {
+					releaseName: "gitbutler-lite",
+					releaseVersion: process.env.VERSION || "dev",
+					deleteAfterUpload: true,
+				},
+			}),
+	],
 	build: {
 		outDir: path.join(here, "../dist/electron"),
 		// The preload build (vite.config.ts) runs first and empties the dir.

--- a/apps/lite/harness/tests/metrics.test.ts
+++ b/apps/lite/harness/tests/metrics.test.ts
@@ -45,7 +45,7 @@ const initMetrics = async (failureLimit?: {
 }) => {
 	mocks.client.getFeatureFlagPayload.mockResolvedValue(failureLimit);
 	const metrics = await import("../../electron/src/metrics.ts");
-	await metrics.initMetrics("1.2.3");
+	await metrics.initMetrics("1.2.3", "development");
 	// The failure limit lands a few microtasks after init returns; a tick drains
 	// them, and unlike a timer it still fires under fake timers.
 	await new Promise((resolve) => process.nextTick(resolve));

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -157,6 +157,7 @@
 		"idb-keyval": "^6.3.0",
 		"ms": "^4.0.0-nightly.202508271359",
 		"p-map": "^7.0.7",
+		"posthog-js": "1.417.1",
 		"posthog-node": "5.21.0",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
@@ -171,6 +172,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "catalog:",
+		"@posthog/rollup-plugin": "^1.6.0",
 		"@storybook/addon-designs": "^11.1.3",
 		"@storybook/addon-docs": "^10.3.3",
 		"@storybook/react-vite": "^10.3.6",

--- a/apps/lite/ui/src/annotation.ts
+++ b/apps/lite/ui/src/annotation.ts
@@ -88,9 +88,6 @@ export const useCommentCreate = () => {
 		onError: (error, input, prev, ctx) => {
 			if (prev) ctx.client.setQueryData(commentsQueryOptions(input.projectId).queryKey, prev);
 
-			// oxlint-disable-next-line no-console
-			console.error(error);
-
 			toastManager.add({
 				type: "error",
 				title: "Failed to create comment",
@@ -109,9 +106,6 @@ export const useCommentUpdate = () => {
 		onSettled: (_comment, _err, input, _result, ctx) =>
 			ctx.client.invalidateQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey }),
 		onError: (error) => {
-			// oxlint-disable-next-line no-console
-			console.error(error);
-
 			toastManager.add({
 				type: "error",
 				title: "Failed to update comment",
@@ -142,9 +136,6 @@ export const useCommentArchive = () => {
 			ctx.client.invalidateQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey }),
 		onError: (error, input, prev, ctx) => {
 			if (prev) ctx.client.setQueryData(commentsQueryOptions(input.projectId).queryKey, prev);
-
-			// oxlint-disable-next-line no-console
-			console.error(error);
 
 			toastManager.add({
 				type: "error",

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,3 +1,4 @@
+import { reportError } from "#ui/error-reporting.ts";
 import { forgeAuthTags } from "#ui/forge.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { remapSearchBranch, remapSearchCommits, setCursor } from "#ui/use-cursor.ts";
@@ -178,8 +179,7 @@ export const useApply = () => {
 								syncCoreCaches(mutation.client, dispatch, input.projectId, checkoutResponse);
 								toastManager.close(toastId);
 							})().catch((error) => {
-								// oxlint-disable-next-line no-console
-								console.error(error);
+								reportError(error);
 
 								toastManager.add({
 									type: "error",
@@ -1199,8 +1199,7 @@ export const useDiscardFileChanges = ({
 			// uncheck it — and discarding the subject instead is not what was asked for.
 			if (changes) runDiscard(changes);
 		} catch (error) {
-			// oxlint-disable-next-line no-console
-			console.error(error);
+			reportError(error);
 
 			toastManager.add({
 				type: "error",

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -716,3 +716,8 @@ export const appSettingsQueryOptions = queryOptions({
 	queryKey: ["appSettings"],
 	queryFn: () => window.lite.getAppSettings(),
 });
+
+export const versionQueryOptions = queryOptions({
+	queryKey: ["version"],
+	queryFn: () => window.lite.getVersion(),
+});

--- a/apps/lite/ui/src/api/query-keys.ts
+++ b/apps/lite/ui/src/api/query-keys.ts
@@ -20,7 +20,8 @@ export type GlobalQueryKey =
 	| "userProfile"
 	| "projects"
 	| "guiSettings"
-	| "markdownTokens";
+	| "markdownTokens"
+	| "version";
 
 /**
  * Client state kept in the query cache, so nothing declares for them. `dryRun`

--- a/apps/lite/ui/src/components/ErrorBoundary.tsx
+++ b/apps/lite/ui/src/components/ErrorBoundary.tsx
@@ -55,13 +55,6 @@ export class ErrorBoundary extends Component<Props, State> {
 		return { error: null, resetKeys };
 	}
 
-	componentDidCatch(error: unknown): void {
-		// The fallback shows only the message, and swallowing the rest once cost
-		// a session two wrong bisections.
-		// oxlint-disable-next-line no-console
-		console.error(error);
-	}
-
 	handleRetry(): void {
 		this.props.onReset?.();
 		this.setState({ error: null, resetKeys: this.props.resetKeys ?? [] });

--- a/apps/lite/ui/src/components/Markdown.tsx
+++ b/apps/lite/ui/src/components/Markdown.tsx
@@ -1,3 +1,4 @@
+import { reportError } from "#ui/error-reporting.ts";
 import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -22,8 +23,7 @@ const openExternally = (evt: MouseEvent<HTMLAnchorElement>): void => {
 	const url = evt.currentTarget.href;
 	if (isExternalUrl(url)) {
 		window.lite.openInWebBrowser(url).catch((error: unknown) => {
-			// oxlint-disable-next-line no-console
-			console.error(error);
+			reportError(error);
 		});
 	}
 };

--- a/apps/lite/ui/src/error-reporting.ts
+++ b/apps/lite/ui/src/error-reporting.ts
@@ -1,0 +1,90 @@
+import { type QueryClient, hashKey } from "@tanstack/react-query";
+import posthog from "posthog-js/dist/module.no-external";
+import "posthog-js/dist/exception-autocapture";
+import {
+	appSettingsQueryOptions,
+	userProfileQueryOptions,
+	versionQueryOptions,
+} from "#ui/api/queries.ts";
+import {
+	getPosthogProjectToken,
+	posthogHost,
+	reportTelemetryInDev,
+} from "../../electron/src/telemetry.ts";
+
+export const initErrorReporting = async (queryClient: QueryClient): Promise<void> => {
+	if (import.meta.env.DEV && !reportTelemetryInDev) return;
+
+	try {
+		const [settings, version, profile] = await Promise.all([
+			queryClient.fetchQuery(appSettingsQueryOptions),
+			queryClient.fetchQuery(versionQueryOptions),
+			queryClient.fetchQuery(userProfileQueryOptions),
+		]);
+
+		if (!settings.telemetry.appErrorReportingEnabled) return;
+
+		const environment = import.meta.env.DEV ? "development" : "production";
+		posthog.init(getPosthogProjectToken(environment), {
+			api_host: posthogHost,
+			persistence: "memory",
+			bootstrap: {
+				distinctID: profile
+					? `user_${profile.id}`
+					: (settings.telemetry.appDistinctId ?? crypto.randomUUID()),
+			},
+			person_profiles: "never",
+			autocapture: false,
+			capture_pageview: false,
+			capture_pageleave: false,
+			capture_performance: false,
+			disable_session_recording: true,
+			disable_surveys: true,
+			advanced_disable_flags: true,
+			disable_external_dependency_loading: true,
+			capture_exceptions: {
+				capture_unhandled_errors: true,
+				capture_unhandled_rejections: true,
+				capture_console_errors: false,
+			},
+			before_send: (event) => {
+				if (event?.event !== "$exception") return null;
+				const exceptions = event.properties.$exception_list as Array<{ type: string }> | undefined;
+				if (exceptions?.[0]?.type === "AbortError") return null;
+
+				return event;
+			},
+		});
+
+		const properties = {
+			appName: "gitbutler-lite",
+			appVersion: version,
+			container: "electron",
+			process: "renderer",
+			environment,
+		};
+		posthog.register(properties);
+
+		queryClient.getQueryCache().subscribe((event) => {
+			if (
+				event.type !== "updated" ||
+				event.query.queryHash !== hashKey(userProfileQueryOptions.queryKey)
+			)
+				return;
+
+			const user = queryClient.getQueryData(userProfileQueryOptions.queryKey);
+			if (user) posthog.register({ distinct_id: `user_${user.id}` });
+		});
+	} catch (error) {
+		// oxlint-disable-next-line no-console
+		console.error("Failed to initialize error reporting", error);
+	}
+};
+
+export const reportError = (error: unknown, properties?: Record<string, unknown>): void => {
+	if (error instanceof Error && error.name === "AbortError") return;
+
+	// oxlint-disable-next-line no-console
+	console.error(error);
+	posthog.captureException(error, properties);
+};

--- a/apps/lite/ui/src/external-link.ts
+++ b/apps/lite/ui/src/external-link.ts
@@ -1,3 +1,4 @@
+import { reportError } from "#ui/error-reporting.ts";
 import type { MouseEvent } from "react";
 
 /**
@@ -7,7 +8,6 @@ import type { MouseEvent } from "react";
 export const openLinkExternally = (evt: MouseEvent<HTMLAnchorElement>): void => {
 	evt.preventDefault();
 	window.lite.openInWebBrowser(evt.currentTarget.href).catch((error: unknown) => {
-		// oxlint-disable-next-line no-console
-		console.error(error);
+		reportError(error);
 	});
 };

--- a/apps/lite/ui/src/main.tsx
+++ b/apps/lite/ui/src/main.tsx
@@ -1,3 +1,4 @@
+import { initErrorReporting, reportError } from "#ui/error-reporting.ts";
 import { MutationCache, QueryCache, QueryClient, focusManager } from "@tanstack/react-query";
 import { App } from "#ui/App.tsx";
 import { invalidateDeclared } from "#ui/api/tags.ts";
@@ -25,8 +26,7 @@ const queryClient: QueryClient = new QueryClient({
 	// rather than raising a toast — but the reason has to land somewhere.
 	queryCache: new QueryCache({
 		onError: (error) => {
-			// oxlint-disable-next-line no-console
-			console.error(error);
+			reportError(error);
 		},
 	}),
 	// A mutation's cache effects come from its endpoint's `invalidates`
@@ -39,8 +39,7 @@ const queryClient: QueryClient = new QueryClient({
 		onSuccess: (_data, _variables, _context, mutation) =>
 			invalidateDeclared(queryClient, mutation.options.mutationKey),
 		onError: (error, _variables, _context, mutation) => {
-			// oxlint-disable-next-line no-console
-			console.error(error);
+			reportError(error);
 
 			const title = mutation.meta?.failureTitle;
 			if (title === undefined) return;
@@ -84,7 +83,9 @@ const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 
 const root = createRoot(rootElement, {
-	onUncaughtError: (error: unknown) => {
+	onCaughtError: (error, info) => reportError(error, { componentStack: info.componentStack }),
+	onUncaughtError: (error: unknown, info) => {
+		reportError(error, { componentStack: info.componentStack });
 		toastManager.add({
 			type: "error",
 			title: "Error",
@@ -93,4 +94,6 @@ const root = createRoot(rootElement, {
 		});
 	},
 });
-root.render(<App queryClient={queryClient} toastManager={toastManager} router={router} />);
+void initErrorReporting(queryClient).then(() => {
+	root.render(<App queryClient={queryClient} toastManager={toastManager} router={router} />);
+});

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -274,9 +274,6 @@ export const useExecuteOperation = (projectId: string) => {
 			}
 		},
 		onError: (error) => {
-			// oxlint-disable-next-line no-console
-			console.error(error);
-
 			toastManager.add({
 				type: "error",
 				title: "Failed to run operation",

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -1,3 +1,4 @@
+import { reportError } from "#ui/error-reporting.ts";
 import {
 	useAddReviewLabels,
 	useRemoveReviewLabel,
@@ -376,11 +377,6 @@ export const NewPullRequestPanel: FC<{
 	);
 };
 
-const reportOpenFailure = (error: unknown) => {
-	// oxlint-disable-next-line no-console
-	console.error(error);
-};
-
 /** A failing check, carrying the dot colour its conclusion earns. */
 type ProblemCheck = { check: CiCheck; tone: "danger" | "warn" | "muted" };
 
@@ -711,7 +707,7 @@ export const PullRequestPanel: FC<{
 
 	const handleOpen = (evt: MouseEvent<HTMLAnchorElement>): void => {
 		evt.preventDefault();
-		window.lite.openInWebBrowser(review.htmlUrl).catch(reportOpenFailure);
+		window.lite.openInWebBrowser(review.htmlUrl).catch(reportError);
 	};
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -265,9 +265,6 @@ export const CommitRow: FC<
 					dryRun: false,
 				});
 			} catch (error) {
-				// oxlint-disable-next-line no-console
-				console.error(error);
-
 				toastManager.add({
 					type: "error",
 					title: "Failed to reword commit",

--- a/apps/lite/ui/src/routes/project/$id/workspace/useFetchFromRemotes.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useFetchFromRemotes.ts
@@ -31,8 +31,6 @@ export const useFetchFromRemotes = (projectId: string) => {
 		void refetch().then(({ error }) => {
 			if (!error) return;
 
-			// oxlint-disable-next-line no-console
-			console.error(error);
 			toastManager.add({
 				type: "error",
 				title: "Failed to fetch",

--- a/apps/lite/ui/vite.config.ts
+++ b/apps/lite/ui/vite.config.ts
@@ -1,3 +1,6 @@
+/* oxlint-disable typescript/strict-boolean-expressions */
+
+import posthogRollupPlugin from "@posthog/rollup-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import path from "node:path";
@@ -9,6 +12,29 @@ const currentDirPath = path.dirname(currentFilePath);
 export default defineConfig(({ command }) => ({
 	root: currentDirPath,
 	plugins: [
+		{
+			name: "posthog-sourcemap-warning",
+			apply: "build",
+			buildStart() {
+				if (!process.env.POSTHOG_PERSONAL_API_KEY)
+					this.warn("Missing $POSTHOG_PERSONAL_API_KEY, PostHog sourcemap uploads disabled.");
+
+				if (!process.env.VERSION)
+					this.warn('Missing $VERSION, PostHog release version defaults to "dev".');
+			},
+		},
+		command === "build" &&
+			!!process.env.POSTHOG_PERSONAL_API_KEY &&
+			posthogRollupPlugin({
+				personalApiKey: process.env.POSTHOG_PERSONAL_API_KEY,
+				projectId: "2812",
+				host: "https://eu.posthog.com",
+				sourcemaps: {
+					releaseName: "gitbutler-lite",
+					releaseVersion: process.env.VERSION || "dev",
+					deleteAfterUpload: true,
+				},
+			}),
 		react({
 			babel: {
 				plugins: ["babel-plugin-react-compiler"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,6 +482,9 @@ importers:
       p-map:
         specifier: ^7.0.7
         version: 7.0.7
+      posthog-js:
+        specifier: 1.417.1
+        version: 1.417.1
       posthog-node:
         specifier: 5.21.0
         version: 5.21.0
@@ -519,6 +522,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.58.2
+      '@posthog/rollup-plugin':
+        specifier: ^1.6.0
+        version: 1.6.0(rollup@4.60.3)
       '@storybook/addon-designs':
         specifier: ^11.1.3
         version: 11.1.3(@storybook/addon-docs@10.3.3(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -3777,11 +3783,24 @@ packages:
   '@posthog/browser-common@0.5.0':
     resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
 
+  '@posthog/cli@0.16.2':
+    resolution: {integrity: sha512-h8bpf9ffBUH/Z9IoyGV+wiI+vS8rIPorKT3eKQXuzuwawO0G7Qvy+hDd7HQ9YJjHByYZ77yPPQvrSs4WsqTUCg==}
+    engines: {node: '>=14.14', npm: '>=6'}
+    hasBin: true
+
   '@posthog/core@1.48.1':
     resolution: {integrity: sha512-mxw31XdYgt/SnlwqLPAcltK67q+QmsiYjVLGQ4GbBc8OJ7O4yRFSDwAXt8QsokHokeyEZtTRWM6jDHL7LYMx1A==}
 
   '@posthog/core@1.9.1':
     resolution: {integrity: sha512-kRb1ch2dhQjsAapZmu6V66551IF2LnCbc1rnrQqnR7ArooVyJN9KOPXre16AJ3ObJz2eTfuP7x25BMyS2Y5Exw==}
+
+  '@posthog/plugin-utils@2.0.0':
+    resolution: {integrity: sha512-PC94+3zeEQ2IkhiU+pskOIOEkAFKZvwVixvrwpRfy+cl4b6gkTuHN44vp5OeG5ndfQOLJQF5onx8/K7yZC3i1g==}
+
+  '@posthog/rollup-plugin@1.6.0':
+    resolution: {integrity: sha512-QdSjBt+wt+j2VwLADpsr1Ii2j8F5rWe+V/m9O9PuZXWT8nUne8ML5ciMxAmsGTIIfVwmLhdXPtDlJEc2LuJ9rg==}
+    peerDependencies:
+      rollup: '>= 4.0.0'
 
   '@posthog/types@1.404.1':
     resolution: {integrity: sha512-i2Gei6ARfOSBeTN4s2yUP1p97s2UNI+1NWmtLjhnR/V6t3RFOfI1sBWKcJNWHjtoOCCWoAFU+PNPY6SgT2VtEQ==}
@@ -12937,6 +12956,10 @@ snapshots:
       '@posthog/core': 1.48.1
       '@posthog/types': 1.404.1
 
+  '@posthog/cli@0.16.2':
+    dependencies:
+      detect-libc: 2.1.2
+
   '@posthog/core@1.48.1':
     dependencies:
       '@posthog/types': 1.404.1
@@ -12944,6 +12967,17 @@ snapshots:
   '@posthog/core@1.9.1':
     dependencies:
       cross-spawn: 7.0.6
+
+  '@posthog/plugin-utils@2.0.0':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@posthog/rollup-plugin@1.6.0(rollup@4.60.3)':
+    dependencies:
+      '@posthog/cli': 0.16.2
+      '@posthog/plugin-utils': 2.0.0
+      magic-string: 0.30.21
+      rollup: 4.60.3
 
   '@posthog/types@1.404.1': {}
 


### PR DESCRIPTION
Nightly builds now soft require `$POSTHOG_PERSONAL_API_KEY` for uploading source maps, which I have added to our repo. This is not to be confused with `$POSTHOG_API_KEY` that we already had, which is actually a project token. I believe it needs to be a personal API key specifically as per https://posthog.com/docs/error-tracking/upload-source-maps/vite.

Both of the reported "secrets" are actually project tokens, which are safe for public record; one of them is already committed elsewhere in the repo.