### PR TITLE
ctx: add function to invalidate workspace

### DIFF
--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -546,6 +546,11 @@ impl Context {
 
 /// Trampolines that create new uncached instances of major types.
 impl Context {
+    /// Invalidates the workspace cache, if it is present.
+    pub fn invalidate_workspace(&mut self, _perm: &mut RepoExclusive) {
+        self.workspace.take();
+    }
+
     /// Create a cached workspace as seen from the current HEAD for editing, and return it,
     /// along with `(guard, &mut repo, &mut ws, &mut db)`.
     /// The guard ensures exclusive process-wide access to the repository.

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -38,13 +38,7 @@ pub fn reload_legacy(
 ) -> anyhow::Result<Vec<StatusOutputLine>> {
     let mut guard = ctx.exclusive_worktree_access();
 
-    {
-        let meta = ctx.meta()?;
-        let project_meta = ctx.project_meta()?;
-        let (repo, mut ws, mut db) =
-            ctx.workspace_mut_and_db_mut_with_perm(guard.write_permission())?;
-        ws.refresh_from_head(&repo, &meta, project_meta, &mut db)?;
-    }
+    ctx.invalidate_workspace(guard.write_permission());
 
     let mut new_lines = Vec::new();
 


### PR DESCRIPTION
This is in preparation for a future change that will make all `workspace_mut`-accessing functions take the cached workspace (instead of merely returning a mut reference to it). In the interest of keeping that PR as small as possible, I'm looking at all such call sites and seeing which ones I can refactor away from that first. This is the first such PR (and probably the only one).
