### PR TITLE
Suggest --above in the dependency-rejection hint

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -152,7 +152,7 @@ For more than two replacement commits or when every message must be chosen durin
 
 To make one existing branch depend on another: `but move <child-branch-name> --above <parent-branch-name>` (use full branch names; commit reordering uses commit IDs). To unstack: `but move <branch-name> --unstack`.
 
-**DO NOT** stack via `uncommit` + `branch delete` + `branch new -a` (git branch names persist after delete and it loses work), and do not use `but undo` to unstack.
+**DO NOT** stack via `uncommit` + `branch delete` + `branch new --above` (git branch names persist after delete and it loses work), and do not use `but undo` to unstack.
 
 ### Create or manage pull requests
 
@@ -164,7 +164,7 @@ If you do create a PR for a stacked branch, use `but pr` — not `gh pr create` 
 
 Changes that build on another branch's commits cannot land on an independent branch. `but commit` and `but amend` fail atomically ("Cannot commit: N changes could not be applied"), naming the branch and commit each rejected change depends on — nothing is committed and no `-b` branch is created.
 
-When there is a single dependency branch, the error's Hint gives the exact recovery command: `but move <your-branch> --above <dependency-branch>` to stack an existing branch on its dependency, or `but branch new <name> --anchor <dependency-branch>` when the target branch didn't exist yet. Run it, then retry the original command. When the error names dependencies without a Hint (several dependency branches, or the dependency is on the target branch itself), run `but status -fv` to see where the dependent commits live before choosing a placement.
+When there is a single dependency branch, the error's Hint gives the exact recovery command: `but move <your-branch> --above <dependency-branch>` to stack an existing branch on its dependency, or `but branch new <name> --above <dependency-branch>` when the target branch didn't exist yet. Run it, then retry the original command. When the error names dependencies without a Hint (several dependency branches, or the dependency is on the target branch itself), run `but status -fv` to see where the dependent commits live before choosing a placement.
 
 If that recovery command fails, do NOT try `uncommit`, `squash`, or `undo` as a workaround — re-run `but status -fv` to confirm both branches exist and are applied, then retry with exact branch names.
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -117,7 +117,7 @@ Example: Adding a new API endpoint and updating button styles are independent.
 
 **To stack an existing branch** on top of another: `but move <child-branch-name> --above <parent-branch-name>`.
 
-**To create a new stacked branch** from scratch: `but branch new <name> -a <anchor>` — only use this when the child branch doesn't exist yet.
+**To create a new stacked branch** from scratch: `but branch new <name> --above <parent-branch-name>` — only use this when the child branch doesn't exist yet.
 
 ```
 main ── authentication ── user-profile ── settings-page

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -57,7 +57,7 @@ but status -fv
 but commit -b add-authentication -m "Add JWT authentication" <file-ids>
 
 # 4. Create stacked branch anchored on authentication
-but branch new user-profile -a add-authentication
+but branch new user-profile --above add-authentication
 
 # 5. Implement profile page (depends on auth)
 # (edit pages/profile.js)

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -108,12 +108,12 @@ Create a new branch.
 ```bash
 but branch new                      # Generated branch name
 but branch new feature              # Independent branch (parallel work)
-but branch new feature -a <anchor>  # Stacked branch (dependent work)
+but branch new feature --above <parent>  # Stacked branch (dependent work)
 ```
 
 Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
 
-In single-branch mode (no managed workspace), `but branch new` stacks the new branch above the checked-out branch (or the `-a` anchor). When the new branch lands above the checked-out branch — always the case without an anchor — it is checked out and `HEAD` moves to it.
+In single-branch mode (no managed workspace), `but branch new` stacks the new branch above the checked-out branch (or the `--above` target). When the new branch lands above the checked-out branch — always the case without `--above` — it is checked out and `HEAD` moves to it.
 
 For "commit these selected changes on a new branch", prefer `but commit -b <branch> -m "message" <ids>` instead of a separate `but branch new` or preflight `but status -fv` — `-b` creates the branch when it does not exist.
 

--- a/crates/but/src/utils/rejection.rs
+++ b/crates/but/src/utils/rejection.rs
@@ -293,7 +293,7 @@ fn write_report<W: std::fmt::Write + ?Sized>(
                 t.local_branch.paint(dependency),
             ),
             format!(
-                "but branch new {} --anchor {}",
+                "but branch new {} --above {}",
                 shell_quote(name),
                 shell_quote(dependency)
             ),

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -921,7 +921,7 @@ Error: Cannot commit: 1 change could not be applied:
     line 1 depends on foo (xsz)
 
 Hint: to apply these changes, create bar stacked on top of foo and try again:
-  but branch new bar --anchor foo
+  but branch new bar --above foo
 
 "#]]);
 }


### PR DESCRIPTION
When `but commit -b <new-branch>` is rejected because a hunk depends on another branch, the hint printed `but branch new <name> --anchor <dep>`. `--anchor` was hidden and deprecated in favour of `--above` when `branch new` was re-implemented, so following the hint produced a deprecation warning and contradicted `but branch new --help`.

The hint now prints `--above`. The skill guide's dependency-conflict recipe taught the same stale flag and is updated alongside. The existing snapshot test on the hint now asserts the new flag, so a future rename fails CI.

Fixes GB-2045