### PR TITLE
Lite: make the Pull Request tab work on narrow panes

### DIFF
--- a/apps/lite/ui/src/components/MarkdownToolbar.module.css
+++ b/apps/lite/ui/src/components/MarkdownToolbar.module.css
@@ -1,14 +1,52 @@
 .toolbar {
 	display: flex;
 	column-gap: 6px;
-	flex-wrap: wrap;
 	align-items: center;
+}
+
+.strip {
+	display: flex;
+	/* Makes each group's offsetLeft read from the strip's own edge. */
+	position: relative;
+	column-gap: 6px;
+	flex: 1 1 0;
+	align-items: center;
+	min-width: 0;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	scrollbar-width: none;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+
+	/* Fades the clipped edge so a half-hidden button or rule reads as more
+	   content, not as a stray line beside the chevrons. */
+	&[data-reach="start"] {
+		mask-image: linear-gradient(to right, #000 calc(100% - 20px), transparent);
+	}
+
+	&[data-reach="middle"] {
+		mask-image: linear-gradient(
+			to right,
+			transparent,
+			#000 20px,
+			#000 calc(100% - 20px),
+			transparent
+		);
+	}
+
+	&[data-reach="end"] {
+		mask-image: linear-gradient(to right, transparent, #000 20px);
+	}
 }
 
 .group {
 	display: flex;
 	column-gap: 6px;
+	flex-shrink: 0;
 	align-items: center;
+	scroll-snap-align: start;
 }
 
 .separator {
@@ -16,4 +54,11 @@
 	width: 1px;
 	height: 18px;
 	background-color: var(--border-3);
+}
+
+.nav {
+	display: flex;
+	column-gap: 6px;
+	flex-shrink: 0;
+	align-items: center;
 }

--- a/apps/lite/ui/src/components/MarkdownToolbar.stories.tsx
+++ b/apps/lite/ui/src/components/MarkdownToolbar.stories.tsx
@@ -1,0 +1,64 @@
+import preview from "#storybook/preview";
+import { FieldTextareaStyles } from "#ui/components/Field.tsx";
+import { MarkdownToolbar } from "#ui/components/MarkdownToolbar.tsx";
+import { Tooltip } from "@base-ui/react";
+import { useRef, useState } from "react";
+import type { FC } from "react";
+
+const meta = preview.meta({
+	component: MarkdownToolbar,
+	decorators: [
+		(Story) => (
+			<Tooltip.Provider>
+				<Story />
+			</Tooltip.Provider>
+		),
+	],
+});
+
+const sample = `Move the commit toolbox above the lane
+
+Selecting a commit used to hide the toolbox behind the graph.`;
+
+/**
+ * The toolbar only rewrites the textarea it is pointed at, so the demo owns
+ * the source and hands the toolbar a ref to the field.
+ */
+const Demo: FC<{ disabled?: boolean; width?: number }> = ({ disabled, width = 480 }) => {
+	const [value, setValue] = useState(sample);
+	const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: 8, width }}>
+			<MarkdownToolbar disabled={disabled} onInput={setValue} targetRef={bodyRef} />
+			<FieldTextareaStyles
+				aria-label="Description"
+				className="text-body"
+				disabled={disabled}
+				onChange={(evt) => setValue(evt.currentTarget.value)}
+				placeholder="Description"
+				ref={bodyRef}
+				rows={6}
+				value={value}
+			/>
+		</div>
+	);
+};
+
+/** Select some text in the field, or place the caret, and press a button. */
+export const Default = meta.story({
+	render: () => <Demo />,
+});
+
+/**
+ * Too narrow for every group, the buttons scroll a group at a time behind the
+ * chevrons; a horizontal wheel or a swipe snaps to the same stops.
+ */
+export const Narrow = meta.story({
+	render: () => <Demo width={300} />,
+});
+
+/** Disabled while a submit is pending: the buttons stay put but do nothing. */
+export const Disabled = meta.story({
+	render: () => <Demo disabled />,
+});

--- a/apps/lite/ui/src/components/MarkdownToolbar.tsx
+++ b/apps/lite/ui/src/components/MarkdownToolbar.tsx
@@ -6,7 +6,8 @@ import type { IconName } from "#ui/components/iconNames.ts";
 import * as md from "#ui/markdown-editing.ts";
 import { applyToTextarea } from "#ui/markdown-textarea.ts";
 import { Tooltip } from "@base-ui/react";
-import type { FC, RefObject } from "react";
+import { Fragment, useRef, useState } from "react";
+import type { FC, RefCallback, RefObject } from "react";
 import styles from "./MarkdownToolbar.module.css";
 
 type ToolbarButton = {
@@ -39,6 +40,24 @@ const groups: ReadonlyArray<ReadonlyArray<ToolbarButton>> = [
 	],
 ];
 
+/** Where the strip's scroll position sits; `fits` means there is nothing to scroll. */
+type Reach = "fits" | "start" | "middle" | "end";
+
+const measureReach = (strip: HTMLElement): Reach => {
+	// The chevrons sit beside the strip and take room from it, so whether the
+	// buttons fit is judged on the room they would give back once gone;
+	// otherwise showing them could never be undone by widening.
+	const nav = strip.nextElementSibling;
+	const room =
+		strip.clientWidth +
+		(nav === null ? 0 : nav.getBoundingClientRect().right - strip.getBoundingClientRect().right);
+	if (strip.scrollWidth <= room + 1) return "fits";
+	const max = strip.scrollWidth - strip.clientWidth;
+	if (strip.scrollLeft <= 1) return "start";
+	if (strip.scrollLeft >= max - 1) return "end";
+	return "middle";
+};
+
 type Props = {
 	/** The textarea whose markdown source the buttons rewrite. */
 	targetRef: RefObject<HTMLTextAreaElement | null>;
@@ -51,43 +70,112 @@ type Props = {
 /**
  * Markdown formatting buttons for a plain textarea. The commands themselves
  * live in `markdown-editing.ts`; this only routes them at the live selection.
+ *
+ * Too narrow to show every group, the buttons scroll sideways a group at a
+ * time, with a chevron pair at the end for anyone without a horizontal wheel.
  */
 export const MarkdownToolbar: FC<Props> = (p) => {
+	const [reach, setReach] = useState<Reach>("fits");
+	const stripRef = useRef<HTMLDivElement | null>(null);
+
+	// A ref callback rather than an effect: the strip's width is what decides
+	// whether the chevrons show, so it is measured as soon as it exists.
+	const observeStrip: RefCallback<HTMLDivElement> = (strip) => {
+		stripRef.current = strip;
+		if (strip === null) return;
+		const measure = () => setReach(measureReach(strip));
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(strip);
+		return () => observer.disconnect();
+	};
+
 	const apply = (command: md.MarkdownCommand) => {
 		const target = p.targetRef.current;
 		if (target !== null) p.onInput(applyToTextarea(target, command));
 	};
 
+	const scrollByGroup = (direction: -1 | 1) => {
+		const strip = stripRef.current;
+		if (strip === null) return;
+		const starts = Array.from(strip.querySelectorAll<HTMLElement>("[data-group]")).map(
+			(group) => group.offsetLeft,
+		);
+		const current = strip.scrollLeft;
+		const next =
+			direction > 0
+				? starts.find((start) => start > current + 1)
+				: starts.findLast((start) => start < current - 1);
+		if (next !== undefined) strip.scrollTo({ left: next, behavior: "smooth" });
+	};
+
 	return (
 		<div className={classes(p.className, styles.toolbar)} role="toolbar" aria-label="Formatting">
-			{groups.map((group, index) => (
-				// Indices are stable: the groups are a module constant.
-				// oxlint-disable-next-line react/no-array-index-key
-				<div key={index} className={styles.group}>
-					{index > 0 && <div aria-hidden className={styles.separator} />}
-					{group.map((button) => (
-						<Tooltip.Root key={button.label}>
-							<Tooltip.Trigger
-								className={getButtonClassName({ variant: "ghost", iconOnly: true })}
-								// base-ui's own `disabled` only suppresses the tooltip, leaving a
-								// live button behind, so the native attributes go on the element.
-								render={<button aria-label={button.label} disabled={p.disabled} type="button" />}
-								// Keeps the caret in the textarea: a plain click would blur it
-								// first, so the command would have no selection to act on.
-								onMouseDown={(evt) => evt.preventDefault()}
-								onClick={() => apply(button.command)}
-							>
-								<Icon name={button.icon} />
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup render={<TooltipPopup />}>{button.label}</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-					))}
+			<div
+				className={styles.strip}
+				data-reach={reach}
+				onScroll={(evt) => setReach(measureReach(evt.currentTarget))}
+				ref={observeStrip}
+			>
+				{groups.map((group, index) => (
+					// Indices are stable: the groups are a module constant.
+					// oxlint-disable-next-line react/no-array-index-key
+					<Fragment key={index}>
+						{index > 0 && <div aria-hidden className={styles.separator} />}
+						<div className={styles.group} data-group>
+							{group.map((button) => (
+								<Tooltip.Root key={button.label}>
+									<Tooltip.Trigger
+										className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+										// base-ui's own `disabled` only suppresses the tooltip, leaving a
+										// live button behind, so the native attributes go on the element.
+										render={
+											<button aria-label={button.label} disabled={p.disabled} type="button" />
+										}
+										// Keeps the caret in the textarea: a plain click would blur it
+										// first, so the command would have no selection to act on.
+										onMouseDown={(evt) => evt.preventDefault()}
+										onClick={() => apply(button.command)}
+									>
+										<Icon name={button.icon} />
+									</Tooltip.Trigger>
+									<Tooltip.Portal>
+										<Tooltip.Positioner sideOffset={4}>
+											<Tooltip.Popup render={<TooltipPopup />}>{button.label}</Tooltip.Popup>
+										</Tooltip.Positioner>
+									</Tooltip.Portal>
+								</Tooltip.Root>
+							))}
+						</div>
+					</Fragment>
+				))}
+			</div>
+
+			{reach !== "fits" && (
+				<div className={styles.nav}>
+					<div aria-hidden className={styles.separator} />
+					<button
+						aria-label="Previous formatting group"
+						className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+						disabled={reach === "start"}
+						onMouseDown={(evt) => evt.preventDefault()}
+						onClick={() => scrollByGroup(-1)}
+						type="button"
+					>
+						<Icon name="chevron-left" />
+					</button>
+					<button
+						aria-label="Next formatting group"
+						className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+						disabled={reach === "end"}
+						onMouseDown={(evt) => evt.preventDefault()}
+						onClick={() => scrollByGroup(1)}
+						type="button"
+					>
+						<Icon name="chevron-right" />
+					</button>
 				</div>
-			))}
+			)}
 		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -311,6 +311,19 @@
 	min-width: 0;
 }
 
+/* Too narrow for two columns: the panel goes above the main column (see
+   the matching query in PullRequestPanel.module.css). */
+@container (max-width: 720px) {
+	.prLayout {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.prMain {
+		order: 1;
+	}
+}
+
 .fileHeader {
 	display: grid;
 	grid-template-columns: auto 1fr auto;

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -21,6 +21,7 @@
 /* The description composer: toolbar, source textarea, and action footer all
    share one card surface, so the focus ring belongs to the card. */
 .descriptionEditor {
+	container-type: inline-size;
 	display: flex;
 	flex-direction: column;
 	border-radius: var(--radius-card);
@@ -112,6 +113,32 @@
 	display: flex;
 	column-gap: 4px;
 	align-items: center;
+}
+
+.submitShortLabel {
+	display: none;
+}
+
+/* Doubled to outrank the icon's own display. */
+.submitPushIcon.submitPushIcon {
+	display: none;
+}
+
+/* Too narrow for the submit label: creating falls back to its icons, with the
+   push arrow joining the PR icon so "push and create" still reads; an edit
+   keeps a short "Save". */
+@container (max-width: 400px) {
+	.submitLabel {
+		display: none;
+	}
+
+	.submitShortLabel {
+		display: inline;
+	}
+
+	.submitPushIcon.submitPushIcon {
+		display: inline-grid;
+	}
 }
 
 .footerSeparator {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -53,7 +53,7 @@ import {
 	usePersistMergeMethod,
 } from "#ui/pr.ts";
 import { type FocusScope, useAutofocusScope } from "#ui/focus-scopes.ts";
-import { Field, Tooltip } from "@base-ui/react";
+import { Button, Field, Tooltip } from "@base-ui/react";
 import type { ForgeReview, ReviewMergeMethod, ReviewMergeStatus } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -61,6 +61,7 @@ import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import {
 	type FC,
 	type ReactNode,
+	type RefCallback,
 	type SubmitEvent,
 	Suspense,
 	useEffect,
@@ -140,6 +141,7 @@ export const PullRequestForm: FC<{
 	const bodyRef = useRef<HTMLTextAreaElement | null>(null);
 	/** Drives the rule under the toolbar, so text never slides under it bare. */
 	const [bodyScrolled, setBodyScrolled] = useState(false);
+	const [submitLabelHidden, setSubmitLabelHidden] = useState(false);
 
 	const remoteOrEmptyDocument = {
 		title: title ?? "",
@@ -283,6 +285,20 @@ export const PullRequestForm: FC<{
 		);
 	};
 
+	// Tracks whether the container query has collapsed the submit button to its
+	// icons, so the label can move into a tooltip. A ref callback rather than a
+	// mount effect: the label is a flex item, so `display: none` zeroes its box
+	// and observing it is enough to tell.
+	const observeSubmitLabel: RefCallback<HTMLSpanElement> = (label) => {
+		if (label === null) return;
+		setSubmitLabelHidden(label.offsetWidth === 0);
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) setSubmitLabelHidden(entry.contentRect.width === 0);
+		});
+		observer.observe(label);
+		return () => observer.disconnect();
+	};
+
 	const handleSubmit = async (evt: SubmitEvent<HTMLFormElement>): Promise<void> => {
 		evt.preventDefault();
 		if (!canSubmit || noCommits || isAnyPending || localDocument.title.trim() === "") return;
@@ -351,6 +367,14 @@ export const PullRequestForm: FC<{
 		enabled: !isAnyPending && hasChanges,
 		target: formRef,
 	});
+
+	const submitLabel = !isNew
+		? "Save changes"
+		: noCommits
+			? "No commits yet"
+			: pushFirst !== null
+				? "Push and create a PR"
+				: "Create a PR";
 
 	return (
 		// oxlint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Used for persistence, not UI per se.
@@ -462,24 +486,41 @@ export const PullRequestForm: FC<{
 									</button>
 								)}
 
-								<button
-									className={getButtonClassName({ variant: "gray" })}
-									disabled={!canSubmit || noCommits || isAnyPending || !hasChanges}
-									type="submit"
-								>
-									{/* The reason rides in the label, not a tooltip: it is the
-									    form's whole story, so it has to be readable without hover
-									    (DESIGN.md → Empty states). */}
-									{!isNew
-										? "Save changes"
-										: noCommits
-											? "No commits yet"
-											: pushFirst !== null
-												? "Push and create a PR"
-												: "Create a PR"}
-									{/* Creating opens a PR; saving only confirms an edit. */}
-									<Icon name={isAnyPending ? "spinner" : isNew ? "pr" : "tick"} />
-								</button>
+								{/* The reason rides in the label, not a tooltip: it is the
+								    form's whole story, so it has to be readable without hover
+								    (DESIGN.md → Empty states). Only once the editor is too
+								    narrow for the label does the tooltip take it over. */}
+								<Tooltip.Root disabled={!submitLabelHidden || !isNew}>
+									<Tooltip.Trigger
+										aria-label={submitLabel}
+										className={getButtonClassName({ variant: "gray" })}
+										render={
+											<Button
+												disabled={!canSubmit || noCommits || isAnyPending || !hasChanges}
+												focusableWhenDisabled
+												type="submit"
+											/>
+										}
+									>
+										<span ref={observeSubmitLabel} className={styles.submitLabel}>
+											{submitLabel}
+										</span>
+										{/* An edit keeps a word when collapsed: "Save" beside Cancel
+										    reads on its own, where a bare tick would not. */}
+										{!isNew && <span className={styles.submitShortLabel}>Save</span>}
+										{/* Creating opens a PR; saving only confirms an edit. */}
+										<Icon name={isAnyPending ? "spinner" : isNew ? "pr" : "tick"} />
+										{/* Collapsed, the arrow stands in for the "push" half of the label. */}
+										{isNew && pushFirst !== null && !noCommits && (
+											<Icon name="arrow-up" className={styles.submitPushIcon} />
+										)}
+									</Tooltip.Trigger>
+									<Tooltip.Portal>
+										<Tooltip.Positioner sideOffset={4}>
+											<Tooltip.Popup render={<TooltipPopup />}>{submitLabel}</Tooltip.Popup>
+										</Tooltip.Positioner>
+									</Tooltip.Portal>
+								</Tooltip.Root>
 							</div>
 						</div>
 					</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -41,6 +41,16 @@
 	color: var(--text-2);
 }
 
+/* Stacked above the main column (the breakpoint is Details.module.css's),
+   the panel spans the pane instead of holding its column, and scrolls
+   with the form rather than pinning over it. */
+@container (max-width: 720px) {
+	.panel {
+		position: static;
+		flex-basis: auto;
+	}
+}
+
 /* The Status section is its header alone: the badge and the PR link sit
    opposite the heading. */
 .statusActions {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -41,6 +41,32 @@
 	color: var(--text-2);
 }
 
+/* Only the stacked layout folds the card; beside the column it has the
+   height to show everything. */
+.panelFooter {
+	display: none;
+	padding-inline: 14px;
+	padding-block: 8px;
+	border-top: 1px solid var(--border-section);
+	border-radius: 0 0 var(--radius-card) var(--radius-card);
+	background-color: var(--bg-2);
+}
+
+.panelFooterToggle {
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-1);
+	/* The designed link treatment: dotted, on the font's own underline. */
+	text-decoration: underline dotted;
+	text-underline-position: from-font;
+	opacity: 0.7;
+
+	&:hover {
+		opacity: 1;
+	}
+}
+
 /* Stacked above the main column (the breakpoint is Details.module.css's),
    the panel spans the pane instead of holding its column, and scrolls
    with the form rather than pinning over it. */
@@ -48,6 +74,16 @@
 	.panel {
 		position: static;
 		flex-basis: auto;
+	}
+
+	/* Folded, the card hides its reference sections behind the footer, so
+	   the description stays in reach. */
+	.panel[data-collapsed] > .foldable {
+		display: none;
+	}
+
+	.panelFooter {
+		display: flex;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -597,6 +597,11 @@ export const PullRequestPanel: FC<{
 	const { mutate: removeReviewLabel } = useRemoveReviewLabel(projectId);
 	const { mutate: requestReview } = useRequestReview(projectId);
 	const { mutate: withdrawReviewRequest } = useWithdrawReviewRequest(projectId);
+	// Stacked above the description, the whole card would push it out of
+	// view, so there the sections marked foldable — the reference ones,
+	// Branches and Created — hide until asked. The footer that asks only
+	// renders in that layout (see the CSS).
+	const [showsAll, setShowsAll] = useState(false);
 	const { isPending: isDraftinessPending, mutate: setReviewDraftiness } =
 		useSetReviewDraftiness(projectId);
 	const { isPending: isUpdateReviewPending, mutate: updateReview } = useUpdateReview(projectId);
@@ -728,7 +733,7 @@ export const PullRequestPanel: FC<{
 	};
 
 	return (
-		<aside className={styles.panel}>
+		<aside className={styles.panel} data-collapsed={showsAll ? undefined : ""}>
 			<Section
 				heading="Status"
 				action={
@@ -817,7 +822,7 @@ export const PullRequestPanel: FC<{
 				<ChecksSection projectId={projectId} reference={review.sourceBranch} />
 			)}
 
-			<Section heading="Branches">
+			<Section heading="Branches" className={styles.foldable}>
 				<div className={classes("text-13", styles.branches)}>
 					<CopyableBranch name={review.sourceBranch} />
 					<TargetBranch name={review.targetBranch} />
@@ -825,12 +830,22 @@ export const PullRequestPanel: FC<{
 			</Section>
 
 			{createdAtMs !== null && (
-				<Section heading="Created">
+				<Section heading="Created" className={styles.foldable}>
 					<span className={classes("text-13", styles.created)}>
 						{formatRelativeTime(createdAtMs)}, {formatAbsoluteTime(createdAtMs)}
 					</span>
 				</Section>
 			)}
+
+			<div className={styles.panelFooter}>
+				<button
+					className={classes("text-13", styles.panelFooterToggle)}
+					onClick={() => setShowsAll((current) => !current)}
+					type="button"
+				>
+					{showsAll ? "Show less" : "Show all"}
+				</button>
+			</div>
 		</aside>
 	);
 };


### PR DESCRIPTION
The Pull Request tab assumed a wide details pane. Three places gave way as it narrowed, each fixed with a container query on the surface it lives on.

- The markdown toolbar scrolls its button groups sideways with snapping, behind a chevron pair that appears only when the buttons overflow. New Storybook story with a narrow variant.
- The submit button collapses to its icons below 400px of editor width, PR plus an up arrow when a push comes first, with the full label moved into a tooltip since it doubles as the disabled reason. An edit keeps a short "Save".
- Below 720px of tab width the side panel stacks above the form and stops being sticky, and folds Branches and Created behind a "Show all" footer so the description stays in reach.

Stacked on the activity feed and reviewer withdraw branches, which touch the same panel.

<img width="344" height="551" alt="BE99A6A9-14CF-444F-A9C1-0ECBEF1EA7E3" src="https://github.com/user-attachments/assets/be797be7-2d50-45cf-aac8-e9a77d8cbeae" />
<img width="592" height="556" alt="D79904DA-A20C-473A-A0BD-D57851D991AC" src="https://github.com/user-attachments/assets/1d36c2e3-04af-418a-a65f-2074a6ed5c49" />
<img width="593" height="894" alt="AB7596A9-B3B3-4756-B8C2-D477301B06CA" src="https://github.com/user-attachments/assets/e15a5126-fb82-4066-9b31-fb93da232e5d" />

---

🚧 **NOTE**: it's more a quick fix rather then a final design.