### PR TITLE
Show review titles and labels in recent branches

### DIFF
--- a/apps/lite/e2e/tests/branches-list.spec.ts
+++ b/apps/lite/e2e/tests/branches-list.spec.ts
@@ -1,3 +1,5 @@
+import type { LiteElectronApi } from "../../electron/src/ipc.ts";
+import type { ListedStack } from "@gitbutler/but-sdk";
 import { expect, test } from "../test.ts";
 
 test.describe("branches list", () => {
@@ -93,5 +95,150 @@ test.describe("branches list", () => {
 				return offset >= end;
 			})
 			.toBe(true);
+	});
+});
+
+test.describe("recent branch reviews", () => {
+	test.use({ scenario: "project-with-remote-branches.sh" });
+
+	test("shows review metadata and filters by labels, authors, and review numbers", async ({
+		appWindow,
+		electronApp,
+	}) => {
+		const stacks = await appWindow.evaluate(async () => {
+			const projectId = location.pathname.split("/")[2];
+			if (projectId === undefined) throw new Error("No project in the URL");
+			return (window as unknown as { lite: LiteElectronApi }).lite.branchList(projectId);
+		});
+		const enriched: Array<ListedStack> = stacks.map((stack) => ({
+			...stack,
+			branches: stack.branches.map((branch) =>
+				branch.displayName === "branch1"
+					? {
+							...branch,
+							reviewStatus: "open",
+							review: {
+								number: 42,
+								title: "Speed up branch listing in large repositories",
+								htmlUrl: "https://example.com/pull/42",
+								unitSymbol: "#",
+								createdAt: "2026-09-01T12:00:00Z",
+								author: { login: "octocat", name: null },
+								labels: [
+									{ name: "performance", color: "0e8a16", description: "Performance improvements" },
+									{ name: "@gitbutler/lite", color: "#ffffff", description: null },
+									{ name: "needs review", color: null, description: null },
+								],
+							},
+						}
+					: branch.displayName === "branch2"
+						? {
+								...branch,
+								reviewStatus: "draft",
+								review: {
+									number: 43,
+									title: "A draft without optional metadata",
+									htmlUrl: "https://example.com/pull/43",
+									unitSymbol: "!",
+									labels: [],
+									author: null,
+									createdAt: null,
+								},
+							}
+						: branch,
+			),
+		}));
+		await electronApp.evaluate(({ ipcMain }, stacks) => {
+			ipcMain.removeHandler("branchList");
+			ipcMain.handle("branchList", () => stacks);
+			ipcMain.removeHandler("openInWebBrowser");
+			ipcMain.handle("openInWebBrowser", (_event, url: string) => {
+				(globalThis as { openedReviewUrl?: string }).openedReviewUrl = url;
+			});
+		}, enriched);
+		await appWindow.reload();
+		await appWindow
+			.getByRole("group", { name: "Pages" })
+			.getByRole("button", { name: "Branches", exact: true })
+			.click();
+		const branch = appWindow.getByRole("treeitem", { name: "branch1", exact: true });
+		await expect(branch).toHaveAccessibleDescription(
+			/Speed up branch listing in large repositories.*performance.*octocat/,
+		);
+		await expect(
+			branch.getByText("Speed up branch listing in large repositories", { exact: true }),
+		).toBeVisible();
+		await expect(branch.getByText("performance", { exact: true })).toBeVisible();
+		await expect(branch.getByTitle("needs review", { exact: true })).not.toHaveCSS(
+			"background-color",
+			"rgba(0, 0, 0, 0)",
+		);
+		await expect(branch.getByText(/by octocat/)).toBeVisible();
+		await expect(branch.getByText("2 commits", { exact: true })).toBeVisible();
+		await expect(
+			appWindow
+				.getByRole("treeitem", { name: "branch2", exact: true })
+				.getByText("Draft", { exact: true }),
+		).toBeVisible();
+		await expect(
+			appWindow
+				.getByRole("treeitem", { name: "branch3", exact: true })
+				.getByTitle("branch3", { exact: true }),
+		).toBeVisible();
+
+		const sidebar = appWindow.locator("#sidebar-panel");
+		await appWindow
+			.getByRole("treeitem", { name: "branch3", exact: true })
+			.getByTitle("branch3", { exact: true })
+			.click();
+		await appWindow.mouse.move(800, 40);
+		const heading = branch.getByTitle("Speed up branch listing in large repositories", {
+			exact: true,
+		});
+		const label = branch.getByText("performance", { exact: true });
+		const beforeHover = {
+			row: await branch.boundingBox(),
+			heading: await heading.boundingBox(),
+			label: await label.boundingBox(),
+		};
+		await expect(branch.getByRole("button", { name: "Branch menu" })).toBeHidden();
+		await heading.hover();
+		await expect(branch.getByRole("button", { name: "Branch menu" })).toBeVisible();
+		expect({
+			row: await branch.boundingBox(),
+			heading: await heading.boundingBox(),
+			label: await label.boundingBox(),
+		}).toEqual(beforeHover);
+		expect(await sidebar.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+
+		await branch.getByRole("button", { name: "Open #42 in browser" }).click();
+		expect(
+			await electronApp.evaluate(
+				() => (globalThis as { openedReviewUrl?: string }).openedReviewUrl,
+			),
+		).toBe("https://example.com/pull/42");
+		await branch.getByTitle("branch1", { exact: true }).click();
+		await expect(branch).toHaveAttribute("aria-selected", "true");
+		await branch.getByRole("button", { name: "Unfold commits" }).click();
+		await expect(branch).toHaveAttribute("aria-expanded", "true");
+		await expect(branch.getByRole("treeitem", { name: "branch1: second commit" })).toBeVisible();
+		await branch.getByRole("button", { name: "Fold commits" }).click();
+
+		await appWindow.getByRole("button", { name: "Filter branches", exact: true }).click();
+		const filter = appWindow.getByRole("textbox", { name: "Filter branches" });
+		for (const query of ["performance", "octocat", "#42"]) {
+			await filter.fill(query);
+			await expect(branch).toBeVisible();
+			await expect(appWindow.getByRole("treeitem", { name: "branch2", exact: true })).toHaveCount(
+				0,
+			);
+		}
+		await filter.fill("!43");
+		await expect(appWindow.getByRole("treeitem", { name: "branch2", exact: true })).toBeVisible();
+		await expect(branch).toHaveCount(0);
+		await filter.fill("#999");
+		await expect(appWindow.getByText("No branches match", { exact: true })).toBeVisible();
+		await filter.press("Escape");
+		await expect(branch).toBeVisible();
 	});
 });

--- a/apps/lite/ui/src/branch.test.ts
+++ b/apps/lite/ui/src/branch.test.ts
@@ -156,10 +156,13 @@ describe("searchStacks", () => {
 			branch({
 				displayName: "unrelated",
 				review: {
-					number: 7,
+					number: 42,
 					title: "Speed up the parser",
-					htmlUrl: "https://example.com/7",
+					htmlUrl: "https://example.com/42",
 					unitSymbol: "#",
+					labels: [{ name: "performance", color: "00ff00", description: null }],
+					author: { login: "octocat", name: "Grace Hopper" },
+					createdAt: null,
 				},
 			}),
 		]),
@@ -181,6 +184,23 @@ describe("searchStacks", () => {
 
 	it("matches on review title", () => {
 		expect(names(searchStacks(stacks, "parser"))).toEqual([["unrelated"]]);
+	});
+
+	it("matches labels and the review author independently of the last commit author", () => {
+		expect(names(searchStacks(stacks, "performance"))).toEqual([["unrelated"]]);
+		expect(names(searchStacks(stacks, "octocat"))).toEqual([["unrelated"]]);
+		expect(names(searchStacks(stacks, "Hopper"))).toEqual([["unrelated"]]);
+	});
+
+	it("matches exact review numbers with a forge symbol", () => {
+		expect(names(searchStacks(stacks, "#42"))).toEqual([["unrelated"]]);
+		expect(searchStacks(stacks, "#17")).toEqual([]);
+		expect(searchStacks(stacks, "!42")).toEqual([]);
+	});
+
+	it("still searches branch names when a number has no forge symbol", () => {
+		const withNumberedBranch = [...stacks, stack([branch({ displayName: "release-42" })])];
+		expect(names(searchStacks(withNumberedBranch, "42"))).toEqual([["unrelated"], ["release-42"]]);
 	});
 
 	it("keeps a matched stack whole, including its non-matching branches", () => {

--- a/apps/lite/ui/src/branch.ts
+++ b/apps/lite/ui/src/branch.ts
@@ -75,12 +75,31 @@ const MIN_SEARCH_LENGTH = 2;
  */
 export const searchStacks = (stacks: Array<ListedStack>, query: string): Array<ListedStack> => {
 	const trimmed = query.trim();
+	const reviewNumber = /^([#!])(\d+)$/.exec(trimmed);
+	if (reviewNumber) {
+		const [, symbol, number] = reviewNumber;
+		return stacks.filter((stack) =>
+			stack.branches.some(
+				({ review }) =>
+					review !== null && String(review.number) === number && review.unitSymbol === symbol,
+			),
+		);
+	}
 	if (trimmed.length < MIN_SEARCH_LENGTH) return stacks;
 
 	const fuse = new Fuse(
 		stacks.flatMap((stack) => stack.branches),
 		{
-			keys: ["displayName", "lastAuthor.name", "lastAuthor.email", "review.title"],
+			keys: [
+				"displayName",
+				"lastAuthor.name",
+				"lastAuthor.email",
+				"review.title",
+				"review.number",
+				"review.labels.name",
+				"review.author.login",
+				"review.author.name",
+			],
 			// Desktop's branch-search calibration: forgiving of typos without
 			// returning half the list; ignoreLocation matches anywhere in the string.
 			threshold: 0.3,

--- a/apps/lite/ui/src/components/ForgeLabel.module.css
+++ b/apps/lite/ui/src/components/ForgeLabel.module.css
@@ -1,0 +1,17 @@
+.label.label {
+	display: inline-flex;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+.label[data-colored] {
+	background-color: color-mix(in srgb, var(--label-color) var(--badge-bg-opacity), transparent);
+	color: color-mix(in oklab, var(--label-color) 30%, var(--text-1));
+}
+
+.text {
+	overflow: hidden;
+	text-box: trim-both cap alphabetic;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/apps/lite/ui/src/components/ForgeLabel.stories.tsx
+++ b/apps/lite/ui/src/components/ForgeLabel.stories.tsx
@@ -1,0 +1,44 @@
+import preview from "#storybook/preview";
+import { ForgeLabel } from "./ForgeLabel.tsx";
+
+const performanceLabel = {
+	name: "performance",
+	color: "0e8a16",
+	description: "Performance improvements",
+};
+
+const meta = preview.meta({
+	component: ForgeLabel,
+	args: { size: "regular" },
+});
+
+export const Regular = meta.story({ args: { label: performanceLabel } });
+
+export const Large = meta.story({ args: { size: "large", label: performanceLabel } });
+
+export const Colorless = meta.story({
+	args: { label: { name: "needs review", color: null, description: null } },
+});
+
+export const LargeColorless = meta.story({
+	args: { size: "large", label: { name: "needs review", color: null, description: null } },
+});
+
+export const PrefixedColor = meta.story({
+	args: { label: { name: "@gitbutler/lite", color: "#ffffff", description: null } },
+});
+
+export const LongLabel = meta.story({
+	args: {
+		label: {
+			name: "A long label that needs to fit in a narrow row",
+			color: "dea584",
+			description: null,
+		},
+	},
+	render: (args) => (
+		<div style={{ width: 160 }}>
+			<ForgeLabel {...args} />
+		</div>
+	),
+});

--- a/apps/lite/ui/src/components/ForgeLabel.tsx
+++ b/apps/lite/ui/src/components/ForgeLabel.tsx
@@ -1,0 +1,29 @@
+import type { ForgeReviewLabel } from "@gitbutler/but-sdk";
+import type { FC } from "react";
+import { Badge, type BadgeSize } from "./Badge.tsx";
+import styles from "./ForgeLabel.module.css";
+
+export const ForgeLabel: FC<{ label: ForgeReviewLabel; size?: BadgeSize }> = ({
+	label,
+	size = "large",
+}) => {
+	// GitHub sends bare hex color codes, GitLab prefixes them with #.
+	const color =
+		label.color === null ? null : label.color.startsWith("#") ? label.color : `#${label.color}`;
+	return (
+		<Badge
+			variant="lightGray"
+			size={size}
+			className={styles.label}
+			data-colored={color !== null || undefined}
+			style={color === null ? undefined : { "--label-color": color }}
+			title={
+				label.description !== null && label.description !== ""
+					? `${label.name}: ${label.description}`
+					: label.name
+			}
+		>
+			<span className={styles.text}>{label.name}</span>
+		</Badge>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -83,5 +83,56 @@
 	justify-content: safe center;
 }
 
-/* The label column and its meta line now live in Row.module.css, shared with
-   the workspace outline's branch rows. */
+.branchRow .headline {
+	display: block;
+	flex-grow: 0;
+	line-height: 22px;
+	overflow-wrap: anywhere;
+}
+
+.title {
+	display: inline;
+	line-height: inherit;
+}
+
+.branchRow .reviewMeta {
+	column-gap: 6px;
+	row-gap: 2px;
+	flex-wrap: wrap;
+	padding-block-end: 2px;
+	font-size: 12px;
+	line-height: 18px;
+}
+
+.reviewLink {
+	display: inline-flex;
+	flex-shrink: 0;
+	align-items: center;
+	padding: 0;
+	gap: 4px;
+	font-size: inherit;
+}
+
+.reviewAuthor {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.branchRow .branchMeta {
+	font-size: 12px;
+}
+
+/* Reserve the action column so hovering never reflows titles or labels. */
+.branchRow .branchToolbar {
+	display: flex;
+	visibility: hidden;
+	flex-shrink: 0;
+	align-items: center;
+	height: var(--single-line-row-height);
+}
+
+.branchRow:hover .branchToolbar,
+.branchRow:focus-within .branchToolbar,
+[aria-selected="true"] > .branchRow .branchToolbar {
+	visibility: visible;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -5,8 +5,10 @@ import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { assert } from "#ui/assert.ts";
 import { activeBranchFilterCount, branchIsEmpty, type BranchFilters } from "#ui/branch.ts";
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
-import { Badge } from "#ui/components/Badge.tsx";
+import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
+import { ForgeLabel } from "#ui/components/ForgeLabel.tsx";
+import type { IconName } from "#ui/components/iconNames.ts";
 import { classes } from "#ui/components/classes.ts";
 import { EmptyState } from "#ui/components/EmptyState.tsx";
 import {
@@ -29,7 +31,7 @@ import { useAutofocusScope, useAddressSpaceHotkeys, type FocusScope } from "#ui/
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import { getRangeExtractorWithIndices } from "#ui/virtual.ts";
-import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
+import type { BranchReviewStatus, Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -40,6 +42,7 @@ import {
 	Fragment,
 	type RefObject,
 	useCallback,
+	useId,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -81,6 +84,16 @@ const filterMenuLabels: Array<[keyof BranchFilters, string]> = [
 	["onlyLocal", "Show Only Local Branches"],
 	["onlyStacks", "Show Only Stacks"],
 ];
+
+const reviewStates: Record<
+	BranchReviewStatus,
+	{ label: string; variant: BadgeVariant; icon: IconName }
+> = {
+	open: { label: "Open", variant: "safe", icon: "pr" },
+	draft: { label: "Draft", variant: "lightGray", icon: "pr-draft" },
+	merged: { label: "Merged", variant: "purple", icon: "branch-merge" },
+	closed: { label: "Closed", variant: "danger", icon: "pr-close" },
+};
 
 /**
  * The graph has no remote-only state, so a branch that exists only on a remote
@@ -300,6 +313,7 @@ const BranchItem: FC<{
 		) && canUnfold;
 	const isSelected = useIsSelected(address);
 	const [now] = useState(() => Date.now());
+	const descriptionId = useId();
 
 	// Same topology as the applied list: nothing above the branch means the
 	// rail turns in from the right, otherwise it joins the branch above it. This
@@ -308,6 +322,8 @@ const BranchItem: FC<{
 	const railGlyph: GraphSegmentGlyph = isTopBranch ? "forkRight" : "joinRight";
 
 	const review = branch.review;
+	const reviewState = branch.reviewStatus === null ? null : reviewStates[branch.reviewStatus];
+	const createdAt = review?.createdAt != null ? Date.parse(review.createdAt) : Number.NaN;
 
 	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
 	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
@@ -358,6 +374,7 @@ const BranchItem: FC<{
 			id={treeItemId(address)}
 			role="treeitem"
 			aria-label={branch.displayName}
+			aria-describedby={review === null ? undefined : descriptionId}
 			aria-level={1}
 			aria-posinset={positionInSet}
 			aria-setsize={setSize}
@@ -367,6 +384,7 @@ const BranchItem: FC<{
 			aria-expanded={canUnfold ? unfolded : undefined}
 		>
 			<Row
+				className={styles.branchRow}
 				isSelected={isSelected}
 				onSelect={() => setCursor("unapplied", address)}
 				onContextMenu={(event) => {
@@ -385,52 +403,96 @@ const BranchItem: FC<{
 					<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />
 				)}
 
-				<RowLabelGroup>
-					<RowLabelContainer>
-						<RowLabel heading singleLine title={branch.displayName}>
-							{branch.displayName}
+				<RowLabelGroup id={descriptionId}>
+					<RowLabelContainer className={styles.headline}>
+						<RowLabel heading className={styles.title} title={review?.title ?? branch.displayName}>
+							{review?.title ?? branch.displayName}
 						</RowLabel>
+						{review?.labels.map((label) => (
+							<Fragment key={label.name}>
+								{" "}
+								<ForgeLabel label={label} size="regular" />
+							</Fragment>
+						))}
 					</RowLabelContainer>
 
-					<RowMeta>
-						{showsAuthorMeta && (
+					{review !== null && (
+						<RowMeta className={styles.reviewMeta}>
+							<button
+								type="button"
+								className={classes(getRowButtonClassName({ variant: "ghost" }), styles.reviewLink)}
+								aria-label={`Open ${review.unitSymbol}${String(review.number)} in browser`}
+								onClick={() => void openReviewInBrowser()}
+							>
+								{reviewState !== null && (
+									<Badge variant={reviewState.variant}>
+										<Icon name={reviewState.icon} size={12} />
+										{reviewState.label}
+									</Badge>
+								)}
+								<span>
+									{review.unitSymbol}
+									{review.number}
+								</span>
+								<Icon name="arrow-up-right" size={12} />
+							</button>
+							<span className={classes(rowStyles.fadedText, styles.reviewAuthor)}>
+								{Number.isFinite(createdAt) && (
+									<>
+										opened <RelativeTime timestamp={createdAt} now={now} compact /> ago{" "}
+									</>
+								)}
+								{review.author && <>by {review.author.login}</>}
+							</span>
+						</RowMeta>
+					)}
+
+					<RowMeta className={styles.branchMeta}>
+						{review !== null ? (
 							<span
 								className={classes(
 									rowStyles.fadedText,
 									rowStyles.metaItem,
 									rowStyles.metaItemShrinkable,
 								)}
-								title={branch.lastAuthor?.email}
+								title={branch.displayName}
 							>
-								<span className={rowStyles.metaItemText}>
-									{lastAuthorName !== undefined && <>{lastAuthorName} </>}
-									{branch.updatedAtMs !== null && (
-										<RelativeTime timestamp={branch.updatedAtMs} now={now} />
-									)}
-								</span>
+								<Icon size={12} name="branch" />
+								<span className={rowStyles.metaItemText}>{branch.displayName}</span>
 							</span>
+						) : (
+							showsAuthorMeta && (
+								<span
+									className={classes(
+										rowStyles.fadedText,
+										rowStyles.metaItem,
+										rowStyles.metaItemShrinkable,
+									)}
+									title={branch.lastAuthor?.email}
+								>
+									<span className={rowStyles.metaItemText}>
+										{lastAuthorName !== undefined && (
+											<>
+												{lastAuthorName}
+												{branch.updatedAtMs !== null && " · "}
+											</>
+										)}
+										{branch.updatedAtMs !== null && (
+											<>
+												updated <RelativeTime timestamp={branch.updatedAtMs} now={now} compact />{" "}
+												ago
+											</>
+										)}
+									</span>
+								</span>
+							)
 						)}
 
 						{showsCommitCount && (
 							<>
-								{showsAuthorMeta && <RowMetaSeparator />}
+								{(review !== null || showsAuthorMeta) && <RowMetaSeparator />}
 								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
-									<Icon size={14} name="commit" />
-									{branch.commitCount}
-								</span>
-							</>
-						)}
-
-						{review !== null && (
-							<>
-								{(showsAuthorMeta || showsCommitCount) && <RowMetaSeparator />}
-								<span
-									title={review.title}
-									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
-								>
-									<Icon size={14} name="pr" />
-									{review.unitSymbol}
-									{review.number}
+									{branch.commitCount} {branch.commitCount === 1 ? "commit" : "commits"}
 								</span>
 							</>
 						)}
@@ -439,7 +501,10 @@ const BranchItem: FC<{
 					</RowMeta>
 				</RowLabelGroup>
 
-				<Toolbar.Root aria-label="Branch actions" render={<RowToolbar />}>
+				<Toolbar.Root
+					aria-label="Branch actions"
+					render={<RowToolbar className={styles.branchToolbar} />}
+				>
 					<Toolbar.Button
 						aria-label="Branch menu"
 						onClick={(event) => {
@@ -554,8 +619,10 @@ export const BranchesList: FC<
 		count: stacks.length,
 		getScrollElement: () => scrollElementRef.current,
 		estimateSize: (index) => {
-			// Keep in sync with Row.module.css and StackCard.module.css.
+			// Estimate unwrapped titles; measured cards account for titles and labels that wrap.
 			const singleLineRowHeight = 28;
+			const branchTitleHeight = 34;
+			const reviewMetaHeight = 22;
 			const branchMetaLineHeight = 20;
 			const branchMetaPaddingEnd = 6;
 			const stackBodyPaddingStart = 6;
@@ -565,12 +632,14 @@ export const BranchesList: FC<
 
 			const branchCount = stacks[index]?.branches.length ?? 0;
 			const commitCount = stacks[index]?.commitCount ?? 0;
+			const reviewCount = stacks[index]?.reviewCount ?? 0;
 
 			return (
 				stackBodyPaddingStart +
 				stackBorderHeight +
 				stackFinalConnectorHeight +
-				branchCount * (singleLineRowHeight + branchMetaLineHeight + branchMetaPaddingEnd) +
+				branchCount * (branchTitleHeight + branchMetaLineHeight + branchMetaPaddingEnd) +
+				reviewCount * reviewMetaHeight +
 				commitCount * singleLineRowHeight +
 				Math.max(0, branchCount - 1) * stackBetweenBranchConnectorHeight
 			);
@@ -764,8 +833,8 @@ export const BranchesList: FC<
 								query === ""
 									? "The filters you have on hide every branch"
 									: isFiltered
-										? `Nothing with “${query}” in its name gets past the filters you have on`
-										: `None of your branches has “${query}” in its name`
+										? `No matches for “${query}” with the current filters`
+										: `No matches for “${query}” in branches or pull requests`
 							}
 						>
 							<button

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -150,15 +150,6 @@
 	gap: 4px;
 }
 
-/* Badge owns the pill itself; forge label colors are arbitrary hex, so only the
-   tint is overridden here — descendant-scoped so it beats Badge's own variant
-   colors regardless of stylesheet order. Colorless labels keep the lightGray
-   variant untouched. */
-.labels .label {
-	background-color: color-mix(in srgb, var(--label-color) 20%, transparent);
-	color: color-mix(in oklab, var(--label-color) 60%, var(--text-1));
-}
-
 .checks {
 	display: flex;
 	flex-direction: column;

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -18,6 +18,7 @@ import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
+import { ForgeLabel } from "#ui/components/ForgeLabel.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { type NativeMenuItem, nativeMenuItem, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
@@ -29,7 +30,6 @@ import { loginKey, sameLogin } from "#ui/review-users.ts";
 import type {
 	CiCheck,
 	ForgeReview,
-	ForgeReviewLabel,
 	ForgeReviewSubmission,
 	ForgeReviewUser,
 } from "@gitbutler/but-sdk";
@@ -138,24 +138,6 @@ export const ReviewUser: FC<{ user: ForgeReviewUser }> = ({ user }) => (
 		<span className={styles.userLogin}>{user.login}</span>
 	</div>
 );
-
-const Label: FC<{ label: ForgeReviewLabel }> = ({ label }) => {
-	// GitHub sends bare hex color codes, GitLab prefixes them with `#`.
-	const color =
-		label.color === null ? null : label.color.startsWith("#") ? label.color : `#${label.color}`;
-
-	return (
-		<Badge
-			variant="lightGray"
-			size="large"
-			className={color === null ? undefined : styles.label}
-			style={color === null ? undefined : { "--label-color": color }}
-			title={label.description ?? undefined}
-		>
-			{label.name}
-		</Badge>
-	);
-};
 
 const CopyableBranch: FC<{ name: string }> = ({ name }) => {
 	const { copied, copy } = useCopied(name);
@@ -325,7 +307,7 @@ export const NewPullRequestPanel: FC<{
 				{pickedLabels.length > 0 && (
 					<div className={styles.labels}>
 						{pickedLabels.map((label) => (
-							<Label key={label.name} label={label} />
+							<ForgeLabel key={label.name} label={label} />
 						))}
 					</div>
 				)}
@@ -747,7 +729,7 @@ export const PullRequestPanel: FC<{
 				{review.labels.length > 0 && (
 					<div className={styles.labels}>
 						{review.labels.map((label) => (
-							<Label key={label.name} label={label} />
+							<ForgeLabel key={label.name} label={label} />
 						))}
 					</div>
 				)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
@@ -29,6 +29,7 @@ type BranchesListBranch = {
 type BranchesListStack = {
 	branches: Array<BranchesListBranch>;
 	commitCount: number;
+	reviewCount: number;
 };
 
 export type BranchesListContent = {
@@ -91,7 +92,9 @@ export const useBranchesList = (projectId: string): UseQueryResult<BranchesListC
 			const stackIndexByAddressIndex: Array<number> = [];
 			const stacks = unapplied.map((stack, stackIndex): BranchesListStack => {
 				let commitCount = 0;
+				let reviewCount = 0;
 				const branches = stack.branches.map((branch): BranchesListBranch => {
+					if (branch.review !== null) reviewCount += 1;
 					const addressIndex = items.length;
 					items.push(branchAddress({ branchRef: encodeBytes(branch.refName.full) }));
 					stackIndexByAddressIndex.push(stackIndex);
@@ -115,7 +118,7 @@ export const useBranchesList = (projectId: string): UseQueryResult<BranchesListC
 					return { branch, addressIndex, commits };
 				});
 
-				return { branches, commitCount };
+				return { branches, commitCount, reviewCount };
 			});
 
 			return {

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -689,9 +689,28 @@ pub mod json {
         /// requests and `!` for GitLab merge requests. Precedes `number` when
         /// displayed.
         pub unit_symbol: String,
+        /// Labels used to categorize the review.
+        pub labels: Vec<but_forge::ForgeReviewLabel>,
+        /// The review author, which may differ from the latest commit author.
+        pub author: Option<ListedForgeReviewAuthor>,
+        /// ISO 8601 timestamp of when the review was opened.
+        pub created_at: Option<String>,
     }
     #[cfg(feature = "export-schema")]
     but_schemars::register_sdk_type!(ListedForgeReview);
+
+    /// Author identity used to display and search listed reviews.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct ListedForgeReviewAuthor {
+        /// The author's username on the forge.
+        pub login: String,
+        /// The author's display name, if available.
+        pub name: Option<String>,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(ListedForgeReviewAuthor);
 
     impl From<&but_forge::ForgeReview> for ListedForgeReview {
         fn from(value: &but_forge::ForgeReview) -> Self {
@@ -700,6 +719,12 @@ pub mod json {
                 title: value.title.clone(),
                 html_url: value.html_url.clone(),
                 unit_symbol: value.unit_symbol.clone(),
+                labels: value.labels.clone(),
+                author: value.author.as_ref().map(|author| ListedForgeReviewAuthor {
+                    login: author.login.clone(),
+                    name: author.name.clone(),
+                }),
+                created_at: value.created_at.clone(),
             }
         }
     }

--- a/crates/but-api/tests/api/branch_list.rs
+++ b/crates/but-api/tests/api/branch_list.rs
@@ -35,6 +35,63 @@ fn cached_review(source_branch: &str, number: i64) -> ForgeReview {
 }
 
 #[test]
+fn listing_serializes_only_the_review_metadata_it_needs() -> anyhow::Result<()> {
+    let mut review = cached_review("feature", 42);
+    review.body = Some("A long review description".into());
+    review.labels.push(but_forge::ForgeReviewLabel {
+        name: "rust".into(),
+        description: Some("Rust changes".into()),
+        color: Some("dea584".into()),
+    });
+    review.author = Some(but_forge::ForgeReviewUser {
+        id: 7,
+        login: "octocat".into(),
+        name: Some("The Octocat".into()),
+        email: Some("octocat@example.com".into()),
+        avatar_url: None,
+        is_bot: false,
+    });
+    review.created_at = Some("2026-09-01T12:00:00Z".into());
+
+    let json = serde_json::to_value(but_api::branch::json::ListedForgeReview::from(&review))?;
+    assert_eq!(
+        json["labels"][0]["name"], "rust",
+        "labels survive transport"
+    );
+    assert_eq!(
+        json["labels"][0]["color"], "dea584",
+        "label colors survive transport"
+    );
+    assert_eq!(
+        json["author"],
+        serde_json::json!({ "login": "octocat", "name": "The Octocat" }),
+        "listing authors include only the login and display name used by the UI and search"
+    );
+    assert_eq!(
+        json["createdAt"], "2026-09-01T12:00:00Z",
+        "opening time survives transport"
+    );
+    assert!(
+        json.get("body").is_none(),
+        "listing responses omit review bodies"
+    );
+
+    let json = serde_json::to_value(but_api::branch::json::ListedForgeReview::from(
+        &cached_review("feature", 43),
+    ))?;
+    assert_eq!(
+        json["labels"],
+        serde_json::json!([]),
+        "unlabeled reviews carry an empty list"
+    );
+    assert!(
+        json["author"].is_null() && json["createdAt"].is_null(),
+        "missing forge metadata stays absent"
+    );
+    Ok(())
+}
+
+#[test]
 fn groups_classifies_and_enriches_from_cache() -> anyhow::Result<()> {
     let (repo, _tmp) = repo_with_feature_branch()?;
     set_project_target_to_feature(&repo)?;

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -130,7 +130,7 @@ export interface AiConfigurationUpdate {
  * This acquires exclusive worktree access from `ctx`, applies
  * `existing_branch`, and records an oplog snapshot on success.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:864}
+ * {@link ../../../../../crates/but-api/src/branch.rs:889}
  */
 export declare function apply(projectId: string, existingBranch: string): Promise<ApplyOutcome>
 
@@ -142,7 +142,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1826}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1851}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -169,7 +169,7 @@ export declare function assignHunk(projectId: string, assignments: Array<HunkAss
  * deduplicated against local branches and the short names of remote-tracking
  * branches, both of which can change afterwards.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:914}
+ * {@link ../../../../../crates/but-api/src/branch.rs:939}
  */
 export declare function branchCannedName(projectId: string): Promise<string>
 
@@ -183,7 +183,7 @@ export declare function branchCannedName(projectId: string): Promise<string>
  * in which case its local tracking branch is checked out, created at the
  * remote-tracking commit first if it doesn't exist yet.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1521}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1546}
  */
 export declare function branchCheckout(projectId: string, branch: FullNameBytes): Promise<BranchCheckoutResult>
 
@@ -195,7 +195,7 @@ export declare function branchCheckout(projectId: string, branch: FullNameBytes)
  * before creating `refs/heads/<name>`. If omitted, a unique canned branch name
  * is generated. The resulting branch must not already exist.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1537}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1562}
  */
 export declare function branchCheckoutNew(projectId: string, name: string | null): Promise<BranchCheckoutResult>
 
@@ -208,7 +208,7 @@ export declare function branchCheckoutNew(projectId: string, name: string | null
  * checked-out local branch. For lower-level implementation details, see
  * [`but_workspace::branch::create_reference()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:929}
+ * {@link ../../../../../crates/but-api/src/branch.rs:954}
  */
 export declare function branchCreate(projectId: string, newRef: MaybeLossyFullNameRef, placement: BranchCreatePlacement): Promise<BranchCreateResult>
 
@@ -224,7 +224,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1723}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1748}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -257,7 +257,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1740}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1765}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -274,7 +274,7 @@ export declare function branchList(projectId: string): Promise<Array<ListedStack
  * lower-level implementation details, see
  * [`but_workspace::branch::remove_reference()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1060}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1085}
  */
 export declare function branchRemove(projectId: string, refName: FullNameBytes): Promise<BranchRemoveResult>
 
@@ -290,7 +290,7 @@ export declare function branchRemove(projectId: string, refName: FullNameBytes):
  * It requires no stack id and works in both managed and ad-hoc/single-branch
  * workspaces.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1218}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1243}
  */
 export declare function branchRename(projectId: string, refName: FullNameBytes, newName: string): Promise<BranchRenameResult>
 
@@ -826,7 +826,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1802}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1827}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -1154,7 +1154,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1883}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1908}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1513,7 +1513,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1970}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1995}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1636,7 +1636,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
 /**
  * Switch to the workspace reference
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1583}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1608}
  */
 export declare function workspaceCheckout(projectId: string): Promise<BranchCheckoutResult>
 
@@ -3707,6 +3707,20 @@ export type ListedForgeReview = {
    * displayed.
    */
   unitSymbol: string;
+  /** Labels used to categorize the review. */
+  labels: Array<ForgeReviewLabel>;
+  /** The review author, which may differ from the latest commit author. */
+  author: ListedForgeReviewAuthor | null;
+  /** ISO 8601 timestamp of when the review was opened. */
+  createdAt: string | null;
+};
+
+/** Author identity used to display and search listed reviews. */
+export type ListedForgeReviewAuthor = {
+  /** The author's username on the forge. */
+  login: string;
+  /** The author's display name, if available. */
+  name: string | null;
 };
 
 /**

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -130,7 +130,7 @@ export interface AiConfigurationUpdate {
  * This acquires exclusive worktree access from `ctx`, applies
  * `existing_branch`, and records an oplog snapshot on success.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:864}
+ * {@link ../../../../../crates/but-api/src/branch.rs:889}
  */
 export declare function apply(projectId: string, existingBranch: string): Promise<ApplyOutcome>
 
@@ -142,7 +142,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1826}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1851}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -169,7 +169,7 @@ export declare function assignHunk(projectId: string, assignments: Array<HunkAss
  * deduplicated against local branches and the short names of remote-tracking
  * branches, both of which can change afterwards.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:914}
+ * {@link ../../../../../crates/but-api/src/branch.rs:939}
  */
 export declare function branchCannedName(projectId: string): Promise<string>
 
@@ -183,7 +183,7 @@ export declare function branchCannedName(projectId: string): Promise<string>
  * in which case its local tracking branch is checked out, created at the
  * remote-tracking commit first if it doesn't exist yet.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1521}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1546}
  */
 export declare function branchCheckout(projectId: string, branch: FullNameBytes): Promise<BranchCheckoutResult>
 
@@ -195,7 +195,7 @@ export declare function branchCheckout(projectId: string, branch: FullNameBytes)
  * before creating `refs/heads/<name>`. If omitted, a unique canned branch name
  * is generated. The resulting branch must not already exist.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1537}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1562}
  */
 export declare function branchCheckoutNew(projectId: string, name: string | null): Promise<BranchCheckoutResult>
 
@@ -208,7 +208,7 @@ export declare function branchCheckoutNew(projectId: string, name: string | null
  * checked-out local branch. For lower-level implementation details, see
  * [`but_workspace::branch::create_reference()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:929}
+ * {@link ../../../../../crates/but-api/src/branch.rs:954}
  */
 export declare function branchCreate(projectId: string, newRef: MaybeLossyFullNameRef, placement: BranchCreatePlacement): Promise<BranchCreateResult>
 
@@ -224,7 +224,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1723}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1748}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -257,7 +257,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1740}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1765}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -274,7 +274,7 @@ export declare function branchList(projectId: string): Promise<Array<ListedStack
  * lower-level implementation details, see
  * [`but_workspace::branch::remove_reference()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1060}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1085}
  */
 export declare function branchRemove(projectId: string, refName: FullNameBytes): Promise<BranchRemoveResult>
 
@@ -290,7 +290,7 @@ export declare function branchRemove(projectId: string, refName: FullNameBytes):
  * It requires no stack id and works in both managed and ad-hoc/single-branch
  * workspaces.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1218}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1243}
  */
 export declare function branchRename(projectId: string, refName: FullNameBytes, newName: string): Promise<BranchRenameResult>
 
@@ -826,7 +826,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1802}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1827}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -1154,7 +1154,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1883}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1908}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1513,7 +1513,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1970}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1995}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1636,7 +1636,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
 /**
  * Switch to the workspace reference
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1583}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1608}
  */
 export declare function workspaceCheckout(projectId: string): Promise<BranchCheckoutResult>
 
@@ -3707,6 +3707,20 @@ export type ListedForgeReview = {
    * displayed.
    */
   unitSymbol: string;
+  /** Labels used to categorize the review. */
+  labels: Array<ForgeReviewLabel>;
+  /** The review author, which may differ from the latest commit author. */
+  author: ListedForgeReviewAuthor | null;
+  /** ISO 8601 timestamp of when the review was opened. */
+  createdAt: string | null;
+};
+
+/** Author identity used to display and search listed reviews. */
+export type ListedForgeReviewAuthor = {
+  /** The author's username on the forge. */
+  login: string;
+  /** The author's display name, if available. */
+  name: string | null;
 };
 
 /**


### PR DESCRIPTION
Recent branches now leads with pull request titles and colored labels, with review state, author, opening time, and a direct link beneath. Branch names and commit counts remain visible, and reserving the menu column prevents hover from reflowing the listing. Search includes labels, PR authors, and review numbers.

The compact branch-list response carries the additional cached metadata, and the PR panel shares its label rendering with the list. Validated with Rust transport tests, Lite typechecking and unit tests, branch end-to-end tests (including hover stability), and light/dark visual checks.