### PR TITLE
Refresh apps after archiving or unarchiving worktrees

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -537,6 +537,8 @@ but worktree remove [-f] <id|name> # Like `git worktree remove`; `-f` for uncomm
 
 Worktrees are listed most recently updated first, as `id name (refs/heads/branch) - path`, with the branch shown only when it differs from the worktree name. Archiving is a GitButler-only state; none of these take part in `but undo`.
 
+Archiving and unarchiving notify open apps to refresh the worktree listing and workspace.
+
 ## History & Undo
 
 ### `but undo` / `but redo`

--- a/crates/but/src/command/worktree/archive.rs
+++ b/crates/but/src/command/worktree/archive.rs
@@ -50,6 +50,10 @@ pub fn run(ctx: &Context, perm: &RepoShared, op: ArchivalOperation) -> Result<Ar
         op.archived,
         perm,
     )?;
+    but_api::tags::signal_invalidation(
+        &ctx.project_data_dir,
+        but_api::worktrees::WORKTREE_SET_ARCHIVED_INVALIDATES,
+    );
     Ok(ArchiveOutcome {
         name: op.worktree,
         archived: op.archived,

--- a/crates/but/tests/but/command/worktree.rs
+++ b/crates/but/tests/but/command/worktree.rs
@@ -226,6 +226,8 @@ old-3 - [..]/worktrees/old-3
 fn archive_and_unarchive_by_id_or_name() {
     let env = flag_on_sandbox();
     add_worktree_with_commit(&env, "wt-feature", "A");
+    let sentinel = env.context().project_data_dir.join("INVALIDATE");
+    let watcher_token = but_project_handle::process_sentinel_token();
 
     env.but("worktree list --active")
         .assert()
@@ -237,6 +239,7 @@ wt wt-feature - [..]/worktrees/wt-feature
 
 "#]]);
 
+    std::fs::write(&sentinel, "").unwrap();
     env.but("worktree archive wt")
         .assert()
         .success()
@@ -245,6 +248,14 @@ wt wt-feature - [..]/worktrees/wt-feature
 Successfully archived wt-feature
 
 "#]]);
+    assert_eq!(
+        but_project_handle::invalidation_by_others(
+            &std::fs::read_to_string(&sentinel).unwrap(),
+            &watcher_token,
+        ),
+        ["Worktrees", "Workspace"],
+        "archiving notifies the app to refresh the worktree listing and workspace"
+    );
     env.but("worktree list")
         .assert()
         .success()
@@ -259,6 +270,7 @@ wt-feature - [..]/worktrees/wt-feature
 "#]]);
 
     // Archived worktrees have no ID, so the name is the way to address them.
+    std::fs::write(&sentinel, "").unwrap();
     env.but("worktree unarchive wt-feature")
         .assert()
         .success()
@@ -267,6 +279,14 @@ wt-feature - [..]/worktrees/wt-feature
 Successfully unarchived wt-feature
 
 "#]]);
+    assert_eq!(
+        but_project_handle::invalidation_by_others(
+            &std::fs::read_to_string(&sentinel).unwrap(),
+            &watcher_token,
+        ),
+        ["Worktrees", "Workspace"],
+        "unarchiving emits a fresh invalidation as well"
+    );
     env.but("worktree list")
         .assert()
         .success()
@@ -280,6 +300,7 @@ Archived worktrees
 
 "#]]);
 
+    std::fs::write(&sentinel, "").unwrap();
     env.but("worktree archive nope")
         .assert()
         .failure()
@@ -290,6 +311,11 @@ Error: Could not find worktree: 'nope'
 Hint: Run `but worktree list` for the worktrees and their IDs.
 
 "#]]);
+    assert_eq!(
+        std::fs::read_to_string(&sentinel).unwrap(),
+        "",
+        "a failed archive leaves the app's caches valid"
+    );
 
     env.but("--json worktree archive wt")
         .allow_json()


### PR DESCRIPTION
Archiving or unarchiving a worktree through the CLI left Lite's workspace stale because the command bypassed the API wrapper's notification. Signal the existing `Worktrees` and `Workspace` invalidation tags after success so the workspace and worktree listing refresh.

Regression coverage checks archive, unarchive, and failure notifications. All four worktree command tests and Rust formatting checks pass.