### PR TITLE
Fix Lite stalls from refetching unchanged blob diffs

### DIFF
--- a/apps/lite/harness/tests/panel.test.tsx
+++ b/apps/lite/harness/tests/panel.test.tsx
@@ -152,7 +152,10 @@ test("a watcher event refreshes the uncommitted files", async () => {
 	worktree = fixtureWorktreeChanges([fixtureFileChange("src/new-file.ts")]);
 	const event: WatcherEvent = {
 		name: "worktreeChanges",
-		payload: { type: "worktreeChanges", subject: { changes: worktree } },
+		payload: {
+			type: "worktreeChanges",
+			subject: { changes: worktree, changedPaths: ["src/new-file.ts"] },
+		},
 	};
 	panel.push(eventChannel, event);
 

--- a/apps/lite/ui/src/api/queries.test.ts
+++ b/apps/lite/ui/src/api/queries.test.ts
@@ -2,8 +2,17 @@ import {
 	getReviewMergeStatusQueryOptions,
 	listCIChecksQueryOptions,
 	treeChangesDiffsQueryOptions,
+	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
-import type { CiCheck, ReviewMergeStatus, TreeChange } from "@gitbutler/but-sdk";
+import { handleProjectEvent } from "#ui/project-events.ts";
+import { invalidateTags } from "#ui/api/tags.ts";
+import type {
+	CiCheck,
+	ReviewMergeStatus,
+	TreeChange,
+	TreeStatus,
+	WatcherEvent,
+} from "@gitbutler/but-sdk";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -147,5 +156,185 @@ describe("treeChangesDiffsQueryOptions", () => {
 		expect(worktree.queryHash).not.toBe(main);
 		expect(elsewhere.queryHash).not.toBe(main);
 		expect(treeChangesDiffsQueryOptions({ projectId: "p1", changes }).queryHash).toBe(main);
+	});
+});
+
+describe("diffs after file events", () => {
+	const change = (id: string): TreeChange => ({
+		path: "file.txt",
+		pathBytes: [102, 105, 108, 101, 46, 116, 120, 116],
+		status: {
+			type: "Modification",
+			subject: {
+				previousState: { id: "a".repeat(40), kind: "Blob" },
+				state: { id, kind: "Blob" },
+				flags: null,
+			},
+		},
+	});
+	const fileEvent = {
+		name: "project://p1/worktree_changes",
+		payload: {
+			type: "worktreeChanges",
+			subject: {
+				changedPaths: ["file.txt"],
+				changes: {
+					changes: [],
+					ignoredChanges: [],
+					modificationTimes: {},
+					assignments: [],
+					assignmentsError: null,
+					dependencies: null,
+					dependenciesError: null,
+				},
+			},
+		},
+	} satisfies WatcherEvent;
+
+	const state = { id: "b".repeat(40), kind: "Blob" } as const;
+	const previousState = { ...state, id: "a".repeat(40) };
+	it.each<TreeStatus>([
+		{ type: "Addition", subject: { state, isUntracked: false } },
+		{ type: "Deletion", subject: { previousState } },
+		{ type: "Modification", subject: { state, previousState, flags: null } },
+		{
+			type: "Rename",
+			subject: {
+				state,
+				previousState,
+				previousPath: "old.txt",
+				previousPathBytes: [],
+				flags: null,
+			},
+		},
+	])(
+		"leaves blob $type diffs alone during file churn, but still honors other invalidations",
+		async (status) => {
+			const client = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } });
+			const treeChangeDiffs = vi.fn().mockResolvedValue(null);
+			vi.stubGlobal("window", { lite: { treeChangeDiffs } });
+			vi.stubGlobal("navigator", { hardwareConcurrency: 2 });
+			const options = treeChangesDiffsQueryOptions({
+				projectId: "p1",
+				changes: [{ ...change(state.id), status }],
+			});
+			await client.fetchQuery(options);
+			const observer = new QueryObserver(client, options);
+			const unsubscribe = observer.subscribe(() => {});
+			try {
+				for (let i = 0; i < 3; i++) {
+					handleProjectEvent(fileEvent, "p1", client);
+					await vi.waitFor(() => expect(client.isFetching()).toBe(0));
+				}
+				expect(treeChangeDiffs).toHaveBeenCalledTimes(1);
+				await invalidateTags(client, ["Diffs"], "p1");
+				expect(treeChangeDiffs).toHaveBeenCalledTimes(2);
+				for (const payload of [
+					{ type: "gitActivity", subject: { headSha: "head" } },
+					{ type: "workspaceActivity", subject: null },
+				] as const) {
+					handleProjectEvent({ name: payload.type, payload }, "p1", client);
+					await vi.waitFor(() => expect(client.isFetching()).toBe(0));
+				}
+				expect(treeChangeDiffs).toHaveBeenCalledTimes(4);
+				for (const changedPaths of [[], undefined]) {
+					handleProjectEvent(
+						{
+							...fileEvent,
+							payload: {
+								...fileEvent.payload,
+								subject: { ...fileEvent.payload.subject, changedPaths },
+							},
+						} as WatcherEvent,
+						"p1",
+						client,
+					);
+					await vi.waitFor(() => expect(client.isFetching()).toBe(0));
+				}
+				expect(treeChangeDiffs).toHaveBeenCalledTimes(6);
+			} finally {
+				unsubscribe();
+				client.clear();
+			}
+		},
+	);
+
+	it.each([undefined, "linked"])(
+		"refreshes mixed live and blob diffs with unchanged descriptors in %s",
+		async (worktree) => {
+			const client = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } });
+			const diff = vi.fn().mockResolvedValue(null);
+			vi.stubGlobal("window", { lite: { treeChangeDiffs: diff, treeChangeDiffsFromSource: diff } });
+			vi.stubGlobal("navigator", { hardwareConcurrency: 2 });
+			const options = treeChangesDiffsQueryOptions({
+				projectId: "p1",
+				changes: [change(state.id), change("0".repeat(40))],
+				worktree,
+			});
+			await client.fetchQuery(options);
+			const observer = new QueryObserver(client, options);
+			const unsubscribe = observer.subscribe(() => {});
+			diff.mockResolvedValue({ type: "Binary" });
+			try {
+				handleProjectEvent(fileEvent, "p1", client);
+				await vi.waitFor(() =>
+					expect(client.getQueryData(options.queryKey)).toEqual([
+						{ type: "Binary" },
+						{ type: "Binary" },
+					]),
+				);
+				expect(diff).toHaveBeenCalledTimes(4);
+			} finally {
+				unsubscribe();
+				client.clear();
+			}
+		},
+	);
+
+	it("does not restart a blob diff stream that has already published a batch", async () => {
+		const client = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } });
+		const pending = Promise.withResolvers<null>();
+		const diff = vi.fn(({ change }: { change: TreeChange }) =>
+			change.path === "64" ? pending.promise : Promise.resolve(null),
+		);
+		vi.stubGlobal("window", { lite: { treeChangeDiffs: diff } });
+		vi.stubGlobal("navigator", { hardwareConcurrency: 2 });
+		const options = treeChangesDiffsQueryOptions({
+			projectId: "p1",
+			changes: Array.from({ length: 65 }, (_, i) => ({ ...change(state.id), path: String(i) })),
+		});
+		const observer = new QueryObserver(client, options);
+		const unsubscribe = observer.subscribe(() => {});
+		try {
+			await vi.waitFor(() => expect(client.getQueryData(options.queryKey)).toHaveLength(64));
+			handleProjectEvent(fileEvent, "p1", client);
+			pending.resolve(null);
+			await vi.waitFor(() => expect(client.isFetching()).toBe(0));
+			expect(client.getQueryData(options.queryKey)).toHaveLength(65);
+			expect(diff).toHaveBeenCalledTimes(65);
+		} finally {
+			pending.resolve(null);
+			unsubscribe();
+			client.clear();
+		}
+	});
+
+	it("filters single-file diffs and conservatively refreshes queries without metadata", async () => {
+		const client = new QueryClient();
+		const blob = treeChangeDiffsQueryOptions({ projectId: "p1", change: change(state.id) });
+		const live = treeChangeDiffsQueryOptions({ projectId: "p1", change: change("0".repeat(40)) });
+		const unknown = { queryKey: ["p1", "treeChangeDiffs", "unknown"] as const };
+		vi.stubGlobal("window", { lite: { treeChangeDiffs: vi.fn().mockResolvedValue(null) } });
+		await client.fetchQuery(blob);
+		await client.fetchQuery(live);
+		client.setQueryData(unknown.queryKey, null);
+		try {
+			handleProjectEvent(fileEvent, "p1", client);
+			expect(client.getQueryState(blob.queryKey)?.isInvalidated).toBe(false);
+			expect(client.getQueryState(live.queryKey)?.isInvalidated).toBe(true);
+			expect(client.getQueryState(unknown.queryKey)?.isInvalidated).toBe(true);
+		} finally {
+			client.clear();
+		}
 	});
 });

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -606,9 +606,15 @@ export const listCIChecksQueryOptions = ({
 		},
 	});
 
+// This matches but_core::unified_diff::filter_from_state: only a null destination
+// object ID reads file content (and attributes) from disk rather than Git.
+const readsWorktree = ({ status }: TreeChange): boolean =>
+	status.type !== "Deletion" && /^0+$/.test(status.subject.state.id);
+
 export const treeChangeDiffsQueryOptions = ({ projectId, change }: PayloadFor<"treeChangeDiffs">) =>
 	queryOptions({
 		queryKey: [projectId, "treeChangeDiffs", change],
+		meta: { readsWorktree: readsWorktree(change) },
 		queryFn: () => window.lite.treeChangeDiffs({ projectId, change }),
 	});
 
@@ -623,7 +629,10 @@ export const treeChangeDiffsQueryOptions = ({ projectId, change }: PayloadFor<"t
  * scope it was computed for, so an array reused under another project or worktree, as a shared
  * empty one is, hashes again rather than colliding.
  */
-const treeChangeDiffHashes = new WeakMap<Array<TreeChange>, { scope: string; hash: string }>();
+const treeChangeDiffHashes = new WeakMap<
+	Array<TreeChange>,
+	{ scope: string; hash: string; readsWorktree: boolean }
+>();
 
 export const treeChangesDiffsQueryOptions = ({
 	projectId,
@@ -638,16 +647,16 @@ export const treeChangesDiffsQueryOptions = ({
 	const queryKey = [projectId, "treeChangeDiffs", worktree, changes] as const;
 
 	const scope = `${projectId}:${worktree ?? ""}`;
-	const cached = treeChangeDiffHashes.get(changes);
-	let queryHash = cached?.scope === scope ? cached.hash : undefined;
-	if (queryHash === undefined) {
-		queryHash = hashKey(queryKey);
-		treeChangeDiffHashes.set(changes, { scope, hash: queryHash });
+	let cached = treeChangeDiffHashes.get(changes);
+	if (cached?.scope !== scope) {
+		cached = { scope, hash: hashKey(queryKey), readsWorktree: changes.some(readsWorktree) };
+		treeChangeDiffHashes.set(changes, cached);
 	}
 
 	return queryOptions({
 		queryKey,
-		queryHash,
+		queryHash: cached.hash,
+		meta: { readsWorktree: cached.readsWorktree },
 		queryFn: experimental_streamedQuery<Array<UnifiedPatch | null>, Array<UnifiedPatch | null>>({
 			initialValue: [],
 			refetchMode: "replace",

--- a/apps/lite/ui/src/project-events.ts
+++ b/apps/lite/ui/src/project-events.ts
@@ -124,8 +124,19 @@ export const handleProjectEvent = (
 	if (payload.type === "gitHead")
 		client.setQueryData([projectId, "operatingMode"], () => payload.subject);
 
-	for (const query of invalidateOn.get(payload.type) ?? [])
-		void client.invalidateQueries({ queryKey: [projectId, query] });
+	for (const query of invalidateOn.get(payload.type) ?? []) {
+		void client.invalidateQueries({
+			queryKey: [projectId, query],
+			// File edits cannot change blob-only diffs. Index events have no paths
+			// and must still refresh everything (e.g. staged attributes).
+			predicate:
+				payload.type === "worktreeChanges" &&
+				Array.isArray(payload.subject.changedPaths) &&
+				payload.subject.changedPaths.length > 0
+					? ({ meta }) => meta?.readsWorktree !== false
+					: undefined,
+		});
+	}
 
 	// Another process's mutation, with the tags it declared: the event table
 	// has nothing to add.

--- a/crates/but-api/src/watcher.rs
+++ b/crates/but-api/src/watcher.rs
@@ -162,6 +162,9 @@ but_schemars::register_sdk_type!(WatcherExternalInvalidationPayload);
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WatcherWorktreeChangesPayload {
+    /// Worktree-relative paths that triggered the event, using the same lossy
+    /// encoding as UI change paths. Empty for index changes or unknown paths.
+    pub changed_paths: Vec<String>,
     /// The file changes in the repository.
     pub changes: WorktreeChanges,
 }

--- a/crates/but-napi/src/lib.rs
+++ b/crates/but-napi/src/lib.rs
@@ -338,11 +338,17 @@ fn event_from_change(change: gitbutler_watcher::Change) -> WatcherEvent {
         gitbutler_watcher::Change::WorktreeChanges {
             project_id,
             changes,
-            changed_paths: _,
+            changed_paths,
         } => WatcherEvent {
             name: format!("project://{project_id}/worktree_changes"),
             payload: serde_json::json!(WatcherPayload::WorktreeChanges(
-                WatcherWorktreeChangesPayload { changes }
+                WatcherWorktreeChangesPayload {
+                    changes,
+                    changed_paths: changed_paths
+                        .iter()
+                        .map(|path| path.to_string_lossy().into_owned())
+                        .collect(),
+                }
             )),
         },
     }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -4758,6 +4758,11 @@ export type WatcherWorkspaceActivityPayload = null;
 
 /** Worktree files changes. */
 export type WatcherWorktreeChangesPayload = {
+  /**
+   * Worktree-relative paths that triggered the event, using the same lossy
+   * encoding as UI change paths. Empty for index changes or unknown paths.
+   */
+  changedPaths: Array<string>;
   /** The file changes in the repository. */
   changes: WorktreeChanges;
 };

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -4758,6 +4758,11 @@ export type WatcherWorkspaceActivityPayload = null;
 
 /** Worktree files changes. */
 export type WatcherWorktreeChangesPayload = {
+  /**
+   * Worktree-relative paths that triggered the event, using the same lossy
+   * encoding as UI change paths. Empty for index changes or unknown paths.
+   */
+  changedPaths: Array<string>;
   /** The file changes in the repository. */
   changes: WorktreeChanges;
 };


### PR DESCRIPTION
Fixes [GB-2046](https://linear.app/gitbutler/issue/GB-2046/next-nightly-stalls-and-saturates-cpu-when-file-events-repeatedly).

File watcher events invalidated every diff query, including an open committed diff whose content had not changed. For a large commit, each refresh repeated native diff work and synchronous hashing of the full changes array inside the streamed query's cache lookups. Repeated unrelated file writes caused CPU saturation and roughly 300 ms renderer stalls.

### Reproduction and impact

The isolated macOS fixture attached to the issue reproduces this on Next Nightly 0.0.200 and the source build before this fix:

1. Create a repository with 5,000 tracked text files plus `.gitignore`, and 23 stable untracked files.
2. Keep the 5,001-file baseline commit selected in the diff view.
3. Repeatedly create and delete an unrelated `fixture-noise.lock` file at 750 ms intervals for 25 seconds (33 writes).

With the same fixture and workload, comparing the source build before and after:

| Observation during file churn | Before | After |
| --- | ---: | ---: |
| Renderer response time, p95 | 273 ms | 5 ms |
| Renderer long tasks | 31 | 0 |
| Main-process CPU time over 25 seconds | 112.43 s | 34.92 s |

CPU time accumulates across threads. These are local reproduction results; the remaining work includes normal watcher processing.

### Fix

Mark diff queries according to whether they read from the worktree, using the same null-destination-object-ID rule as the Rust diff engine. Preserve the watcher's changed paths through N-API so ordinary file events can skip blob-only diffs.

Index events still refresh broadly: they carry no changed paths, and staged attributes can affect blob diffs. Missing paths or query metadata also keep the existing broad invalidation behavior. Live and mixed worktree diffs continue refreshing, including edits that leave their change descriptors unchanged; editing and restoring a file in the reproduction app updated the displayed diff in both directions.

This keeps the change confined to watcher payload forwarding and Lite query invalidation. It adds no debounce or scheduling mechanism and leaves live-worktree invalidation broad.