### PR TITLE
Restore Workspace history and refine graph lines in Lite

### DIFF
--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -221,6 +221,16 @@ export const workspaceTargetCommitsQueryOptions = (projectId: string) =>
 		queryFn: () => window.lite.workspaceTargetCommits({ projectId, from: null, limit: null }),
 	});
 
+/** The cursor is exclusive. Sharing the listing's key prefix also shares its invalidation. */
+export const olderTargetCommitsInfiniteQueryOptions = (projectId: string, from: string) =>
+	infiniteQueryOptions({
+		queryKey: [projectId, "workspaceTargetCommits", { olderThan: from }],
+		queryFn: ({ pageParam }) =>
+			window.lite.workspaceTargetCommits({ projectId, from: pageParam, limit: 25 }),
+		initialPageParam: from,
+		getNextPageParam: (page) => (page.hasMore ? page.commits.at(-1)?.commit.id : undefined),
+	});
+
 export const workspaceFetchStatusQueryOptions = (projectId: string) =>
 	queryOptions({
 		queryKey: [projectId, "workspaceFetchStatus"],

--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -24,22 +24,27 @@
 .tone {
 	&[data-status="LocalOnly"] {
 		--commit-status-color: var(--commit-local);
+		--graph-line-strength: 30%;
 	}
 
 	&[data-status="LocalAndRemote"] {
 		--commit-status-color: var(--commit-remote);
+		--graph-line-strength: 40%;
 	}
 
 	&[data-status="Integrated"] {
 		--commit-status-color: var(--commit-integrated);
+		--graph-line-strength: 40%;
 	}
 
 	&[data-status="Upstream"] {
 		--commit-status-color: var(--commit-upstream);
+		--graph-line-strength: 40%;
 	}
 
 	&[data-status="Diverged"] {
 		--commit-status-color: var(--commit-local);
+		--graph-line-strength: 30%;
 	}
 }
 
@@ -47,11 +52,11 @@
    one colour wherever it runs; the inversion above flips the card colour
    too. */
 .line {
-	stroke: color-mix(in srgb, currentColor 40%, var(--bg-1));
+	stroke: color-mix(in srgb, currentColor var(--graph-line-strength, 40%), var(--bg-1));
 }
 
-/* Columns sit at a 12px pitch with their line 8px in; the glyph's own column
-   is the 16px canvas, so the label after it stays where it is. */
+/* Column widths come from graph-spacing.ts; the glyph's own column stays
+   on its 16px canvas. */
 
 /* A column the main line runs through behind the row. Translucent, unlike
    the other rails: it crosses row fills, and a mid grey stays visible on a
@@ -59,7 +64,6 @@
 .pass {
 	position: relative;
 	flex-shrink: 0;
-	width: 12px;
 
 	&::after {
 		position: absolute;
@@ -71,22 +75,20 @@
 	}
 }
 
-/* The first column is the trunk's. It sits one column left of the row's inset,
-   which layout.ts's ROW_INSET sizes to land its line on the panel's edge. No
-   glyph ever sits in it: a row the trunk enters hooks it into the glyph column
-   beside it, drawing left of the canvas. */
-.edgePass,
-.gap > svg:first-child {
-	margin-inline-start: -12px;
-}
-
 /* The trunk itself rather than a line behind a lane, so it keeps the weight
    the gaps draw it at; translucent like the other passes, as it crosses row
    fills. */
 .edgePass {
 	flex-shrink: 0;
-	width: 12px;
-	stroke: color-mix(in srgb, var(--commit-local) 40%, transparent);
+	/* Narrow lanes can place the line beyond the column's layout box. */
+	overflow: visible;
+	stroke: color-mix(in srgb, var(--commit-local) 30%, transparent);
+}
+
+/* Cards hide the lines passing behind their rows. */
+.container > .edgePass,
+.container > .pass {
+	visibility: var(--graph-through-visibility, visible);
 }
 
 /* The trunk's tail below the row's centre line fades to nothing. */

--- a/apps/lite/ui/src/components/GraphSegment.stories.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.stories.tsx
@@ -1,28 +1,31 @@
 import preview from "#storybook/preview";
 import { type GraphSegmentGlyph, GraphSegment } from "./GraphSegment.tsx";
 
+const glyphs = [
+	"parent",
+	"horizontal",
+	"space",
+	"forkLeft",
+	"forkRight",
+	"notch",
+	"forkBoth",
+	"mergeLeft",
+	"mergeRight",
+	"mergeBoth",
+	"joinLeft",
+	"joinRight",
+	"joinBoth",
+	"hook",
+	"commit",
+	"group",
+] satisfies Array<GraphSegmentGlyph>;
+
 const meta = preview.meta({
 	component: GraphSegment,
 	argTypes: {
 		glyph: {
 			control: { type: "select" },
-			options: [
-				"parent",
-				"horizontal",
-				"space",
-				"forkLeft",
-				"forkRight",
-				"notch",
-				"forkBoth",
-				"mergeLeft",
-				"mergeRight",
-				"mergeBoth",
-				"joinLeft",
-				"joinRight",
-				"joinBoth",
-				"commit",
-				"group",
-			],
+			options: glyphs,
 		},
 	},
 });
@@ -48,25 +51,7 @@ export const Default = meta.story({
 export const AllGlyphs = meta.story({
 	render: () => (
 		<div style={{ display: "flex", gap: 16 }}>
-			{(
-				[
-					"parent",
-					"horizontal",
-					"forkLeft",
-					"forkRight",
-					"notch",
-					"forkBoth",
-					"mergeLeft",
-					"mergeRight",
-					"mergeBoth",
-					"joinLeft",
-					"joinRight",
-					"joinBoth",
-					"commit",
-					"group",
-					"space",
-				] satisfies Array<GraphSegmentGlyph>
-			).map((glyph) => (
+			{glyphs.map((glyph) => (
 				<div
 					key={glyph}
 					style={{

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -1,7 +1,19 @@
 import styles from "./GraphSegment.module.css";
 import { classes } from "#ui/components/classes.ts";
+import { GRAPH_COMMIT_BEND_PADDING, GRAPH_LANE_WIDTH } from "./graph-spacing.ts";
 import type { ComponentProps, FC } from "react";
 import type { CommitState } from "@gitbutler/but-sdk";
+
+const ARC_K = 0.5523;
+const n = (value: number): string => String(Math.round(value * 100) / 100);
+const trunkX = 8 - GRAPH_LANE_WIDTH;
+const hookRadius = Math.min(4, GRAPH_LANE_WIDTH / 2);
+const hookK = ARC_K * hookRadius;
+const hookHeadPath = `M${trunkX} 0V${14 - hookRadius}C${trunkX} ${n(14 - hookRadius + hookK)} ${n(trunkX + hookRadius - hookK)} 14 ${trunkX + hookRadius} 14`;
+const laneStyle = { width: GRAPH_LANE_WIDTH };
+const gapInsetStyle = { marginInlineStart: -GRAPH_LANE_WIDTH };
+const trunkStyle = { ...laneStyle, ...gapInsetStyle };
+const commitBendStyle = { height: 28 + GRAPH_COMMIT_BEND_PADDING };
 
 const glyphPaths = {
 	parent: "M8 0V28",
@@ -10,8 +22,10 @@ const glyphPaths = {
 	// Forks
 	forkLeft: "M-5.96046e-08 14H2C5.31371 14 8 16.6863 8 20V28",
 	forkRight: "M16 14H14C10.6863 14 8 16.6863 8 20V28",
-	/** A tick off the trunk on the panel's edge, 4px left of the canvas, as a stacked branch's off its rail. */
-	notch: "M-4 14H4",
+	/** A tick off the trunk near the panel's edge. */
+	notch: `M${trunkX} 14H${trunkX + 5}`,
+	/** The trunk joins the history's column through two quarter turns. */
+	hook: `${hookHeadPath}H${8 - hookRadius}C${n(8 - hookRadius + hookK)} 14 8 ${n(14 + hookRadius - hookK)} 8 ${14 + hookRadius}V28`,
 	forkBoth: "M0 14H8M16 14H8M8 28L8 14",
 	// Merges
 	mergeLeft: "M-5.96046e-08 14H2C5.31371 14 8 11.3137 8 8V2.38419e-07",
@@ -42,7 +56,8 @@ const passes = (behind: number, folded = false) =>
 			<svg
 				key={column}
 				className={classes(styles.edgePass, folded && styles.edgePassFading)}
-				viewBox="0 0 12 28"
+				style={trunkStyle}
+				viewBox={`0 0 ${GRAPH_LANE_WIDTH} 28`}
 				preserveAspectRatio="none"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
@@ -52,7 +67,7 @@ const passes = (behind: number, folded = false) =>
 				<path d="M8 0V28" strokeWidth="1.5" />
 			</svg>
 		) : (
-			<span key={column} className={styles.pass} aria-hidden />
+			<span key={column} className={styles.pass} style={laneStyle} aria-hidden />
 		),
 	);
 
@@ -61,11 +76,22 @@ const ringPath =
 
 const ring = <path d={ringPath} stroke="currentColor" strokeWidth="1.5" />;
 
-const commitGlyph = (below: GraphSegmentStatus | undefined) => (
+const commitGlyph = (
+	above: GraphSegmentStatus | undefined,
+	below: GraphSegmentStatus | undefined,
+	railEnds: boolean,
+	fromTrunk: boolean,
+) => (
 	<>
-		<path className={styles.line} d="M8 0V11" strokeWidth="1.5" />
+		{fromTrunk ? (
+			<g transform={`translate(16 ${-GRAPH_COMMIT_BEND_PADDING}) scale(-1 1)`}>
+				<Tone status={above} d={bendPath(11 + GRAPH_COMMIT_BEND_PADDING)} />
+			</g>
+		) : (
+			<Tone status={above} d="M8 0V11" />
+		)}
 		{ring}
-		<Tone status={below} d="M8 17V28" />
+		{!railEnds && <Tone status={below} d="M8 17V28" />}
 	</>
 );
 
@@ -76,14 +102,6 @@ const groupGlyph = (
 	<>
 		<path className={styles.line} d="M8 0V2.78571M8 17.0038V26" strokeWidth="1.5" />
 		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
-	</>
-);
-
-/** The commit node without the tail below it, for the row a rail ends on. */
-const commitFootGlyph = (
-	<>
-		<path className={styles.line} d="M8 0V11" strokeWidth="1.5" />
-		{ring}
 	</>
 );
 
@@ -140,6 +158,7 @@ export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group";
 
 /** Glyphs whose rail carries on past the drawing, so a taller row goes on drawing it. */
 const stretchableGlyphs = new Set<GraphSegmentGlyph>([
+	"hook",
 	"parent",
 	"commit",
 	"group",
@@ -170,6 +189,8 @@ interface GraphSegmentProps extends ComponentProps<"span"> {
 	/** The rail above or below the icon in another status's colour; a stretch between two icons is the lower one's. */
 	above?: GraphSegmentStatus;
 	below?: GraphSegmentStatus;
+	/** Bend from the trunk one column left into this commit's ring. */
+	fromTrunk?: boolean;
 	/** How many columns of the main line run behind the row, left of the glyph. */
 	behind?: number;
 }
@@ -183,6 +204,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 	centered = false,
 	above,
 	below,
+	fromTrunk = false,
 	behind = 0,
 	...props
 }) => (
@@ -195,18 +217,25 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 					styles.mainSegment,
 					glyph === "group" && !centered && styles.groupSegment,
 				)}
-				viewBox={glyph === "group" && !centered ? "0 0 16 26" : "0 0 16 28"}
+				viewBox={
+					fromTrunk
+						? `0 ${-GRAPH_COMMIT_BEND_PADDING} 16 ${28 + GRAPH_COMMIT_BEND_PADDING}`
+						: glyph === "group" && !centered
+							? "0 0 16 26"
+							: "0 0 16 28"
+				}
+				style={fromTrunk ? commitBendStyle : undefined}
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 				aria-hidden="true"
 				focusable="false"
 			>
-				{railEnds && glyph === "commit" ? (
-					commitFootGlyph
+				{glyph === "commit" ? (
+					commitGlyph(above, below, railEnds, fromTrunk)
 				) : railEnds && glyph === "group" && centered ? (
 					groupCenteredFootGlyph
-				) : glyph === "commit" ? (
-					commitGlyph(below)
+				) : railEnds && glyph === "hook" ? (
+					<path className={styles.line} d={`${hookHeadPath}H8`} strokeWidth="1.5" />
 				) : glyph === "joinRight" ? (
 					joinRightGlyph(above, below)
 				) : glyph === "parent" ? (
@@ -241,22 +270,20 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 	</span>
 );
 
-const ARC_K = 0.5523;
-const n = (value: number): string => String(Math.round(value * 100) / 100);
-
 /**
  * The bend from the column right of the main line onto it, through a gap of
- * this height: two quarter turns of radius 4 joined by a straight, meeting the
+ * this height: two quarter turns joined by a straight, meeting the
  * line at the gap's foot.
  */
 const bendPath = (height: number): string => {
-	const r = 4;
+	const r = Math.min(4, GRAPH_LANE_WIDTH / 2, height / 2);
 	const k = ARC_K * r;
 	const my = height / 2;
+	const from = 8 + GRAPH_LANE_WIDTH;
 	return [
-		`M20 0 V${n(my - r)}`,
-		`C20 ${n(my - r + k)} ${n(20 - (r - k))} ${n(my)} 16 ${n(my)}`,
-		`L12 ${n(my)}`,
+		`M${from} 0 V${n(my - r)}`,
+		`C${from} ${n(my - r + k)} ${n(from - (r - k))} ${n(my)} ${from - r} ${n(my)}`,
+		`L${8 + r} ${n(my)}`,
 		`C${n(8 + (r - k))} ${n(my)} 8 ${n(my + r - k)} 8 ${n(my + r)}`,
 		`V${n(height)}`,
 	].join(" ");
@@ -307,15 +334,16 @@ export const GraphEdge: FC<{ glyph: keyof typeof edgePaths }> = ({ glyph }) => (
  * `behind`, the gap sits that far right, the lines behind it passing through;
  * with none, the main line is the trunk on the panel's edge.
  */
-export const GraphGap: FC<{ height: number; bend?: GraphSegmentStatus; behind?: number }> = ({
-	height,
-	bend,
-	behind = 0,
-}) => (
+export const GraphGap: FC<{
+	height: number;
+	bend?: GraphSegmentStatus;
+	behind?: number;
+}> = ({ height, bend, behind = 0 }) => (
 	<div className={styles.gap} style={{ height }} aria-hidden>
 		{passes(behind)}
 		<svg
 			viewBox={`0 0 28 ${height}`}
+			style={behind === 0 ? gapInsetStyle : undefined}
 			width="28"
 			height={height}
 			fill="none"

--- a/apps/lite/ui/src/components/graph-spacing.ts
+++ b/apps/lite/ui/src/components/graph-spacing.ts
@@ -1,0 +1,8 @@
+/** Horizontal distance between graph lanes, in pixels. */
+export const GRAPH_LANE_WIDTH = 6;
+
+/** Left padding before the uncommitted files' trunk, in pixels. */
+export const GRAPH_TRUNK_INSET = 9;
+
+/** Extra room above a commit when its incoming line bends from the trunk. */
+export const GRAPH_COMMIT_BEND_PADDING = 6;

--- a/apps/lite/ui/src/projects/graph.ts
+++ b/apps/lite/ui/src/projects/graph.ts
@@ -1,18 +1,22 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 /**
- * The stacks graph's fold state: what the upstream section below the cards
- * shows. Its rows share the applied list's cursor.
+ * Fold state for the upstream and History sections below the stacks.
+ * Their rows share the applied list's cursor.
  */
 export type GraphState = {
 	/** The target header's fold: the commits incoming from the target. */
 	incomingExpanded: boolean;
+	historyExpanded: boolean;
+	moreHistory: number;
 	/** How many times more of each run was asked for, keyed by the run's newest commit id. */
 	moreRuns: Record<string, number>;
 };
 
 const initialState = (): GraphState => ({
 	incomingExpanded: false,
+	historyExpanded: false,
+	moreHistory: 0,
 	moreRuns: {},
 });
 
@@ -22,6 +26,14 @@ const graphSlice = createSlice({
 	reducers: {
 		toggleIncoming: (state) => {
 			state.incomingExpanded = !state.incomingExpanded;
+		},
+		toggleHistory: (state) => {
+			state.historyExpanded = !state.historyExpanded;
+			if (!state.historyExpanded) state.moreHistory = 0;
+		},
+		showMoreHistory: (state) => {
+			if (!state.historyExpanded) return;
+			state.moreHistory += 1;
 		},
 		showMoreRun: (state, { payload: { runId } }: PayloadAction<{ runId: string }>) => {
 			state.moreRuns[runId] = (state.moreRuns[runId] ?? 0) + 1;
@@ -38,6 +50,12 @@ const graphSlice = createSlice({
 export const createInitialGraphState = (): GraphState => graphSlice.getInitialState();
 
 export const graphReducers = {
+	toggleHistory: (state: GraphState) => {
+		graphSlice.caseReducers.toggleHistory(state);
+	},
+	showMoreHistory: (state: GraphState) => {
+		graphSlice.caseReducers.showMoreHistory(state);
+	},
 	toggleIncoming: (state: GraphState) => {
 		graphSlice.caseReducers.toggleIncoming(state);
 	},

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -183,6 +183,12 @@ export const projectReducers = {
 	toggleGraphIncoming: (state: ProjectState) => {
 		graphReducers.toggleIncoming(state.graph);
 	},
+	toggleGraphHistory: (state: ProjectState) => {
+		graphReducers.toggleHistory(state.graph);
+	},
+	showMoreGraphHistory: (state: ProjectState) => {
+		graphReducers.showMoreHistory(state.graph);
+	},
 	showMoreGraphRun: (state: ProjectState, { runId }: { runId: string }) => {
 		graphReducers.showMoreRun(state.graph, { runId });
 	},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -5,6 +5,7 @@
 	justify-content: center;
 	width: 16px;
 	height: var(--single-line-row-height);
+	translate: var(--row-fold-chevron-offset, 0px);
 	color: var(--text-2);
 }
 
@@ -34,11 +35,28 @@
 	overflow: hidden;
 }
 
-/* A card like a forked stack card's, for the worktree cards under the stacks
-   (WorktreeLane). Keep in sync with StackCard.module.css. */
+/* Shared with the worktree cards below the stacks. Keep in sync with StackCard.module.css. */
+.card,
+.cardHead,
+.cardBody {
+	--graph-through-visibility: hidden;
+
+	background-color: var(--bg-1);
+}
+
 .card {
 	border-block: 1px solid var(--border-section);
-	background-color: var(--bg-1);
+}
+
+/* Split around the dock marker so the sticky stand-in keeps the full list
+   as its containing block. */
+.cardHead {
+	padding-block-start: 4px;
+	border-block-start: 1px solid var(--border-section);
+}
+
+.cardBody {
+	border-block-end: 1px solid var(--border-section);
 }
 
 /* The card's air over its header, as a row of gutter. */
@@ -87,11 +105,12 @@
 	}
 }
 
-/* A quiet note beside a header's label. */
-.caption {
-	margin-inline-start: 8px;
-	color: var(--text-3);
-	font-weight: 400;
+.trunkHeader {
+	--row-fold-chevron-offset: -6px;
+}
+
+.header {
+	--row-label-offset: calc(-3px + var(--row-fold-chevron-offset, 0px));
 }
 
 /* Centred on the label line, so the row keeps its height. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createRef, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { assert } from "#ui/assert.ts";
+import { Section } from "./Section.tsx";
+import type { Plan } from "./layout.ts";
+import type { Graph } from "./usePlan.ts";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+vi.mock("#ui/hotkeys.ts", () => ({
+	workspaceHotkeys: { fetchFromRemotes: { hotkey: "F", meta: { name: "Fetch" } } },
+}));
+vi.mock("#ui/components/Kbd.tsx", () => ({ Kbd: () => null }));
+vi.mock("#ui/components/Tooltip.tsx", () => ({
+	TooltipPopup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("#ui/api/mutations.ts", () => ({
+	useWorkspaceIntegrateUpstream: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+vi.mock("#ui/projects/state.ts", () => ({
+	projectSlice: { selectors: { selectPendingOperation: () => ({ _tag: "None" }) } },
+}));
+vi.mock("#ui/store.ts", () => ({
+	useAppSelector: (select: (state: object) => unknown) => select({}),
+}));
+vi.mock("#ui/routes/project/$id/workspace/WorkspaceLists/context.tsx", () => ({
+	useAddressSpace: () => ({ items: [], indexByKey: new Map() }),
+}));
+vi.mock("#ui/routes/project/$id/workspace/useFetchFromRemotes.ts", () => ({
+	useFetchFromRemotes: () => ({ fetch: vi.fn(), isPending: false, enabled: true }),
+}));
+vi.mock("./TargetCommitRow.tsx", () => ({ TargetCommitRow: () => null }));
+
+let root: Root;
+let container: HTMLDivElement;
+let client: QueryClient;
+const onMore = vi.fn();
+const plan: Plan = {
+	order: [],
+	header: { label: "origin/main", current: false, incoming: 0 },
+	incomingExpanded: false,
+	incoming: [],
+	historyAvailable: true,
+	historyExpanded: true,
+	history: [],
+	historyHidden: 20,
+	worktrees: { on: new Map(), standalone: [] },
+};
+
+beforeEach(() => {
+	onMore.mockReset();
+	client = new QueryClient({ defaultOptions: { queries: { retry: false, enabled: false } } });
+	container = document.createElement("div");
+	document.body.append(container);
+	root = createRoot(container);
+});
+afterEach(async () => {
+	await act(async () => root.unmount());
+	client.clear();
+	container.remove();
+});
+const render = async (historyMore: Graph["historyMore"] = "idle", current = false) => {
+	await act(async () => {
+		root.render(
+			<QueryClientProvider client={client}>
+				<Section
+					projectId="section-test"
+					plan={{ ...plan, header: { ...assert(plan.header), current } }}
+					onToggleIncoming={vi.fn()}
+					onToggleHistory={vi.fn()}
+					onShowMoreHistory={onMore}
+					historyMore={historyMore}
+					onShowMoreRun={vi.fn()}
+					onFoldRun={vi.fn()}
+					scrollElementRef={createRef<HTMLDivElement>()}
+				/>
+			</QueryClientProvider>,
+		);
+	});
+};
+const more = () => assert(container.querySelector<HTMLElement>('[role="button"]'));
+
+it("keeps the update action on a stale target with no incoming commits", async () => {
+	await render();
+	expect(container.textContent).toContain("Pull latest");
+	expect(container.querySelector('[aria-label="Unfold incoming commits"]')).toBeNull();
+	expect(container.textContent).not.toContain("Workspace base");
+	await render("idle", true);
+	expect(container.textContent).not.toContain("Pull latest");
+});
+
+it.each(["idle", "failed"] as const)(
+	"makes the %s History action focusable and keyboard-activatable",
+	async (state) => {
+		await render(state);
+		const button = more();
+		expect(button.tabIndex).toBe(0);
+		for (const key of ["Enter", " "]) {
+			await act(async () => {
+				button.focus();
+				button.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+				button.dispatchEvent(new KeyboardEvent("keyup", { key, bubbles: true }));
+			});
+		}
+		expect(onMore).toHaveBeenCalledTimes(2);
+	},
+);
+
+it("does not activate History pagination while a page is loading", async () => {
+	await render("loading");
+	const button = more();
+	expect(button.getAttribute("aria-disabled")).toBe("true");
+	await act(async () => {
+		button.focus();
+		button.click();
+		button.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+	});
+	expect(onMore).not.toHaveBeenCalled();
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -1,4 +1,4 @@
-import { GraphGap, GraphSegment } from "#ui/components/GraphSegment.tsx";
+import { GraphGap, GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
@@ -28,24 +28,36 @@ import { useQuery } from "@tanstack/react-query";
 import { type FC, type ReactNode, type RefObject, useRef, useState } from "react";
 import styles from "./Section.module.css";
 import { TargetCommitRow } from "./TargetCommitRow.tsx";
-import { LEG_GAP, type Plan, type Run, targetCommitAddress } from "./layout.ts";
+import {
+	CARD_GAP,
+	HEAD_DOCKED_HEIGHT,
+	LEG_GAP,
+	type Plan,
+	type Run,
+	targetCommitAddress,
+} from "./layout.ts";
+import type { Graph } from "./usePlan.ts";
 
 /*
  * The upstream section under the stacks: the target's row, standing for the
  * workspace's base, folding the incoming commits when the target has moved
- * on. No card around it: the target is not in the workspace, and its rows
- * sit on the panel itself to say so. Commit rows are values on the applied
- * cursor; the header is not.
+ * on. Expanded, the header and incoming commits form a card. Commit rows are
+ * values on the applied cursor; the header is not. History opens independently,
+ * continuing from the workspace's shared target commits into older pages.
  *
- * The trunk runs down the panel's edge past the target's row, its tail
- * fading below it, or to where the target's leg rejoins it. Scrolled out of
- * view below, a stand-in for the row docks at the scroller's foot, so the
- * target is always in reach: a sticky mark of no height right after the row,
- * stuck exactly while the row is below the viewport.
+ * When the target's row is below the viewport, a stand-in docks at the
+ * scroller's foot to keep it in reach. A sticky mark of no height right after
+ * the row determines when the stand-in appears.
  */
 
 // The rows sit in the column beside the trunk. Rows a pending operation drops from the list are inert.
-const commitRow = (commit: TargetCommit, addressSpace: AddressSpace<Address>) => {
+const commitRow = (
+	commit: TargetCommit,
+	addressSpace: AddressSpace<Address>,
+	railEnds = false,
+	above?: GraphSegmentStatus,
+	fromTrunk = false,
+) => {
 	const index = addressSpace.indexByKey.get(addressIdentityKey(targetCommitAddress(commit)));
 	return (
 		<TargetCommitRow
@@ -53,7 +65,10 @@ const commitRow = (commit: TargetCommit, addressSpace: AddressSpace<Address>) =>
 			commit={commit}
 			positionInSet={(index ?? -1) + 1}
 			setSize={addressSpace.items.length}
-			behind={1}
+			behind={commit.inWorkspace ? 0 : 1}
+			railEnds={railEnds}
+			above={above}
+			fromTrunk={fromTrunk}
 			inert={index === undefined}
 		/>
 	);
@@ -82,8 +97,8 @@ const Header: FC<{
 	label: string;
 	/** Beside the label, in the label's own line: a count, or a note. */
 	caption?: ReactNode;
-	/** The fold the header opens; none for a plain row. Its chevron swaps in for the glyph on hover, unless the glyph is one. */
-	fold?: { open: boolean; onToggle: () => void; name: string; hoverChevron?: boolean };
+	/** The fold the header opens; none for a plain row. */
+	fold?: { open: boolean; onToggle: () => void; name: string; chevron?: "always" | "none" };
 	/** The row's gutter. */
 	rail: ReactNode;
 	/** At the row's end, past the label. */
@@ -100,7 +115,7 @@ const Header: FC<{
 				glyph={rail}
 				aria-label={`${fold.open ? "Fold" : "Unfold"} ${fold.name}`}
 				onClick={fold.onToggle}
-				hoverChevron={fold.hoverChevron}
+				chevron={fold.chevron ?? "always"}
 			/>
 		)}
 		<RowLabelContainer>
@@ -119,8 +134,12 @@ const Elided: FC<{ run: Run; onMore: () => void; onFold: () => void }> = ({
 	onMore,
 	onFold,
 }) => (
-	// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A row that reveals or folds, styled as the rows around it.
-	<Row role="button" onSelect={run.hidden > 0 ? onMore : onFold} aria-expanded={run.expanded}>
+	<Button
+		render={<Row />}
+		nativeButton={false}
+		onClick={run.hidden > 0 ? onMore : onFold}
+		aria-expanded={run.expanded}
+	>
 		<GraphSegment
 			glyph={run.hidden > 0 ? "group" : "parent"}
 			status="Upstream"
@@ -132,7 +151,7 @@ const Elided: FC<{ run: Run; onMore: () => void; onFold: () => void }> = ({
 				{run.hidden === 0 ? "Show fewer" : `${run.hidden} more`}
 			</RowLabel>
 		</RowLabelContainer>
-	</Row>
+	</Button>
 );
 
 const Fold: FC<{
@@ -144,6 +163,28 @@ const Fold: FC<{
 		<div className={styles.foldInner}>{children}</div>
 	</div>
 );
+
+const MoreHistory: FC<{ state: Graph["historyMore"]; onMore: () => void }> = ({ state, onMore }) =>
+	state === "hidden" ? null : (
+		<Button
+			render={<Row />}
+			nativeButton={false}
+			onClick={onMore}
+			disabled={state === "loading"}
+			focusableWhenDisabled
+		>
+			<GraphSegment glyph="group" status="Integrated" centered railEnds />
+			<RowLabelContainer>
+				<RowLabel singleLine className={styles.elided}>
+					{state === "loading"
+						? "Loading…"
+						: state === "failed"
+							? "Could not load history — retry"
+							: "Show more"}
+				</RowLabel>
+			</RowLabelContainer>
+		</Button>
+	);
 
 const runRows = (
 	run: Run,
@@ -222,11 +263,24 @@ export const Section: FC<{
 	projectId: string;
 	plan: Plan;
 	onToggleIncoming: () => void;
+	onToggleHistory: () => void;
+	onShowMoreHistory: () => void;
+	historyMore: Graph["historyMore"];
 	onShowMoreRun: (runId: string) => void;
 	onFoldRun: (runId: string) => void;
 	/** The scroller, for the docked row's toggle to scroll to its place. */
 	scrollElementRef: RefObject<HTMLDivElement | null>;
-}> = ({ projectId, plan, onToggleIncoming, onShowMoreRun, onFoldRun, scrollElementRef }) => {
+}> = ({
+	projectId,
+	plan,
+	onToggleIncoming,
+	onToggleHistory,
+	onShowMoreHistory,
+	historyMore,
+	onShowMoreRun,
+	onFoldRun,
+	scrollElementRef,
+}) => {
 	const addressSpace = useAddressSpace();
 	// One mutation for the row and its docked stand-in: each rendering its own
 	// would leave the other's button enabled while a pull runs.
@@ -252,10 +306,17 @@ export const Section: FC<{
 		const fold = incomingFold.current;
 		const rows = incomingRows.current;
 		if (!plan.incomingExpanded && scroller !== null && fold !== null && rows !== null) {
-			scroller.scrollTop = scroller.scrollHeight;
+			const reveal = () => {
+				const height = Math.min(fold.offsetHeight, scroller.clientHeight - HEAD_DOCKED_HEIGHT - 28);
+				scroller.scrollTop += Math.max(
+					0,
+					fold.getBoundingClientRect().top + height - scroller.getBoundingClientRect().bottom,
+				);
+			};
+			reveal();
 			let height = 0;
 			const hold = new ResizeObserver(() => {
-				scroller.scrollTop = scroller.scrollHeight;
+				reveal();
 				// Lets go once the fold has grown to its rows, or shrinks: folded again midway.
 				if (fold.offsetHeight >= rows.offsetHeight || fold.offsetHeight < height) hold.disconnect();
 				height = fold.offsetHeight;
@@ -267,26 +328,19 @@ export const Section: FC<{
 	const target = plan.header;
 	if (target === null) return null;
 	const branched = target.incoming > 0;
+	const expanded = branched && plan.incomingExpanded;
+	const continuesToHistory = expanded && plan.historyAvailable;
 	/** The target's row. The docked stand-in, with no line to show, wears a chevron instead of the rail. */
 	const header = (docked = false) => (
 		<Header
 			label={target.label}
 			caption={
-				branched ? (
+				branched && (
 					<Caption
 						className={styles.incoming}
 						hint={`${target.incoming === 1 ? "A commit" : "Commits"} on ${target.label} not yet in the workspace`}
 					>
 						{target.incoming} new
-					</Caption>
-				) : (
-					// Nothing incoming, yet the base may still trail the target: a lane can
-					// already hold the target's newest commits.
-					<Caption
-						className={styles.caption}
-						hint={target.current ? "Up to date" : `Behind ${target.label}`}
-					>
-						Workspace base
 					</Caption>
 				)
 			}
@@ -296,26 +350,33 @@ export const Section: FC<{
 							open: plan.incomingExpanded,
 							onToggle: toggleIncoming,
 							name: "incoming commits",
-							hoverChevron: !docked,
+							chevron: docked ? "none" : "always",
 						}
 					: undefined
 			}
 			rail={
 				docked ? (
 					<span className={styles.chevron}>
-						<Icon name={plan.incomingExpanded ? "chevron-down" : "chevron-right"} />
+						{branched && <Icon name={plan.incomingExpanded ? "chevron-down" : "chevron-right"} />}
 					</span>
-				) : branched ? (
-					// The incoming commits' leg forks off the row, the trunk running on behind.
+				) : expanded ? (
 					<GraphSegment glyph="forkRight" status="Upstream" behind={1} />
 				) : (
-					// The trunk runs on past the row with a tick at it, its tail fading out:
-					// the history below is not shown, but this is not where it starts.
-					<GraphSegment glyph="notch" status="LocalOnly" behind={1} folded />
+					<GraphSegment
+						glyph={branched ? "notch" : "space"}
+						status={branched ? "Upstream" : "LocalOnly"}
+						behind={1}
+						folded={!plan.historyAvailable}
+					/>
 				)
 			}
 			toolbar={<Fetch projectId={projectId} />}
-			className={docked ? styles.docked : undefined}
+			className={classes(
+				styles.header,
+				!expanded && styles.trunkHeader,
+				docked && styles.docked,
+				!docked && expanded && styles.cardHead,
+			)}
 		>
 			{!target.current && (
 				<Pull
@@ -327,9 +388,7 @@ export const Section: FC<{
 			)}
 		</Header>
 	);
-	// With the target moved on, its incoming commits sit on a leg that starts
-	// at its row and bends onto the trunk in the gap below; its row says how
-	// many are new and pulls them, so seeing and acting sit together.
+	// The upstream leg rejoins the trunk below its card; History stays on the trunk.
 	return (
 		<>
 			{header()}
@@ -337,7 +396,7 @@ export const Section: FC<{
 			{branched && (
 				<>
 					<Fold open={plan.incomingExpanded} ref={incomingFold}>
-						<div ref={incomingRows} className={styles.rows}>
+						<div ref={incomingRows} className={classes(styles.rows, expanded && styles.cardBody)}>
 							{plan.incoming.map((run) =>
 								runRows(
 									run,
@@ -346,9 +405,46 @@ export const Section: FC<{
 									() => onFoldRun(run.id),
 								),
 							)}
+							{expanded && (
+								<Row interactive={false} className={styles.stub}>
+									<GraphSegment glyph="parent" status="Upstream" behind={1} />
+								</Row>
+							)}
 						</div>
 					</Fold>
-					<GraphGap height={LEG_GAP} bend="Upstream" />
+					<GraphGap
+						height={expanded ? CARD_GAP : LEG_GAP}
+						bend={continuesToHistory ? "LocalOnly" : expanded ? "Upstream" : undefined}
+					/>
+				</>
+			)}
+			{plan.historyAvailable && (
+				<>
+					<Header
+						label="History"
+						className={classes(styles.header, styles.trunkHeader)}
+						fold={{ open: plan.historyExpanded, onToggle: onToggleHistory, name: "history" }}
+						rail={
+							<GraphSegment
+								glyph={plan.historyExpanded ? "space" : "hook"}
+								behind={plan.historyExpanded ? 1 : 0}
+								status="LocalOnly"
+								railEnds={!plan.historyExpanded}
+							/>
+						}
+					/>
+					<Fold open={plan.historyExpanded}>
+						{plan.history.map((commit, index) =>
+							commitRow(
+								commit,
+								addressSpace,
+								historyMore === "hidden" && index === plan.history.length - 1,
+								index === 0 ? "LocalOnly" : undefined,
+								index === 0,
+							),
+						)}
+						{plan.historyExpanded && <MoreHistory state={historyMore} onMore={onShowMoreHistory} />}
+					</Fold>
 				</>
 			)}
 		</>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.module.css
@@ -1,10 +1,3 @@
-.label {
-	display: flex;
-	flex-grow: 1;
-	flex-direction: column;
-	min-width: 0;
-}
-
 .labelMeta {
 	display: flex;
 	align-items: center;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.tsx
@@ -2,15 +2,17 @@ import rowStyles from "../Row.module.css";
 import { setCursor } from "#ui/use-cursor.ts";
 import { commitTitle } from "#ui/commit.ts";
 import { classes } from "#ui/components/classes.ts";
-import { GraphSegment } from "#ui/components/GraphSegment.tsx";
-import { Icon } from "#ui/components/Icon.tsx";
+import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
+import { GRAPH_COMMIT_BEND_PADDING } from "#ui/components/graph-spacing.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import type { TargetCommit } from "@gitbutler/but-sdk";
 import { type FC, useState } from "react";
-import { Row, RowLabel, RowLabelContainer, RowLabelFooter } from "../Row.tsx";
+import { Row, RowLabel, RowLabelContainer, RowLabelFooter, RowLabelGroup } from "../Row.tsx";
 import { treeItemId, useIsSelected } from "../Row-utils.ts";
 import { targetCommitAddress } from "./layout.ts";
 import styles from "./TargetCommitRow.module.css";
+
+const commitBendLabelStyle = { paddingBlockStart: GRAPH_COMMIT_BEND_PADDING };
 
 /** A target commit in the stacks graph's upstream section: a value on the applied cursor. */
 export const TargetCommitRow: FC<{
@@ -21,7 +23,19 @@ export const TargetCommitRow: FC<{
 	inert?: boolean;
 	/** Columns of the main line running behind the row, left of its rail. */
 	behind?: number;
-}> = ({ commit: targetCommit, positionInSet, setSize, inert, behind }) => {
+	railEnds?: boolean;
+	above?: GraphSegmentStatus;
+	fromTrunk?: boolean;
+}> = ({
+	commit: targetCommit,
+	positionInSet,
+	setSize,
+	inert,
+	behind,
+	railEnds,
+	above,
+	fromTrunk,
+}) => {
 	const { commit, review } = targetCommit;
 	const address = targetCommitAddress(targetCommit);
 	const isSelected = useIsSelected(address, "applied");
@@ -46,8 +60,15 @@ export const TargetCommitRow: FC<{
 			scrollSelectedIntoView
 			onSelect={() => setCursor("applied", address)}
 		>
-			<GraphSegment glyph="commit" status="Upstream" behind={behind} />
-			<div className={styles.label}>
+			<GraphSegment
+				glyph="commit"
+				status={targetCommit.inWorkspace ? "Integrated" : "Upstream"}
+				above={above}
+				fromTrunk={fromTrunk}
+				behind={behind}
+				railEnds={railEnds}
+			/>
+			<RowLabelGroup style={fromTrunk ? commitBendLabelStyle : undefined}>
 				<RowLabelContainer>
 					<RowLabel singleLine>
 						{title === undefined ? (
@@ -65,19 +86,8 @@ export const TargetCommitRow: FC<{
 						{authorName !== "" && <>{authorName} </>}
 						<RelativeTime timestamp={commit.committedAt} now={now} />
 					</span>
-
-					{review !== null && (
-						<span
-							title={review.title}
-							className={classes(rowStyles.fadedText, styles.labelMetaItem)}
-						>
-							<Icon name="pr" />
-							{review.unitSymbol}
-							{review.number}
-						</span>
-					)}
 				</RowLabelFooter>
-			</div>
+			</RowLabelGroup>
 		</Row>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -9,9 +9,10 @@ import type {
 import { describe, expect, it } from "vitest";
 import type { Address } from "#ui/addresses.ts";
 import {
-	inSection,
+	foldAt,
 	layout,
 	sectionAddresses,
+	foldAddresses,
 	targetCommitAddress,
 	worktreesOnTip,
 } from "./layout.ts";
@@ -90,7 +91,12 @@ const target = (isCurrent: boolean): Target => ({
 	isCurrent,
 });
 
-const folded: Folds = { incomingExpanded: false, moreRuns: {} };
+const folded: Folds = {
+	incomingExpanded: false,
+	historyExpanded: false,
+	moreHistory: 0,
+	moreRuns: {},
+};
 const expanded: Folds = { ...folded, incomingExpanded: true };
 
 // Newest first: two incoming, a shallow base, three had, a deep base.
@@ -114,6 +120,92 @@ const incomingAbove = (ids: Array<string>): TargetCommitPage => ({
 });
 
 describe("layout", () => {
+	it("keeps History independent of the incoming fold and includes the base commit", () => {
+		const closed = layout([stack("deep")], target(false), listing, folded);
+		expect(closed.history).toEqual([]);
+		const plan = layout([stack("deep")], target(false), listing, {
+			...folded,
+			historyExpanded: true,
+		});
+		expect(plan.history.map((entry) => entry.commit.id)).toEqual([
+			"shallow",
+			"h1",
+			"h2",
+			"h3",
+			"deep",
+		]);
+		expect(plan.incoming).toEqual([]);
+		expect(plan.header).toEqual(closed.header);
+		expect(sectionAddresses(plan)).toEqual(plan.history.map(targetCommitAddress));
+		expect(foldAt(plan, targetCommitAddress(commit("h1", true)))).toBe("history");
+		expect(foldAt(closed, targetCommitAddress(commit("h1", true)))).toBeNull();
+	});
+
+	it("walks incoming commits before History and closes only the selected fold", () => {
+		const plan = layout([], target(false), listing, { ...expanded, historyExpanded: true });
+		expect(sectionAddresses(plan)).toEqual(listing.commits.map(targetCommitAddress));
+		expect(foldAddresses(plan, "incoming")).toEqual(
+			listing.commits.slice(0, 2).map(targetCommitAddress),
+		);
+		expect(foldAddresses(plan, "history")).toEqual(
+			listing.commits.slice(2).map(targetCommitAddress),
+		);
+		expect(foldAt(plan, targetCommitAddress(commit("i1", false)))).toBe("incoming");
+		expect(foldAt(plan, targetCommitAddress(commit("h1", true)))).toBe("history");
+	});
+
+	it("hides History while loading or when there is no target", () => {
+		expect(layout([], target(true), undefined, folded).historyAvailable).toBe(false);
+		expect(layout([], null, { commits: [], hasMore: false }, folded).historyAvailable).toBe(false);
+		expect(layout([], target(true), listing, folded).historyAvailable).toBe(true);
+	});
+
+	it("offers a way to discover History beyond a clipped incoming page", () => {
+		const clipped = { commits: [commit("incoming", false)], hasMore: true };
+		expect(layout([], target(false), clipped, folded).historyAvailable).toBe(true);
+		expect(layout([], target(false), { ...clipped, hasMore: false }, folded).historyAvailable).toBe(
+			false,
+		);
+	});
+
+	it("excludes cached older commits when the target no longer has shared history", () => {
+		const plan = layout(
+			[],
+			target(false),
+			{ commits: [commit("unrelated", false)], hasMore: false },
+			{ ...folded, historyExpanded: true },
+			[],
+			[commit("cached", true)],
+		);
+		expect(plan.historyAvailable).toBe(false);
+		expect(plan.history).toEqual([]);
+		expect(sectionAddresses(plan)).toEqual([]);
+	});
+
+	it("never puts incoming continuation commits in History", () => {
+		const plan = layout(
+			[],
+			target(false),
+			listing,
+			{ ...folded, historyExpanded: true, moreHistory: 1 },
+			[],
+			[commit("incoming", false), commit("older", true)],
+		);
+		expect(plan.history.every((entry) => entry.inWorkspace)).toBe(true);
+	});
+
+	it("reveals older History in pages without changing the upstream count", () => {
+		const older = Array.from({ length: 30 }, (_, i) => commit(`older${i}`, true));
+		const open = { ...folded, historyExpanded: true, moreHistory: 0 };
+		const plan = layout([], target(false), listing, open, [], older);
+		expect(plan.history).toHaveLength(5);
+		expect(plan.historyHidden).toBe(30);
+		expect(plan.header?.incoming).toBe(2);
+		const more = layout([], target(false), listing, { ...open, moreHistory: 1 }, [], older);
+		expect(more.history).toHaveLength(25);
+		expect(more.historyHidden).toBe(10);
+	});
+
 	it("orders cards by base depth, deepest first, then as given", () => {
 		const plan = layout([stack("deep"), stack("shallow"), stack("deep")], null, listing, folded);
 		expect(plan.order).toEqual([0, 2, 1]);
@@ -143,10 +235,10 @@ describe("layout", () => {
 			addresses.map((address) => (address._tag === "Commit" ? address.commitId : address._tag));
 		// The incoming commits only: the workspace's own commits and the header are not values.
 		expect(ids(sectionAddresses(plan))).toEqual(["i1", "i2"]);
-		const at = (id: string) => inSection(plan, targetCommitAddress(commit(id, true)));
-		expect(at("i1")).toBe(true);
-		expect(at("deep")).toBe(false);
-		expect(at("h1")).toBe(false);
+		const at = (id: string) => foldAt(plan, targetCommitAddress(commit(id, true)));
+		expect(at("i1")).toBe("incoming");
+		expect(at("deep")).toBeNull();
+		expect(at("h1")).toBeNull();
 	});
 
 	it("shows an incoming run's newest first, more with each ask, unless a fold would hide one row", () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -1,12 +1,13 @@
 import { addressEquals, commitAddress, type Address } from "#ui/addresses.ts";
 import { assert } from "#ui/assert.ts";
 import { remoteTrackingLabel } from "#ui/branch.ts";
+import { GRAPH_LANE_WIDTH, GRAPH_TRUNK_INSET } from "#ui/components/graph-spacing.ts";
 import type { RefInfo, Stack, TargetCommit, TargetCommitPage, Worktree } from "@gitbutler/but-sdk";
 
 /*
  * The stacks section as a graph: card order and which section rows show. Pure.
  *
- * One main line, the trunk, runs up the panel's edge from below the target's
+ * One main line, the trunk, runs up near the panel's edge from below the target's
  * row to the uncommitted files. Every stack card, and a moved-on target's, sits in
  * the column beside it and bends onto it in the gap under it. Rows draw their
  * own gutters, a column each for the lines behind them and the glyph
@@ -14,14 +15,10 @@ import type { RefInfo, Stack, TargetCommit, TargetCommitPage, Worktree } from "@
  */
 
 /**
- * The rows' inset in the graph. The trunk's column sits one 12px column left
- * of it, so its line, 8px in, is centred at x = 1 on the panel's edge, and the
- * first glyph column starts here. Whole pixels throughout: SVGs snap to them
- * where CSS boxes do not, and a fractional inset puts the two out of step. The
- * uncommitted files card carries no inset: the edge column is its whole
- * gutter (GraphEdge).
+ * GraphEdge's line is 1px into its canvas; regular glyphs are 8px in.
+ * Leave one lane between them while keeping the trunk at its shared inset.
  */
-export const ROW_INSET = 12 - 8 + 1;
+export const ROW_INSET = GRAPH_TRUNK_INSET + 1 + GRAPH_LANE_WIDTH - 8;
 /** The gap under a card, tall enough for a line to bend through. */
 export const CARD_GAP = 20;
 /** The gap under a worktree lane, which its line bends through. */
@@ -32,13 +29,16 @@ export const TIP_GAP = 8;
 export const DOCKED_HEIGHT = 1 + 4 + 28 + 4;
 /** The stuck uncommitted files row's height: the card's head room, a row and a hairline. Keep in sync with WorkspaceLists.module.css. */
 export const HEAD_DOCKED_HEIGHT = 6 + 28 + 1;
-/** A long run shows this much at first, and this much more with each ask. */
-const FIRST = 10;
-const MORE = 20;
+const FIRST_INCOMING = 10;
+const FIRST_HISTORY = 5;
+/** Additional commits revealed with each ask. */
+export const MORE_COMMITS = 20;
 
 type Folds = {
 	/** The target header's fold: the commits incoming from the target. */
 	incomingExpanded: boolean;
+	historyExpanded: boolean;
+	moreHistory: number;
 	/** How many times more of each run was asked for, by the run's id. */
 	moreRuns: Readonly<Record<string, number>>;
 };
@@ -86,6 +86,11 @@ export type Plan = {
 	incomingExpanded: boolean;
 	/** Commits on the target the workspace lacks, on their leg. Empty while folded. */
 	incoming: Array<Run>;
+	historyAvailable: boolean;
+	historyExpanded: boolean;
+	/** The workspace's target history, starting at its newest shared commit. */
+	history: Array<TargetCommit>;
+	historyHidden: number;
 	worktrees: WorktreePlacement;
 };
 
@@ -119,7 +124,7 @@ const incomingRuns = (line: ReadonlyArray<TargetItem>, folds: Folds): Array<Run>
 		if (item.type === "fork" || item.inWorkspace) return [];
 		const id = assert(item.commits[0]).commit.id;
 		const asked = folds.moreRuns[id] ?? 0;
-		const asFar = FIRST + asked * MORE;
+		const asFar = FIRST_INCOMING + asked * MORE_COMMITS;
 		const count = item.commits.length - asFar <= 1 ? item.commits.length : asFar;
 		return [
 			{
@@ -171,17 +176,19 @@ export const worktreesOnTip = (
 	return worktrees.on.get(tip.id) ?? [];
 };
 
-export const layout = (
-	stacks: ReadonlyArray<Stack>,
-	target: RefInfo["target"],
-	listing: TargetCommitPage | undefined,
-	folds: Folds,
-	worktrees: ReadonlyArray<Worktree> = [],
-): Plan => {
-	const commits = listing?.commits ?? [];
-	const line = segmentAtForks(commits, stacks);
-	const forkOrder = line.flatMap((item) => (item.type === "fork" ? [item.commit.commit.id] : []));
+/** A clipped listing may not have reached the shared base yet. */
+export const canLoadHistory = (listing: TargetCommitPage | undefined): boolean =>
+	listing !== undefined &&
+	(listing.hasMore || listing.commits.some((commit) => commit.inWorkspace));
 
+/** Stack placement is independent of the folds and older History pages. */
+export const layoutStructure = (
+	stacks: ReadonlyArray<Stack>,
+	listing: TargetCommitPage | undefined,
+	worktrees: ReadonlyArray<Worktree>,
+) => {
+	const line = segmentAtForks(listing?.commits ?? [], stacks);
+	const forkOrder = line.flatMap((item) => (item.type === "fork" ? [item.commit.commit.id] : []));
 	// Deeper bases first; a base the listing does not reach counts as deepest,
 	// keeping the order given.
 	const depth = (stack: Stack): number => {
@@ -196,7 +203,32 @@ export const layout = (
 		});
 
 	return {
+		line,
 		order: order.map((entry) => entry.index),
+		worktrees: placeWorktrees(stacks, worktrees),
+	};
+};
+
+export const layout = (
+	stacks: ReadonlyArray<Stack>,
+	target: RefInfo["target"],
+	listing: TargetCommitPage | undefined,
+	folds: Folds,
+	worktrees: ReadonlyArray<Worktree> = [],
+	olderPages: ReadonlyArray<TargetCommit> = [],
+	structure = layoutStructure(stacks, listing, worktrees),
+): Plan => {
+	const commits = listing?.commits ?? [];
+	const shared = commits.filter((commit) => commit.inWorkspace);
+	const historyAvailable = target !== null && canLoadHistory(listing);
+	const history =
+		historyAvailable && folds.historyExpanded
+			? [...shared, ...olderPages.filter((commit) => commit.inWorkspace)]
+			: [];
+	const historyCount = FIRST_HISTORY + folds.moreHistory * MORE_COMMITS;
+
+	return {
+		order: structure.order,
 		header:
 			target === null || listing === undefined
 				? null
@@ -209,19 +241,39 @@ export const layout = (
 						current: target.isCurrent,
 					},
 		incomingExpanded: folds.incomingExpanded,
-		incoming: folds.incomingExpanded ? incomingRuns(line, folds) : [],
-		worktrees: placeWorktrees(stacks, worktrees),
+		incoming: folds.incomingExpanded ? incomingRuns(structure.line, folds) : [],
+		historyAvailable,
+		historyExpanded: folds.historyExpanded,
+		history: history.slice(0, historyCount),
+		historyHidden: Math.max(0, history.length - historyCount),
+		worktrees: structure.worktrees,
 	};
 };
 
 /** The section's rows as values, top to bottom, as the fold state shows them. The header is not a value. */
-export const sectionAddresses = (plan: Plan): Array<Address> =>
-	plan.incoming.flatMap((run) => run.shown.map(targetCommitAddress));
+export const foldAddresses = (plan: Plan, fold: "incoming" | "history"): Array<Address> =>
+	(fold === "incoming" ? plan.incoming.flatMap((run) => run.shown) : plan.history).map(
+		targetCommitAddress,
+	);
+
+export const sectionAddresses = (plan: Plan): Array<Address> => [
+	...foldAddresses(plan, "incoming"),
+	...foldAddresses(plan, "history"),
+];
 
 /** The review a commit on the target line landed, by commit id; null when none or not on the line. */
-export const targetCommitReview = (listing: TargetCommitPage | undefined, commitId: string) =>
-	listing?.commits.find((commit) => commit.commit.id === commitId)?.review ?? null;
+export const targetCommitReview = (
+	listing: TargetCommitPage | undefined,
+	commitId: string,
+	history: ReadonlyArray<TargetCommit> = [],
+) =>
+	listing?.commits.find((commit) => commit.commit.id === commitId)?.review ??
+	history.find((commit) => commit.commit.id === commitId)?.review ??
+	null;
 
 /** Whether a row sits in the section's fold, so a fold key on the row can close it. */
-export const inSection = (plan: Plan, address: Address): boolean =>
-	sectionAddresses(plan).some((other) => addressEquals(address, other));
+export const foldAt = (plan: Plan, address: Address): "incoming" | "history" | null => {
+	const inFold = (fold: "incoming" | "history") =>
+		foldAddresses(plan, fold).some((other) => addressEquals(address, other));
+	return inFold("incoming") ? "incoming" : inFold("history") ? "history" : null;
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.test.tsx
@@ -1,0 +1,271 @@
+/** @vitest-environment jsdom */
+import type { RefInfo, TargetCommit, TargetCommitPage } from "@gitbutler/but-sdk";
+import { configureStore } from "@reduxjs/toolkit";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createRef, useImperativeHandle } from "react";
+import { assert } from "#ui/assert.ts";
+import { createRoot, type Root } from "react-dom/client";
+import { Provider } from "react-redux";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { projectSlice } from "#ui/projects/state.ts";
+import { usePlan, type Graph } from "./usePlan.ts";
+import { sectionAddresses } from "./layout.ts";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const projectId = "history-test";
+const commit = (id: string, inWorkspace = true): TargetCommit => ({
+	commit: {
+		id,
+		message: id,
+		authoredAt: 0,
+		committedAt: 0,
+		changeId: null,
+		author: { name: "", email: "", gravatarUrl: "" },
+	},
+	inWorkspace,
+	review: null,
+});
+const listing: TargetCommitPage = {
+	commits: [commit("incoming", false), commit("base")],
+	hasMore: false,
+};
+const page = (prefix: string): TargetCommitPage => ({
+	commits: Array.from({ length: 25 }, (_, i) => commit(`${prefix}${i}`)),
+	hasMore: true,
+});
+const targetCommits = vi.fn();
+let client: QueryClient;
+let store: ReturnType<typeof createStore>;
+let root: Root;
+let container: HTMLDivElement;
+const graphRef = createRef<Graph>();
+const graph = () => assert(graphRef.current);
+const createStore = () => configureStore({ reducer: { project: projectSlice.reducer } });
+const Probe = () => {
+	const result = usePlan(projectId);
+	useImperativeHandle(graphRef, () => result, [result]);
+	return null;
+};
+const flush = async () => {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(20);
+	});
+};
+const toggleHistory = async () => {
+	await act(async () => {
+		store.dispatch(projectSlice.actions.toggleGraphHistory({ projectId }));
+	});
+	await flush();
+};
+const showMoreHistory = async () => {
+	await act(async () => {
+		await graph().showMoreHistory();
+	});
+	await flush();
+};
+
+beforeEach(async () => {
+	vi.useFakeTimers();
+	targetCommits
+		.mockReset()
+		.mockImplementation(({ from }: { from: string | null }) =>
+			Promise.resolve(from === null ? listing : from === "base" ? page("older") : page("oldest")),
+		);
+	vi.stubGlobal("lite", {
+		headInfo: () =>
+			Promise.resolve({
+				stacks: [],
+				worktrees: [],
+				target: {
+					remoteTrackingRef: { displayName: "main", remoteName: "origin", fullNameBytes: [] },
+					isCurrent: false,
+					commitsAhead: 1,
+				},
+			} as unknown as RefInfo),
+		workspaceTargetCommits: targetCommits,
+	});
+	client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+	store = createStore();
+	container = document.createElement("div");
+	document.body.append(container);
+	root = createRoot(container);
+	await act(async () => {
+		root.render(
+			<Provider store={store}>
+				<QueryClientProvider client={client}>
+					<Probe />
+				</QueryClientProvider>
+			</Provider>,
+		);
+	});
+	await flush();
+});
+
+afterEach(async () => {
+	await act(async () => {
+		root.unmount();
+	});
+	client.clear();
+	container.remove();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+it("fetches older commits only when History opens, even when the base listing reports its natural end", async () => {
+	expect(targetCommits).toHaveBeenCalledTimes(1);
+	expect(graph().plan.history).toEqual([]);
+	await toggleHistory();
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "base", limit: 25 });
+	expect(graph().plan.history).toHaveLength(5);
+	expect(graph().plan.history[0]?.commit.id).toBe("base");
+	expect(graph().plan.incoming).toEqual([]);
+	expect(graph().plan.header?.incoming).toBe(1);
+	expect(graph().historyMore).toBe("idle");
+
+	await showMoreHistory();
+	expect(graph().plan.history).toHaveLength(25);
+	expect(targetCommits).toHaveBeenCalledTimes(2);
+	await showMoreHistory();
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "older24", limit: 25 });
+	expect(graph().plan.history).toHaveLength(45);
+	expect(new Set(graph().plan.history.map((c) => c.commit.id)).size).toBe(45);
+
+	await toggleHistory();
+	await toggleHistory();
+	expect(graph().plan.history).toHaveLength(5);
+	expect(targetCommits).toHaveBeenCalledTimes(3);
+});
+
+it("keeps loaded History on a failed page and lets the next ask retry the same cursor", async () => {
+	await toggleHistory();
+	await showMoreHistory();
+	targetCommits.mockRejectedValueOnce(new Error("history unavailable"));
+	await showMoreHistory();
+	expect(graph().historyMore).toBe("failed");
+	expect(graph().plan.history).toHaveLength(25);
+	await showMoreHistory();
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "older24", limit: 25 });
+	expect(graph().historyMore).toBe("idle");
+	expect(graph().plan.history).toHaveLength(45);
+});
+
+it("keeps History reset when a pending page finishes after it is collapsed", async () => {
+	await toggleHistory();
+	await showMoreHistory();
+	const nextPage = Promise.withResolvers<TargetCommitPage>();
+	targetCommits.mockReturnValueOnce(nextPage.promise);
+	let request: Promise<void>;
+	await act(async () => {
+		request = graph().showMoreHistory();
+	});
+	await toggleHistory();
+	await act(async () => {
+		nextPage.resolve(page("oldest"));
+		await request;
+	});
+	await flush();
+	await toggleHistory();
+	expect(graph().plan.history).toHaveLength(5);
+});
+
+it("discovers shared history after multiple clipped incoming pages", async () => {
+	await act(async () => {
+		client.setQueryData([projectId, "workspaceTargetCommits"], {
+			commits: Array.from({ length: 1000 }, (_, index) => commit(`incoming${index}`, false)),
+			hasMore: true,
+		});
+	});
+	targetCommits.mockResolvedValueOnce({ commits: [commit("continued", false)], hasMore: true });
+	expect(graph().plan.historyAvailable).toBe(true);
+	await toggleHistory();
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "incoming999", limit: 25 });
+	expect(graph().plan.history).toEqual([]);
+	expect(graph().historyMore).toBe("idle");
+	targetCommits.mockResolvedValueOnce({
+		commits: [commit("shared"), commit("older")],
+		hasMore: false,
+	});
+	await showMoreHistory();
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "continued", limit: 25 });
+	expect(graph().plan.history.map((entry) => entry.commit.id)).toEqual(["shared", "older"]);
+	expect(graph().plan.header?.incoming).toBe(1001);
+	expect(graph().historyMore).toBe("hidden");
+});
+
+it("retries an initial History failure even with more than a page already cached", async () => {
+	await act(async () => {
+		client.setQueryData([projectId, "workspaceTargetCommits"], {
+			commits: Array.from({ length: 30 }, (_, index) => commit(`shared${index}`)),
+			hasMore: false,
+		});
+	});
+	targetCommits.mockRejectedValueOnce(new Error("history unavailable"));
+	await toggleHistory();
+	expect(graph().historyMore).toBe("failed");
+	expect(graph().plan.historyHidden).toBe(25);
+	const before = targetCommits.mock.calls.length;
+	await showMoreHistory();
+	expect(targetCommits).toHaveBeenCalledTimes(before + 1);
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "shared29", limit: 25 });
+	expect(graph().historyMore).toBe("idle");
+});
+
+it("does not fetch or navigate hidden history after the target loses its shared tail", async () => {
+	await toggleHistory();
+	const before = targetCommits.mock.calls.length;
+	await act(async () => {
+		client.setQueryData([projectId, "workspaceTargetCommits"], {
+			commits: [commit("unrelated", false)],
+			hasMore: false,
+		});
+	});
+	await flush();
+	expect(targetCommits).toHaveBeenCalledTimes(before);
+	expect(graph().plan.historyAvailable).toBe(false);
+	expect(graph().plan.history).toEqual([]);
+	expect(sectionAddresses(graph().plan)).toEqual([]);
+	expect(graph().historyMore).toBe("hidden");
+});
+
+it("ignores cached pages for the same cursor once it is no longer shared", async () => {
+	await toggleHistory();
+	await act(async () => {
+		client.setQueryData([projectId, "workspaceTargetCommits"], {
+			commits: [commit("base", false)],
+			hasMore: false,
+		});
+	});
+	await flush();
+	expect(graph().plan.history).toEqual([]);
+	expect(sectionAddresses(graph().plan)).toEqual([]);
+	expect(graph().historyMore).toBe("hidden");
+});
+
+it("stops offering History when a clipped walk ends without any shared commits", async () => {
+	await act(async () => {
+		client.setQueryData([projectId, "workspaceTargetCommits"], {
+			commits: [commit("unrelated", false)],
+			hasMore: true,
+		});
+	});
+	targetCommits.mockResolvedValueOnce({ commits: [commit("root", false)], hasMore: false });
+	await toggleHistory();
+	expect(graph().plan.historyAvailable).toBe(false);
+	expect(graph().plan.history).toEqual([]);
+	expect(graph().historyMore).toBe("hidden");
+	const before = targetCommits.mock.calls.length;
+	await showMoreHistory();
+	expect(targetCommits).toHaveBeenCalledTimes(before);
+});
+
+it("preserves stack placement identities while History opens and pages", async () => {
+	const stacks = graph().stacks;
+	const worktrees = graph().plan.worktrees;
+	await toggleHistory();
+	expect(graph().stacks).toBe(stacks);
+	expect(graph().plan.worktrees).toBe(worktrees);
+	await showMoreHistory();
+	expect(graph().stacks).toBe(stacks);
+	expect(graph().plan.worktrees).toBe(worktrees);
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
@@ -1,38 +1,112 @@
-import { headInfoQueryOptions, workspaceTargetCommitsQueryOptions } from "#ui/api/queries.ts";
+import {
+	headInfoQueryOptions,
+	olderTargetCommitsInfiniteQueryOptions,
+	workspaceTargetCommitsQueryOptions,
+} from "#ui/api/queries.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { useAppSelector } from "#ui/store.ts";
-import type { Stack, Worktree } from "@gitbutler/but-sdk";
-import { useQuery } from "@tanstack/react-query";
+import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import type { Stack, TargetCommit, TargetCommitPage, Worktree } from "@gitbutler/but-sdk";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { layout, type Plan } from "./layout.ts";
+import { canLoadHistory, layout, layoutStructure, MORE_COMMITS, type Plan } from "./layout.ts";
 
 const noWorktrees: ReadonlyArray<Worktree> = [];
+const noCommits: ReadonlyArray<TargetCommit> = [];
 
 /** The stacks graph as its host computes it once: the plan, the cards in its order, the linked worktrees, and the target line. */
 export type Graph = ReturnType<typeof usePlan>;
 
 /** The stacks graph's plan and the cards in its order. Called once per host, which hands it to the stacks. */
 export const usePlan = (projectId: string) => {
+	const dispatch = useAppDispatch();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const { data: listing } = useQuery(workspaceTargetCommitsQueryOptions(projectId));
+	const { data: baseListing } = useQuery(workspaceTargetCommitsQueryOptions(projectId));
 	const folds = useAppSelector((state) =>
 		projectSlice.selectors.selectGraphFolds(state, projectId),
 	);
 	const listOrder = useMemo(() => headInfo?.stacks ?? [], [headInfo]);
 	const target = headInfo?.target ?? null;
 	const worktrees = headInfo?.worktrees ?? noWorktrees;
-	// Explicit: the compiler does not memoise imported calls, and the rails re-measure on every new plan.
+	const olderFrom = baseListing?.commits.at(-1)?.commit.id ?? "";
+	const {
+		data: olderData,
+		fetchNextPage,
+		hasNextPage,
+		isFetching,
+		isError,
+	} = useInfiniteQuery({
+		...olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom),
+		enabled: (query) =>
+			folds.historyExpanded &&
+			target !== null &&
+			olderFrom !== "" &&
+			canLoadHistory(baseListing) &&
+			(baseListing?.hasMore !== true ||
+				query.state.data === undefined ||
+				baseListing.commits.some((commit) => commit.inWorkspace) ||
+				query.state.data.pages.some((page) => page.commits.some((commit) => commit.inWorkspace)) ||
+				query.state.data.pages.at(-1)?.hasMore === true),
+	});
+	const olderPages = useMemo(
+		() => olderData?.pages.flatMap((page) => page.commits) ?? [],
+		[olderData],
+	);
+	// A clipped initial page still belongs to the upstream line until a shared
+	// commit is reached; only continuation below its natural end is older History.
+	const listing: TargetCommitPage | undefined = useMemo(
+		() =>
+			baseListing?.hasMore && olderData !== undefined
+				? {
+						commits: [...baseListing.commits, ...olderPages],
+						hasMore: olderData.pages.at(-1)?.hasMore ?? false,
+					}
+				: baseListing,
+		[baseListing, olderData, olderPages],
+	);
+	const historyPages = baseListing?.hasMore ? noCommits : olderPages;
+	const structure = useMemo(
+		() => layoutStructure(listOrder, listing, worktrees),
+		[listOrder, listing, worktrees],
+	);
+	// Keep the plan stable: the rails re-measure whenever its identity changes.
 	const plan: Plan = useMemo(
-		() => layout(listOrder, target, listing, folds, worktrees),
-		[listOrder, target, listing, folds, worktrees],
+		() => layout(listOrder, target, listing, folds, worktrees, historyPages, structure),
+		[listOrder, target, listing, folds, worktrees, historyPages, structure],
 	);
 	const stacks: Array<Stack> = useMemo(
 		() =>
-			plan.order.flatMap((index) => {
+			structure.order.flatMap((index) => {
 				const stack = listOrder[index];
 				return stack === undefined ? [] : [stack];
 			}),
-		[plan, listOrder],
+		[structure.order, listOrder],
 	);
-	return { plan, stacks, worktrees, listing };
+	const showMoreHistory = async () => {
+		if (isFetching || !plan.historyAvailable) return;
+		if (
+			isError ||
+			(plan.historyHidden < MORE_COMMITS && (olderData === undefined || hasNextPage))
+		) {
+			const result = await fetchNextPage();
+			if (result.isError) return;
+		}
+		if (plan.history.length > 0) dispatch(projectSlice.actions.showMoreGraphHistory({ projectId }));
+	};
+	return {
+		plan,
+		stacks,
+		worktrees,
+		listing,
+		showMoreHistory,
+		historyMore:
+			!plan.historyAvailable || !plan.historyExpanded
+				? ("hidden" as const)
+				: isFetching
+					? ("loading" as const)
+					: isError
+						? ("failed" as const)
+						: plan.historyHidden > 0 || hasNextPage
+							? ("idle" as const)
+							: ("hidden" as const),
+	};
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -491,7 +491,7 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	// A commit on the target line, selected anywhere in the graph, carries the review it landed.
 	const appliedReview =
 		appliedSelection?._tag === "Commit"
-			? targetCommitReview(graph.listing, appliedSelection.commitId)
+			? targetCommitReview(graph.listing, appliedSelection.commitId, graph.plan.history)
 			: null;
 	const details = useMemo(() => {
 		const viewProps = { projectId, onActiveFileSelection, viewerRef, didScrollToViaFileRef };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -145,7 +145,8 @@
 
 	.container:hover &,
 	.container:focus-within &,
-	.containerSelected & {
+	.containerSelected &,
+	.foldToggle[data-chevron="always"] & {
 		display: flex;
 		position: absolute;
 		align-items: center;
@@ -156,7 +157,7 @@
 		width: 16px;
 		height: var(--single-line-row-height);
 		inset-block-start: 0;
-		inset-inline-start: max(0px, calc(100% - 16px));
+		inset-inline-start: calc(max(0px, calc(100% - 16px)) + var(--row-fold-chevron-offset, 0px));
 		color: var(--text-3);
 	}
 
@@ -170,6 +171,28 @@
 
 .foldGlyph {
 	display: flex;
+
+	/* Clear only the chevron's ink plus six pixels; the connector survives
+	   above and below it, including when the row is hovered. */
+	.foldToggle[data-chevron="always"] & {
+		--graph-segment-glyph-visibility: visible;
+		--chevron-clearance: 6px;
+		--chevron-ink-top: 10.5px;
+		--chevron-ink-bottom: 17px;
+
+		mask-image: linear-gradient(
+			to bottom,
+			black calc(var(--chevron-ink-top) - var(--chevron-clearance)),
+			transparent calc(var(--chevron-ink-top) - var(--chevron-clearance)),
+			transparent calc(var(--chevron-ink-bottom) + var(--chevron-clearance)),
+			black calc(var(--chevron-ink-bottom) + var(--chevron-clearance))
+		);
+	}
+
+	.foldToggle[data-chevron="always"][aria-expanded="false"] & {
+		--chevron-ink-top: 8.5px;
+		--chevron-ink-bottom: 19.5px;
+	}
 
 	/* The indicator takes over the rail from the second line down and draws its
 	   own line around the rings, so this one has to stop at the glyph rather
@@ -220,6 +243,7 @@
 	align-items: center;
 	min-width: 0;
 	margin-right: 2px;
+	margin-inline-start: var(--row-label-offset, 0px);
 	padding-block: var(--single-line-row-label-padding-block);
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -131,14 +131,14 @@ export const RowCheckbox: FC<ComponentProps<typeof Checkbox>> = (props) => (
 
 /**
  * The fold control on a row's graph rail: `glyph` at rest, a chevron once the
- * row is hovered or focused. Both are rendered and the swap is CSS-only (see
- * `.foldToggle`), which blanks just the glyph's own segment so the rail below
- * it keeps drawing. The chevron direction reports the state the way a
+ * row is hovered or focused, or always for section headers. The swap is
+ * CSS-only: hover chevrons replace the glyph, while permanent ones mask only
+ * the line directly behind them. The chevron direction reports the state the way a
  * disclosure triangle does. A glyph that is a chevron itself, as a section
  * header's, turns the hover one off, or the two overlap.
  *
  * `foldedIndicator` marks the rail for as long as the row is folded. The
- * chevron only appears on hover, so it cannot carry that on its own, and
+ * default chevron only appears on hover, so it cannot carry that on its own, and
  * `glyph` is busy describing the row's position in the graph. It takes the
  * second line, leaving the first to the glyph and the chevron.
  */
@@ -147,13 +147,14 @@ export const RowFoldToggle: FC<
 		folded: boolean;
 		glyph: ReactNode;
 		foldedIndicator?: ReactNode;
-		hoverChevron?: boolean;
+		chevron?: "hover" | "always" | "none";
 	} & ComponentProps<"button">
-> = ({ folded, glyph, foldedIndicator, hoverChevron = true, ...props }) => (
+> = ({ folded, glyph, foldedIndicator, chevron = "hover", ...props }) => (
 	<button
 		type="button"
 		{...props}
 		aria-expanded={!folded}
+		data-chevron={chevron}
 		className={classes(props.className, styles.foldToggle)}
 	>
 		<span className={styles.foldGlyph}>{glyph}</span>
@@ -162,7 +163,7 @@ export const RowFoldToggle: FC<
 			<span className={styles.foldIndicator}>{foldedIndicator}</span>
 		)}
 
-		{hoverChevron && (
+		{chevron !== "none" && (
 			<span className={styles.foldChevron}>
 				<Icon size={14} name={folded ? "chevron-right" : "chevron-down"} />
 			</span>

--- a/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
@@ -1,6 +1,8 @@
 /* A card runs the full width of its panel, divided from the next by its own
    floor rather than held off it by rounding and a gap. */
 .card {
+	--graph-through-visibility: hidden;
+
 	display: flex;
 	flex-direction: column;
 	border-block-end: 1px solid var(--border-section);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.module.css
@@ -1,5 +1,13 @@
+.headerLabel {
+	margin-inline-start: 1px;
+}
+
 /* A quiet note beside the label. */
 .caption {
 	flex-shrink: 0;
 	color: var(--text-3);
+}
+
+.foldToggle [data-icon] {
+	translate: -4px;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.tsx
@@ -158,7 +158,7 @@ export const UncommittedChangesRow: FC<{
 				className={className}
 			>
 				<GraphEdge glyph="forkRight" />
-				<RowLabelContainer>
+				<RowLabelContainer className={styles.headerLabel}>
 					<RowLabel heading singleLine>
 						Uncommitted files
 					</RowLabel>
@@ -179,12 +179,13 @@ export const UncommittedChangesRow: FC<{
 			}}
 		>
 			<RowFoldToggle
+				className={styles.foldToggle}
 				folded={mode.folded}
 				glyph={<GraphEdge glyph="forkRight" />}
 				aria-label={`${mode.folded ? "Unfold" : "Fold"} uncommitted files`}
 				onClick={mode.onToggleFolded}
 			/>
-			<RowLabelContainer>
+			<RowLabelContainer className={styles.headerLabel}>
 				<RowLabel id={mode.headingId} heading singleLine>
 					Uncommitted files
 				</RowLabel>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -51,8 +51,7 @@
 }
 
 .dockRow {
-	/* The glyph sets its own visibility (GraphSegment.module.css), so hiding
-	   the row alone leaves it showing through. */
+	/* Keep the gutter spacing without drawing the graph in the docked header. */
 	--graph-segment-glyph-visibility: hidden;
 	--graph-segment-rail-visibility: hidden;
 
@@ -60,16 +59,12 @@
 	position: absolute;
 	inset-inline: 0;
 	top: calc(-1 * var(--dock-offset));
-	/* The card's head room and no air below, so the label and the curve's tail
-	   stay put as the row takes over. */
+	/* Match the card's head room so the label stays put as the row takes over. */
 	padding-block-start: 6px;
 	border-block-end: 1px solid var(--border-section);
 	background-color: var(--bg-2);
 
 	@container scroll-state(stuck: top) {
-		--graph-segment-glyph-visibility: visible;
-		--graph-segment-rail-visibility: visible;
-
 		visibility: visible;
 	}
 }
@@ -79,13 +74,21 @@
    the gap below picks the trunk up. */
 .uncommittedCard,
 .dockRow {
-	/* The trunk's edge column is the rows' whole gutter: no inset. */
-	--row-padding-inline-start: 0px;
+	/* Keep the trunk aligned with the stack rows and gaps: see layout.ts's ROW_INSET. */
+	--row-padding-inline-start: var(--graph-trunk-inset);
 }
 
 .uncommittedCard {
+	--graph-through-visibility: hidden;
+
 	border-block-end: 1px solid var(--border-section);
 	background-color: var(--bg-1);
+}
+
+/* The leading graph rail stays put; the first tree guide moves to the same
+   16px spacing as the guides at deeper directory levels. */
+.uncommittedFiles [role="treeitem"] > :first-child {
+	margin-inline-end: -5px;
 }
 
 /* The card's head, header and filter, stays at the scroller's top while the
@@ -118,24 +121,6 @@
 	flex: 1;
 	min-width: 0;
 	margin-block: 8px;
-}
-
-/* The commit form keeps to the scroller's foot while the card's own foot is
-   below it, over the docked target row when there is one (its `bottom`),
-   so a long list still commits. A hairline while stuck says the rows pass
-   beneath; a shadow, so the form's height does not change as it sticks. */
-.commitFoot {
-	container-type: scroll-state;
-
-	z-index: 1;
-	position: sticky;
-	background-color: var(--bg-1);
-}
-
-.commitFootRow {
-	@container scroll-state(stuck: bottom) {
-		box-shadow: 0 -1px 0 var(--border-section);
-	}
 }
 
 /* With no stacks, the one block is centred in the room under the uncommitted

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -64,12 +64,13 @@ import {
 	DOCKED_HEIGHT,
 	HEAD_DOCKED_HEIGHT,
 	ROW_INSET,
-	inSection,
-	sectionAddresses,
+	foldAt,
+	foldAddresses,
 	type WorktreePlacement,
 	worktreesOnTip,
 } from "../Graph/layout.ts";
 import type { Graph } from "../Graph/usePlan.ts";
+import { GRAPH_TRUNK_INSET } from "#ui/components/graph-spacing.ts";
 import { StackCard } from "../StackCard.tsx";
 import stackCardStyles from "../StackCard.module.css";
 import { treeItemId } from "../Row-utils.ts";
@@ -163,7 +164,7 @@ const UncommittedChanges: FC<
 		worktreeChanges: WorktreeChanges | undefined;
 		/** The graph's scroller, which the card heads. */
 		scrollElementRef: RefObject<HTMLDivElement | null>;
-		/** The docked target row's height at the scroller's foot, or 0: the commit form sticks above it. */
+		/** The docked target row's height that file navigation must clear, or 0. */
 		footDock: number;
 		/** The card's head, measured by the parent, which docks a stand-in as soon as the head is pushed. */
 		headRef: (element: HTMLElement | null) => void;
@@ -225,9 +226,6 @@ const UncommittedChanges: FC<
 
 	const cardRef = useRef<HTMLDivElement>(null);
 	const fileListRef = useRef<HTMLDivElement>(null);
-	// The head sticks at the scroller's top and the commit form at its foot, so a row
-	// scrolled into view clears both.
-	const [formRef, formHeight] = useHeight();
 	// The list's start in the scroller, which the card heads: the rows above the
 	// list come and go with the filter and the worktree, so the card's size says
 	// when to measure again.
@@ -316,6 +314,7 @@ const UncommittedChanges: FC<
 				    under a header still reading "Uncommitted". */}
 				<Activity mode={isClean || worktreeChanges === undefined ? "hidden" : "visible"}>
 					<FilesTree
+						className={styles.uncommittedFiles}
 						aria-labelledby={uncommittedChangesHeadingId}
 						canUncommit={false}
 						data-preview-source={activeList === "uncommitted"}
@@ -343,29 +342,27 @@ const UncommittedChanges: FC<
 						scrollElementRef={scrollElementRef}
 						scrollMargin={listOffset}
 						scrollPaddingStart={headHeight}
-						scrollPaddingEnd={footDock + formHeight}
-						// The rows sit on the trunk, whose edge column is their whole gutter: no inset, the tree's own included.
-						style={{ "--row-padding-inline-start": "0px" }}
+						scrollPaddingEnd={footDock}
+						// Override the tree's inset to keep the rows on the uncommitted card's trunk.
+						style={{ "--row-padding-inline-start": "var(--graph-trunk-inset)" }}
 					/>
 				</Activity>
 
-				<div ref={formRef} className={styles.commitFoot} style={{ bottom: footDock }}>
-					<Row interactive={false} className={styles.commitFootRow}>
-						{trunk}
-						<CommitForm
-							projectId={projectId}
-							commitTarget={commitTarget}
-							targetComboboxItems={targetComboboxItems}
-							hasNoBranches={hasNoBranches}
-							startCommitButtonId={startCommitButtonId}
-							commitMessageInputId={commitMessageInputId}
-							className={styles.commitForm}
-							onAmendCommit={amendCommit}
-							canAmendCommit={canAmendCommit}
-							worktreeChanges={worktreeChanges}
-						/>
-					</Row>
-				</div>
+				<Row interactive={false}>
+					{trunk}
+					<CommitForm
+						projectId={projectId}
+						commitTarget={commitTarget}
+						targetComboboxItems={targetComboboxItems}
+						hasNoBranches={hasNoBranches}
+						startCommitButtonId={startCommitButtonId}
+						commitMessageInputId={commitMessageInputId}
+						className={styles.commitForm}
+						onAmendCommit={amendCommit}
+						canAmendCommit={canAmendCommit}
+						worktreeChanges={worktreeChanges}
+					/>
+				</Row>
 			</Activity>
 
 			<Row interactive={false} className={styles.stub}>
@@ -1221,8 +1218,8 @@ const Stacks: FC<{
 	const selectedAddressKey = selection === null ? undefined : addressIdentityKey(selection);
 	// Whether the selection sits in the section's fold, looked up once per
 	// selection or plan: the hotkeys ask on every render.
-	const selectedInSection = useMemo(
-		() => selection !== null && inSection(plan, selection),
+	const selectedFold = useMemo(
+		() => (selection === null ? null : foldAt(plan, selection)),
 		[plan, selection],
 	);
 	const lastRevealedAddressKeyRef = useRef<string>(undefined);
@@ -1246,6 +1243,7 @@ const Stacks: FC<{
 	}, [rowVirtualizer, selectedAddressKey, selectedStackIndex]);
 
 	const toggleIncoming = () => dispatch(projectSlice.actions.toggleGraphIncoming({ projectId }));
+	const toggleHistory = () => dispatch(projectSlice.actions.toggleGraphHistory({ projectId }));
 	const showMoreRun = (runId: string) =>
 		dispatch(projectSlice.actions.showMoreGraphRun({ projectId, runId }));
 	const foldRun = (runId: string) =>
@@ -1261,18 +1259,20 @@ const Stacks: FC<{
 		pendingPushBranches,
 		// The fold key on a section row closes the fold and parks the cursor on
 		// the row above it, since the header is not a value.
-		sectionToggle: selectedInSection
-			? () => {
-					const first = sectionAddresses(plan)[0];
-					const index =
-						first === undefined
-							? undefined
-							: addressSpace.indexByKey.get(addressIdentityKey(first));
-					const above = index === undefined ? undefined : addressSpace.items[index - 1];
-					if (above !== undefined) setCursor("applied", above);
-					toggleIncoming();
-				}
-			: null,
+		sectionToggle:
+			selectedFold !== null
+				? () => {
+						const first = foldAddresses(plan, selectedFold)[0];
+						const index =
+							first === undefined
+								? undefined
+								: addressSpace.indexByKey.get(addressIdentityKey(first));
+						const above = index === undefined ? undefined : addressSpace.items[index - 1];
+						if (above !== undefined) setCursor("applied", above);
+						if (selectedFold === "incoming") toggleIncoming();
+						else toggleHistory();
+					}
+				: null,
 	});
 
 	return (
@@ -1280,7 +1280,10 @@ const Stacks: FC<{
 			<div
 				ref={retainScrollElement}
 				className={classes(uiStyles.scroller, styles.stacksScroller)}
-				style={{ "--row-padding-inline-start": `${ROW_INSET}px` }}
+				style={{
+					"--row-padding-inline-start": `${ROW_INSET}px`,
+					"--graph-trunk-inset": `${GRAPH_TRUNK_INSET}px`,
+				}}
 			>
 				{/* Its own tree: the files walk with their own cursor, and the arrow
 				    keys spill into the cards' tree at its edge. */}
@@ -1350,6 +1353,9 @@ const Stacks: FC<{
 						projectId={projectId}
 						plan={plan}
 						onToggleIncoming={toggleIncoming}
+						onToggleHistory={toggleHistory}
+						onShowMoreHistory={() => void graph.showMoreHistory()}
+						historyMore={graph.historyMore}
 						onShowMoreRun={showMoreRun}
 						onFoldRun={foldRun}
 						scrollElementRef={scrollElementRef}
@@ -1521,8 +1527,7 @@ export const WorkspaceLists: FC<
 		focusScope("uncommitted-files");
 	};
 	const scrollElementRef = useRef<HTMLDivElement>(null);
-	// The docked target row's height, which the card's commit form sticks above; a row
-	// scrolled into view clears it, else the foot's gradient.
+	// Rows scrolled into view clear the docked target row, or the foot's gradient.
 	const footDock = graph.plan.header !== null ? DOCKED_HEIGHT : 0;
 	const scrollPaddingEnd = Math.max(footDock, 14);
 	// The card's head, whose height says when its docked stand-in takes over.


### PR DESCRIPTION
Restore a separately expandable History row below upstream, with paginated older commits. Keep upstream available in its sticky row and present its expanded commits as a card.

Inset and soften the graph lines, hide through-lines behind cards, and align the connectors using shared spacing constants. Remove PR-number badges from upstream and History commits, remove the sticky commit form, and hide the curve in the docked Uncommitted files header.

Includes pagination regression coverage, including a request finishing after History collapses.

Validation: type-checking, lint, Knip, formatting, 499 unit tests, and 30 end-to-end tests against the independent branch. Before/after screenshots captured over CDP.
