### PR TITLE
Point the unknown-change hint at `but diff`

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -34,8 +34,12 @@ impl std::fmt::Display for CliIdArg {
 }
 
 impl CliIdArg {
-    #[expect(missing_docs)]
+    /// Hint for an argument that resolved to no branch or commit.
     pub const TARGET_MISSING_HINT: &str = "Run `but status` for applicable targets.";
+    /// Hint for an argument that resolved to no uncommitted file or hunk.
+    /// `but status` shows no hunk IDs, so point at the read that mints them.
+    pub const CHANGE_MISSING_HINT: &str =
+        "Run `but diff` for the current change IDs; a hunk ID is `<file>:<hunk>`.";
 
     /// Parse this argument into all matching CLI IDs in the workspace.
     pub fn parse(&self, repo: &gix::Repository, id_map: &IdMap) -> CliResult<Vec<CliId>> {
@@ -354,7 +358,7 @@ impl CliIdArg {
         } else {
             Err(
                 bad_input(format!("Could not find uncommitted change: '{self}'"))
-                    .hint(Self::TARGET_MISSING_HINT)
+                    .hint(Self::CHANGE_MISSING_HINT)
                     .into(),
             )
         }

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -269,7 +269,7 @@ fn resolve(
 /// The retired syntax put the target branch in positional position
 /// (`but commit <branch> -m "message"`), which the modern grammar reads as a
 /// change. When a change fails to resolve but names an applied branch,
-/// suggest `-b` targeting instead of the generic missing-target hint.
+/// suggest `-b` targeting instead of the generic missing-change hint.
 fn unresolved_change_error(change: &CliIdArg, repo: &gix::Repository, id_map: &IdMap) -> CliError {
     let names_branch = change
         .parse(repo, id_map)
@@ -284,7 +284,7 @@ fn unresolved_change_error(change: &CliIdArg, repo: &gix::Repository, id_map: &I
         ))
         .into()
     } else {
-        err.hint(CliIdArg::TARGET_MISSING_HINT).into()
+        err.hint(CliIdArg::CHANGE_MISSING_HINT).into()
     }
 }
 

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -27,6 +27,26 @@ Hint: Name it with `but reword g0` first! Note that the short ID is likely to ch
 "#]]);
 }
 
+#[test]
+fn unknown_source_points_at_diff() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.file("new.txt", "content\n");
+
+    // Sources resolve through the shared `resolve_uncommitted`, so the hint
+    // names the read that mints change IDs rather than the target hint.
+    env.but("amend -t A notexist")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Could not find uncommitted change: 'notexist'
+
+Hint: Run `but diff` for the current change IDs; a hunk ID is `<file>:<hunk>`.
+
+"#]]);
+}
+
 fn uncommitted_contains_file(status: &serde_json::Value, file_path: &str) -> bool {
     status["uncommittedChanges"]
         .as_array()

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1793,7 +1793,7 @@ Hint: 'A' is a branch. To commit onto it, run `but commit -b A -m "message" [<ch
         .stderr_eq(snapbox::str![[r#"
 Error: Could not find uncommitted change: 'notexist'
 
-Hint: Run `but status` for applicable targets.
+Hint: Run `but diff` for the current change IDs; a hunk ID is `<file>:<hunk>`.
 
 "#]]);
 }


### PR DESCRIPTION
`Could not find uncommitted change: '<id>'` reused `TARGET_MISSING_HINT`, which tells the reader to run `but status` for applicable targets. That hint is written for branch and commit targets: `but status` shows no hunk IDs, so an agent that follows it literally cannot recover. `but diff` is the read that mints file and hunk IDs.

This gives the error its own hint:

```
Hint: Run `but diff` for the current change IDs; a hunk ID is `<file>:<hunk>`.
```

It names the read and the ID shape, since passing a bare hunk suffix (`2e4` instead of `uvw:2e4`) is the usual cause in agent traces. Both sites that emit the error use the new hint (`CliIdArg::resolve_uncommitted` and `commit.rs::unresolved_change_error`); `TARGET_MISSING_HINT` stays for branch/commit targets, and the `-b` suggestion for a change that names a branch is unchanged.

One snapshot updated in `tests/but/command/commit.rs`.