### PR TITLE
Add a saved History display menu in Lite

### DIFF
--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -29,6 +29,7 @@ const guiSettingsV1 = type({
 	"fileDisplayMode?": "'list' | 'tree'",
 	"filesPanelRight?": "boolean",
 	"handCursor?": "boolean",
+	"historyDisplayMode?": "'commits' | 'last-12-hours'",
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",
 	"minimap?": "boolean",
 	"pathFirst?": "boolean",

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -7,6 +7,7 @@ import type {
 	ForgeName,
 	ForgeReview,
 	ReviewMergeStatus,
+	TargetCommit,
 	TreeChange,
 	UnifiedPatch,
 } from "@gitbutler/but-sdk";
@@ -222,11 +223,41 @@ export const workspaceTargetCommitsQueryOptions = (projectId: string) =>
 	});
 
 /** The cursor is exclusive. Sharing the listing's key prefix also shares its invalidation. */
-export const olderTargetCommitsInfiniteQueryOptions = (projectId: string, from: string) =>
+export const olderTargetCommitsInfiniteQueryOptions = (
+	projectId: string,
+	from: string,
+	recent = false,
+) =>
 	infiniteQueryOptions({
-		queryKey: [projectId, "workspaceTargetCommits", { olderThan: from }],
-		queryFn: ({ pageParam }) =>
-			window.lite.workspaceTargetCommits({ projectId, from: pageParam, limit: 25 }),
+		queryKey: [projectId, "workspaceTargetCommits", { olderThan: from, recent }],
+		queryFn: async ({ pageParam, signal }) => {
+			const since = recent && pageParam === from ? Date.now() - 12 * 60 * 60 * 1000 : undefined;
+			const commits: Array<TargetCommit> = [];
+			let cursor = pageParam;
+			for (;;) {
+				signal.throwIfAborted();
+				const page = await window.lite.workspaceTargetCommits({
+					projectId,
+					from: cursor,
+					limit: 25,
+				});
+				commits.push(...page.commits);
+				const last = page.commits.at(-1);
+				if (
+					since === undefined ||
+					!page.hasMore ||
+					last === undefined ||
+					last.commit.id === cursor ||
+					(last.inWorkspace && last.commit.committedAt < since)
+				) {
+					return {
+						commits,
+						hasMore: page.hasMore && last !== undefined && last.commit.id !== cursor,
+					};
+				}
+				cursor = last.commit.id;
+			}
+		},
 		initialPageParam: from,
 		getNextPageParam: (page) => (page.hasMore ? page.commits.at(-1)?.commit.id : undefined),
 	});

--- a/apps/lite/ui/src/projects/graph.ts
+++ b/apps/lite/ui/src/projects/graph.ts
@@ -35,6 +35,9 @@ const graphSlice = createSlice({
 			if (!state.historyExpanded) return;
 			state.moreHistory += 1;
 		},
+		resetHistory: (state) => {
+			state.moreHistory = 0;
+		},
 		showMoreRun: (state, { payload: { runId } }: PayloadAction<{ runId: string }>) => {
 			state.moreRuns[runId] = (state.moreRuns[runId] ?? 0) + 1;
 		},
@@ -50,6 +53,9 @@ const graphSlice = createSlice({
 export const createInitialGraphState = (): GraphState => graphSlice.getInitialState();
 
 export const graphReducers = {
+	resetHistory: (state: GraphState) => {
+		graphSlice.caseReducers.resetHistory(state);
+	},
 	toggleHistory: (state: GraphState) => {
 		graphSlice.caseReducers.toggleHistory(state);
 	},

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -189,6 +189,9 @@ export const projectReducers = {
 	showMoreGraphHistory: (state: ProjectState) => {
 		graphReducers.showMoreHistory(state.graph);
 	},
+	resetGraphHistory: (state: ProjectState) => {
+		graphReducers.resetHistory(state.graph);
+	},
 	showMoreGraphRun: (state: ProjectState, { runId }: { runId: string }) => {
 		graphReducers.showMoreRun(state.graph, { runId });
 	},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/HistoryMenu.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/HistoryMenu.tsx
@@ -1,0 +1,58 @@
+import { useSaveGUISettings } from "#ui/api/mutations.ts";
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import { nativeMenuItem, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppDispatch } from "#ui/store.ts";
+import { useQuery } from "@tanstack/react-query";
+import type { GUISettings } from "#electron/settings.ts";
+import { Icon } from "#ui/components/Icon.tsx";
+import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
+import { Button, Tooltip } from "@base-ui/react";
+import type { FC } from "react";
+
+export const HistoryMenu: FC<{ projectId: string }> = ({ projectId }) => {
+	const dispatch = useAppDispatch();
+	const { data: mode = defaultSettings.historyDisplayMode } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (settings) => settings.historyDisplayMode ?? defaultSettings.historyDisplayMode,
+	});
+	const { mutate: saveGUISettings } = useSaveGUISettings();
+	const select = (historyDisplayMode: NonNullable<GUISettings["historyDisplayMode"]>) => {
+		if (historyDisplayMode === mode) return;
+		dispatch(projectSlice.actions.resetGraphHistory({ projectId }));
+		saveGUISettings({ historyDisplayMode });
+	};
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				aria-label="History menu"
+				aria-haspopup="menu"
+				className={getRowButtonClassName({ iconOnly: true })}
+				render={<Button />}
+				onClick={(event) => {
+					void showNativeMenuFromTrigger(event.currentTarget, [
+						nativeMenuItem({
+							label: "Last 5 commits",
+							checked: mode === "commits",
+							onSelect: () => select("commits"),
+						}),
+						nativeMenuItem({
+							label: "Last 12 hours",
+							checked: mode === "last-12-hours",
+							onSelect: () => select("last-12-hours"),
+						}),
+					]);
+				}}
+			>
+				<Icon name="kebab" />
+			</Tooltip.Trigger>
+			<Tooltip.Portal>
+				<Tooltip.Positioner sideOffset={4}>
+					<Tooltip.Popup render={<TooltipPopup />}>History menu</Tooltip.Popup>
+				</Tooltip.Positioner>
+			</Tooltip.Portal>
+		</Tooltip.Root>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.test.tsx
@@ -18,12 +18,17 @@ vi.mock("#ui/components/Tooltip.tsx", () => ({
 }));
 vi.mock("#ui/api/mutations.ts", () => ({
 	useWorkspaceIntegrateUpstream: () => ({ isPending: false, mutate: vi.fn() }),
+	useSaveGUISettings: () => ({ mutate: saveSettings }),
 }));
 vi.mock("#ui/projects/state.ts", () => ({
-	projectSlice: { selectors: { selectPendingOperation: () => ({ _tag: "None" }) } },
+	projectSlice: {
+		selectors: { selectPendingOperation: () => ({ _tag: "None" }) },
+		actions: { resetGraphHistory: (payload: unknown) => ({ type: "resetGraphHistory", payload }) },
+	},
 }));
 vi.mock("#ui/store.ts", () => ({
 	useAppSelector: (select: (state: object) => unknown) => select({}),
+	useAppDispatch: () => dispatch,
 }));
 vi.mock("#ui/routes/project/$id/workspace/WorkspaceLists/context.tsx", () => ({
 	useAddressSpace: () => ({ items: [], indexByKey: new Map() }),
@@ -37,6 +42,9 @@ let root: Root;
 let container: HTMLDivElement;
 let client: QueryClient;
 const onMore = vi.fn();
+const saveSettings = vi.fn();
+const dispatch = vi.fn();
+const showNativeMenu = vi.fn();
 const plan: Plan = {
 	order: [],
 	header: { label: "origin/main", current: false, incoming: 0 },
@@ -51,6 +59,10 @@ const plan: Plan = {
 
 beforeEach(() => {
 	onMore.mockReset();
+	saveSettings.mockReset();
+	dispatch.mockReset();
+	showNativeMenu.mockReset();
+	vi.stubGlobal("lite", { showNativeMenu });
 	client = new QueryClient({ defaultOptions: { queries: { retry: false, enabled: false } } });
 	container = document.createElement("div");
 	document.body.append(container);
@@ -60,6 +72,7 @@ afterEach(async () => {
 	await act(async () => root.unmount());
 	client.clear();
 	container.remove();
+	vi.unstubAllGlobals();
 });
 const render = async (historyMore: Graph["historyMore"] = "idle", current = false) => {
 	await act(async () => {
@@ -118,4 +131,41 @@ it("does not activate History pagination while a page is loading", async () => {
 		button.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
 	});
 	expect(onMore).not.toHaveBeenCalled();
+});
+
+it("offers both History defaults and saves the selected mode", async () => {
+	await render();
+	showNativeMenu.mockResolvedValueOnce("native-menu:1");
+	const button = assert(container.querySelector<HTMLButtonElement>('[aria-label="History menu"]'));
+	expect(button.tabIndex).toBe(0);
+	expect(button.getAttribute("aria-haspopup")).toBe("menu");
+	await act(async () => button.click());
+	expect(showNativeMenu).toHaveBeenCalledWith(
+		expect.objectContaining({
+			items: [
+				expect.objectContaining({ label: "Last 5 commits", checked: true }),
+				expect.objectContaining({ label: "Last 12 hours", checked: false }),
+			],
+		}),
+	);
+	expect(saveSettings).toHaveBeenCalledWith({ historyDisplayMode: "last-12-hours" });
+	expect(dispatch).toHaveBeenCalledWith({
+		type: "resetGraphHistory",
+		payload: { projectId: "section-test" },
+	});
+	await act(async () => {
+		client.setQueryData(["guiSettings"], { version: 1, historyDisplayMode: "last-12-hours" });
+	});
+	await render();
+	showNativeMenu.mockResolvedValueOnce("native-menu:0");
+	await act(async () => button.click());
+	expect(showNativeMenu).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			items: [
+				expect.objectContaining({ label: "Last 5 commits", checked: false }),
+				expect.objectContaining({ label: "Last 12 hours", checked: true }),
+			],
+		}),
+	);
+	expect(saveSettings).toHaveBeenLastCalledWith({ historyDisplayMode: "commits" });
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -1,3 +1,4 @@
+import { HistoryMenu } from "./HistoryMenu.tsx";
 import { GraphGap, GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -422,6 +423,7 @@ export const Section: FC<{
 				<>
 					<Header
 						label="History"
+						toolbar={<HistoryMenu projectId={projectId} />}
 						className={classes(styles.header, styles.trunkHeader)}
 						fold={{ open: plan.historyExpanded, onToggle: onToggleHistory, name: "history" }}
 						rail={

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -206,6 +206,29 @@ describe("layout", () => {
 		expect(more.historyHidden).toBe(10);
 	});
 
+	it("includes the time boundary and keeps intervening commits in graph order", () => {
+		const timed = [100, 99, 101, 98].map((committedAt, index) => {
+			const entry = commit(`history${index}`, true);
+			return { ...entry, commit: { ...entry.commit, committedAt } };
+		});
+		const plan = layout(
+			[],
+			target(true),
+			{ commits: timed, hasMore: false },
+			{
+				...folded,
+				historyExpanded: true,
+				historySince: 100,
+			},
+		);
+		expect(plan.history.map((entry) => entry.commit.id)).toEqual([
+			"history0",
+			"history1",
+			"history2",
+		]);
+		expect(plan.historyHidden).toBe(1);
+	});
+
 	it("orders cards by base depth, deepest first, then as given", () => {
 		const plan = layout([stack("deep"), stack("shallow"), stack("deep")], null, listing, folded);
 		expect(plan.order).toEqual([0, 2, 1]);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -39,6 +39,7 @@ type Folds = {
 	incomingExpanded: boolean;
 	historyExpanded: boolean;
 	moreHistory: number;
+	historySince?: number;
 	/** How many times more of each run was asked for, by the run's id. */
 	moreRuns: Readonly<Record<string, number>>;
 };
@@ -225,7 +226,13 @@ export const layout = (
 		historyAvailable && folds.historyExpanded
 			? [...shared, ...olderPages.filter((commit) => commit.inWorkspace)]
 			: [];
-	const historyCount = FIRST_HISTORY + folds.moreHistory * MORE_COMMITS;
+	// Keep the graph contiguous even when commit timestamps are out of order.
+	const since = folds.historySince;
+	const initialHistory =
+		since === undefined
+			? FIRST_HISTORY
+			: history.findLastIndex((entry) => entry.commit.committedAt >= since) + 1;
+	const historyCount = initialHistory + folds.moreHistory * MORE_COMMITS;
 
 	return {
 		order: structure.order,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { projectSlice } from "#ui/projects/state.ts";
 import { usePlan, type Graph } from "./usePlan.ts";
 import { sectionAddresses } from "./layout.ts";
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -73,6 +74,7 @@ beforeEach(async () => {
 			Promise.resolve(from === null ? listing : from === "base" ? page("older") : page("oldest")),
 		);
 	vi.stubGlobal("lite", {
+		readGUISettings: () => Promise.resolve({ version: 1 }),
 		headInfo: () =>
 			Promise.resolve({
 				stacks: [],
@@ -268,4 +270,112 @@ it("preserves stack placement identities while History opens and pages", async (
 	await showMoreHistory();
 	expect(graph().stacks).toBe(stacks);
 	expect(graph().plan.worktrees).toBe(worktrees);
+});
+
+const setRecentHistory = async (recent = true) => {
+	await act(async () => {
+		client.setQueryData(guiSettingsQueryOptions.queryKey, {
+			version: 1,
+			historyDisplayMode: recent ? "last-12-hours" : "commits",
+		});
+	});
+	await flush();
+};
+const timedCommit = (id: string, age: number, inWorkspace = true): TargetCommit => ({
+	...commit(id, inWorkspace),
+	commit: { ...commit(id).commit, committedAt: Date.now() - age },
+});
+const hour = 60 * 60 * 1000;
+
+it("automatically loads the last 12 hours across pages and still reveals older commits on demand", async () => {
+	const first = Array.from({ length: 25 }, (_, i) => timedCommit(`recent${i}`, hour));
+	const second = [timedCommit("last-recent", 11 * hour), timedCommit("old", 13 * hour)];
+	targetCommits.mockResolvedValueOnce({ commits: first, hasMore: true });
+	targetCommits.mockResolvedValueOnce({ commits: second, hasMore: true });
+	await setRecentHistory();
+	expect(targetCommits).toHaveBeenCalledTimes(1);
+	const stacks = graph().stacks;
+	const worktrees = graph().plan.worktrees;
+	await toggleHistory();
+	expect(targetCommits).toHaveBeenCalledTimes(3);
+	expect(targetCommits).toHaveBeenLastCalledWith({ projectId, from: "recent24", limit: 25 });
+	expect(graph().plan.history.at(-1)?.commit.id).toBe("last-recent");
+	expect(graph().plan.history).toHaveLength(27);
+	expect(graph().plan.historyHidden).toBe(1);
+	expect(graph().stacks).toBe(stacks);
+	expect(graph().plan.worktrees).toBe(worktrees);
+	targetCommits.mockResolvedValueOnce({ commits: [commit("oldest")], hasMore: false });
+	await showMoreHistory();
+	expect(graph().plan.history.at(-1)?.commit.id).toBe("oldest");
+	expect(graph().historyMore).toBe("hidden");
+	await toggleHistory();
+	await toggleHistory();
+	expect(graph().plan.history.at(-1)?.commit.id).toBe("last-recent");
+});
+
+it("lets Show more reveal history when there are no commits in the last 12 hours", async () => {
+	await setRecentHistory();
+	await toggleHistory();
+	expect(graph().plan.history).toEqual([]);
+	expect(graph().historyMore).toBe("idle");
+	await showMoreHistory();
+	expect(graph().plan.history).toHaveLength(20);
+	expect(graph().plan.history[0]?.commit.id).toBe("base");
+});
+
+it("keeps walking old incoming pages until it reaches shared history", async () => {
+	await act(async () => {
+		client.setQueryData([projectId, "workspaceTargetCommits"], {
+			commits: [commit("incoming", false)],
+			hasMore: true,
+		});
+	});
+	targetCommits.mockResolvedValueOnce({ commits: [commit("continued", false)], hasMore: true });
+	targetCommits.mockResolvedValueOnce({
+		commits: [timedCommit("shared", hour), commit("old")],
+		hasMore: false,
+	});
+	await setRecentHistory();
+	await toggleHistory();
+	expect(graph().plan.history.map((entry) => entry.commit.id)).toEqual(["shared"]);
+	expect(graph().plan.header?.incoming).toBe(2);
+});
+
+it("updates the time window while open without refetching its cached history", async () => {
+	targetCommits.mockResolvedValueOnce({
+		commits: [timedCommit("recent", 12 * hour - 30_000), commit("old")],
+		hasMore: false,
+	});
+	await setRecentHistory();
+	await toggleHistory();
+	expect(graph().plan.history.at(-1)?.commit.id).toBe("recent");
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(60_000);
+	});
+	expect(graph().plan.history).toEqual([]);
+	expect(targetCommits).toHaveBeenCalledTimes(2);
+	await setRecentHistory(false);
+	expect(graph().plan.history).toHaveLength(5);
+});
+
+it("does not expand a newly selected mode when an earlier Show more request finishes", async () => {
+	await toggleHistory();
+	await showMoreHistory();
+	const next = Promise.withResolvers<TargetCommitPage>();
+	targetCommits.mockReturnValueOnce(next.promise);
+	let request: Promise<void>;
+	await act(async () => {
+		request = graph().showMoreHistory();
+	});
+	await act(async () => {
+		store.dispatch(projectSlice.actions.resetGraphHistory({ projectId }));
+	});
+	await setRecentHistory();
+	await act(async () => {
+		next.resolve(page("oldest"));
+		await request;
+	});
+	await flush();
+	expect(graph().plan.history).toEqual([]);
+	expect(projectSlice.selectors.selectGraphFolds(store.getState(), projectId).moreHistory).toBe(0);
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
@@ -1,12 +1,15 @@
 import {
 	headInfoQueryOptions,
+	guiSettingsQueryOptions,
 	olderTargetCommitsInfiniteQueryOptions,
 	workspaceTargetCommitsQueryOptions,
 } from "#ui/api/queries.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import { useNow } from "#ui/components/useNow.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import type { Stack, TargetCommit, TargetCommitPage, Worktree } from "@gitbutler/but-sdk";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { canLoadHistory, layout, layoutStructure, MORE_COMMITS, type Plan } from "./layout.ts";
 
@@ -19,11 +22,19 @@ export type Graph = ReturnType<typeof usePlan>;
 /** The stacks graph's plan and the cards in its order. Called once per host, which hands it to the stacks. */
 export const usePlan = (projectId: string) => {
 	const dispatch = useAppDispatch();
+	const queryClient = useQueryClient();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const { data: baseListing } = useQuery(workspaceTargetCommitsQueryOptions(projectId));
 	const folds = useAppSelector((state) =>
 		projectSlice.selectors.selectGraphFolds(state, projectId),
 	);
+	const { data: historyDisplayMode = defaultSettings.historyDisplayMode } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (settings) => settings.historyDisplayMode ?? defaultSettings.historyDisplayMode,
+	});
+	const recent = historyDisplayMode === "last-12-hours";
+	const now = useNow(recent && folds.historyExpanded ? 60_000 : null);
+	const historySince = recent ? now - 12 * 60 * 60 * 1000 : undefined;
 	const listOrder = useMemo(() => headInfo?.stacks ?? [], [headInfo]);
 	const target = headInfo?.target ?? null;
 	const worktrees = headInfo?.worktrees ?? noWorktrees;
@@ -35,7 +46,7 @@ export const usePlan = (projectId: string) => {
 		isFetching,
 		isError,
 	} = useInfiniteQuery({
-		...olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom),
+		...olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom, recent),
 		enabled: (query) =>
 			folds.historyExpanded &&
 			target !== null &&
@@ -70,8 +81,17 @@ export const usePlan = (projectId: string) => {
 	);
 	// Keep the plan stable: the rails re-measure whenever its identity changes.
 	const plan: Plan = useMemo(
-		() => layout(listOrder, target, listing, folds, worktrees, historyPages, structure),
-		[listOrder, target, listing, folds, worktrees, historyPages, structure],
+		() =>
+			layout(
+				listOrder,
+				target,
+				listing,
+				{ ...folds, historySince },
+				worktrees,
+				historyPages,
+				structure,
+			),
+		[listOrder, target, listing, folds, historySince, worktrees, historyPages, structure],
 	);
 	const stacks: Array<Stack> = useMemo(
 		() =>
@@ -89,8 +109,13 @@ export const usePlan = (projectId: string) => {
 		) {
 			const result = await fetchNextPage();
 			if (result.isError) return;
+			const currentMode =
+				queryClient.getQueryData(guiSettingsQueryOptions.queryKey)?.historyDisplayMode ??
+				defaultSettings.historyDisplayMode;
+			if (currentMode !== historyDisplayMode) return;
 		}
-		if (plan.history.length > 0) dispatch(projectSlice.actions.showMoreGraphHistory({ projectId }));
+		if (plan.history.length > 0 || plan.historyHidden > 0)
+			dispatch(projectSlice.actions.showMoreGraphHistory({ projectId }));
 	};
 	return {
 		plan,

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -24,6 +24,7 @@ export const defaultSettings = {
 	filesPanelRight: false,
 	// Desktop apps keep the arrow over controls; the hand is a web convention (DESIGN.md, Cursors).
 	handCursor: false,
+	historyDisplayMode: "commits",
 	// Pierre's own default, named here so the setting has somewhere to fall back to.
 	lineDiffType: "word-alt",
 	// Experimental; opt in from the Experimental settings.


### PR DESCRIPTION
## 🧢 Changes

Add a kebab to the sidebar's History section to choose its default view: the last five commits or the last 12 hours. Save the preference, load enough history for the time window, and keep Show more available in both modes.

## ☕️ Reasoning

The time window uses commit time and keeps intervening commits in graph order. Switching modes resets pagination, including when an earlier request finishes afterwards.

Validation: Lite typecheck, lint, formatting, both Knip checks, 553 unit tests, and 33 end-to-end tests passed (9 skipped). After extracting the menu component, typecheck and all 67 graph tests passed; React Compiler memoization was checked.