### PR TITLE
Keep commit controls in a resizable Workspace pane

### DIFF
--- a/apps/lite/e2e/tests/commit-form.spec.ts
+++ b/apps/lite/e2e/tests/commit-form.spec.ts
@@ -32,3 +32,186 @@ test.describe("commit form", () => {
 		await expect(checkbox).toBeChecked();
 	});
 });
+
+test.describe("commit split view", () => {
+	test.use({ scenario: "project-with-many-independent-stacks.sh" });
+	test("keeps the button in place, scrolls each pane independently, and preserves the draft when resized", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		test.slow();
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		for (let index = 0; index < 80; index++) {
+			writeFileSync(
+				path.join(clone, `uncommitted-${String(index).padStart(3, "0")}.txt`),
+				"new file\n",
+			);
+		}
+		await appWindow.reload();
+		const start = appWindow.getByRole("button", { name: /start commit/i });
+		await expect(start).toBeInViewport();
+		const shared = appWindow.locator('[data-commit-mode="false"]');
+		const upstream = appWindow.locator('[class*="docked"]');
+		const expectCommitDocked = async () => {
+			await expect
+				.poll(async () => {
+					const footerElement = appWindow.locator('[class*="commitRow"]');
+					const footer = await footerElement.boundingBox();
+					const rail = await footerElement.locator('[class*="stretchSegment"]').boundingBox();
+					const button = await start.boundingBox();
+					const row = await upstream.boundingBox();
+					if (!footer || !rail || !button || !row) return Infinity;
+					const bottom = footer.y + footer.height;
+					return Math.max(
+						Math.abs(row.y - bottom),
+						Math.abs(rail.y + rail.height - bottom),
+						Math.abs(button.y - footer.y - (bottom - button.y - button.height)),
+					);
+				})
+				.toBeLessThan(1);
+		};
+		const expectUpstreamDocked = async () => {
+			await expect(upstream).toBeVisible();
+			await expect(upstream).toBeInViewport({ ratio: 1 });
+			await expect
+				.poll(async () => {
+					const row = await upstream.boundingBox();
+					const pane = await appWindow.locator("#sidebar-panel").boundingBox();
+					return row && pane ? Math.abs(row.y + row.height - pane.y - pane.height) : Infinity;
+				})
+				.toBeLessThan(1);
+		};
+		await expectUpstreamDocked();
+		await expectCommitDocked();
+		await shared.evaluate((el) => {
+			el.scrollTop = 400;
+		});
+		await expect.poll(() => shared.evaluate((el) => el.scrollTop)).toBe(400);
+		await expectUpstreamDocked();
+		await expectCommitDocked();
+		const before = await start.boundingBox();
+		if (!before) throw new Error("Commit button has no box");
+		await start.click();
+		const message = appWindow.getByRole("textbox", { name: "Compose commit message" });
+		await expect(message).toBeFocused();
+		const submit = appWindow.locator('[data-commit-form] button[type="submit"]');
+		const expectComposerInset = async () => {
+			await expect
+				.poll(async () => {
+					const row = await appWindow.locator('[class*="commitRow"]').boundingBox();
+					const form = await appWindow.locator("[data-commit-form]").boundingBox();
+					return row && form ? row.y + row.height - form.y - form.height : 0;
+				})
+				.toBe(8);
+		};
+		await expectComposerInset();
+		await expect
+			.poll(async () => {
+				const box = await submit.boundingBox();
+				return box ? Math.abs(box.y + box.height - before.y - before.height) : Infinity;
+			})
+			.toBeLessThan(2);
+		await message.fill("Keep this draft while resizing");
+		const divider = appWindow.getByRole("separator", {
+			name: "Resize uncommitted files and workspace",
+		});
+		const dividerBox = await divider.boundingBox();
+		if (!dividerBox) throw new Error("Split view has no divider");
+		await appWindow.mouse.move(
+			dividerBox.x + dividerBox.width / 2,
+			dividerBox.y + dividerBox.height / 2,
+		);
+		await appWindow.mouse.down();
+		await appWindow.mouse.move(dividerBox.x + dividerBox.width / 2, dividerBox.y - 220, {
+			steps: 8,
+		});
+		await appWindow.mouse.up();
+		await expect
+			.poll(async () => (await divider.boundingBox())?.y ?? Infinity)
+			.toBeLessThan(dividerBox.y - 150);
+		await expect(message).toHaveValue("Keep this draft while resizing");
+		await expectComposerInset();
+		await expectUpstreamDocked();
+		const files = appWindow.locator("[data-uncommitted-scroll]").filter({ visible: true });
+		const stacks = appWindow.locator('#commit-stacks [class*="workspaceScroller"]');
+		const fileOffset = await files.evaluate((el) => el.scrollTop);
+		const submitBefore = await submit.boundingBox();
+		const stackBox = await stacks.boundingBox();
+		if (!stackBox || !submitBefore) throw new Error("Missing split region");
+		await appWindow.mouse.move(stackBox.x + stackBox.width / 2, stackBox.y + stackBox.height / 2);
+		await appWindow.mouse.wheel(0, 900);
+		await expect.poll(() => stacks.evaluate((el) => el.scrollTop)).toBeGreaterThan(300);
+		expect(await files.evaluate((el) => el.scrollTop)).toBe(fileOffset);
+		const stackOffset = await stacks.evaluate((el) => el.scrollTop);
+		const fileBox = await files.boundingBox();
+		if (!fileBox) throw new Error("Missing file region");
+		await appWindow.mouse.move(fileBox.x + fileBox.width / 2, fileBox.y + fileBox.height / 2);
+		await appWindow.mouse.wheel(0, 500);
+		await expect.poll(() => files.evaluate((el) => el.scrollTop)).toBeGreaterThan(fileOffset);
+		expect(await stacks.evaluate((el) => el.scrollTop)).toBe(stackOffset);
+		expect((await submit.boundingBox())?.y).toBeCloseTo(submitBefore.y, 0);
+		const cancelOffset = await files.evaluate((el) => el.scrollTop);
+		const anchor = await files.evaluate((el) => {
+			const top = el.getBoundingClientRect().top;
+			const row = [...el.querySelectorAll('[role="treeitem"]')].find(
+				(row) => row.getBoundingClientRect().top >= top,
+			);
+			if (!row) throw new Error("No visible file to anchor cancellation");
+			const name = row.getAttribute("aria-label");
+			if (name === null) throw new Error("File row has no label");
+			return { name, top: row.getBoundingClientRect().top };
+		});
+		await message.focus();
+		await appWindow.keyboard.press("Escape");
+		await expect(divider).toHaveCount(0);
+		await expect.poll(() => shared.evaluate((el) => el.scrollTop)).toBe(cancelOffset);
+		await expectUpstreamDocked();
+		await expectCommitDocked();
+		await expect
+			.poll(async () => {
+				const box = await appWindow
+					.getByRole("treeitem", { name: anchor.name, exact: true })
+					.boundingBox();
+				return box ? Math.abs(box.y - anchor.top) : Infinity;
+			})
+			.toBeLessThan(2);
+		await start.click();
+		await expect(message).toHaveValue("Keep this draft while resizing");
+		const longDraft = "A longer commit message\n".repeat(40);
+		const buttonBox = await submit.boundingBox();
+		if (!buttonBox) throw new Error("Commit button is missing");
+		const buttonTop = buttonBox.y;
+		await message.fill(longDraft);
+		await expect(submit).toBeInViewport();
+		await expect
+			.poll(async () => Math.abs(((await submit.boundingBox())?.y ?? Infinity) - buttonTop))
+			.toBeLessThan(2);
+		const split = await divider.boundingBox();
+		const workspace = await stacks.boundingBox();
+		if (!split || !workspace) throw new Error("Missing split region");
+		await appWindow.mouse.move(split.x + split.width / 2, split.y + split.height / 2);
+		await appWindow.mouse.down();
+		await appWindow.mouse.move(split.x + split.width / 2, workspace.y + workspace.height - 1);
+		await appWindow.mouse.up();
+		await expect
+			.poll(async () => (await stacks.boundingBox())?.height ?? Infinity)
+			.toBeLessThan(40);
+		await expect
+			.poll(async () => {
+				const row = await upstream.boundingBox();
+				const pane = await stacks.boundingBox();
+				return row && pane ? row.y - pane.y : -Infinity;
+			})
+			.toBeGreaterThanOrEqual(0);
+		await message.focus();
+		await appWindow.keyboard.press("Escape");
+		await expect(divider).toHaveCount(0);
+		await shared.evaluate((el) => {
+			el.scrollTop = el.scrollHeight;
+		});
+		await expect(upstream).toBeHidden();
+		await expect(
+			appWindow.getByText("origin/master", { exact: true }).filter({ visible: true }),
+		).toBeInViewport();
+	});
+});

--- a/apps/lite/e2e/tests/stacks-list.spec.ts
+++ b/apps/lite/e2e/tests/stacks-list.spec.ts
@@ -40,7 +40,9 @@ test.describe("stacks list", () => {
 				// Anchored on a stack row: the hidden sidebar tabs are still in the
 				// document, and they look just like this list from the outside.
 				const row = document.querySelector('[role="treeitem"][aria-label^="stack-"]');
-				const scroller = row?.closest('[role="tree"]')?.parentElement;
+				let scroller = row?.parentElement;
+				while (scroller && getComputedStyle(scroller).overflowY !== "auto")
+					scroller = scroller.parentElement;
 				if (!scroller) throw new Error("Stacks list has no scroller");
 
 				return {

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -160,6 +160,8 @@ export const CommitForm: FC<{
 	canAmendCommit: boolean;
 	worktreeChanges: WorktreeChanges | undefined;
 	className?: string;
+	isExpanded: boolean;
+	onExpandedChange: (expanded: boolean) => void;
 }> = ({
 	projectId,
 	commitTarget,
@@ -171,6 +173,8 @@ export const CommitForm: FC<{
 	canAmendCommit,
 	worktreeChanges,
 	className,
+	isExpanded,
+	onExpandedChange,
 }) => {
 	const store = useAppStore();
 	const { isPending: isCommitCreatePending, mutate: commitCreate } = useCommitCreate();
@@ -230,7 +234,6 @@ export const CommitForm: FC<{
 	const draftBranchLabel = cannedBranchName ?? "New branch";
 
 	const [open, setOpen] = useState(false);
-	const [isExpanded, setIsExpanded] = useState(false);
 	const [commitLabelHidden, setCommitLabelHidden] = useState(false);
 	const generationButton = commitMessageGenerationButtonState({
 		enabled: isProjectAiEnabled,
@@ -451,7 +454,7 @@ export const CommitForm: FC<{
 
 			// Persist the draft before the textarea unmounts.
 			persistDraftMessage({ projectId, message: commitTextareaRef.current?.value ?? "" });
-			setIsExpanded(false);
+			onExpandedChange(false);
 			setOpen(false);
 			focusScope("uncommitted-files");
 		},
@@ -541,7 +544,7 @@ export const CommitForm: FC<{
 					className={styles.startCommitSplit}
 					variant={hasWorktreeChanges ? "pop" : "outline"}
 					id={startCommitButtonId}
-					onClick={() => setIsExpanded(true)}
+					onClick={() => onExpandedChange(true)}
 					disabled={!noOperationPending}
 					actionTooltip={hasWorktreeChanges ? undefined : "Makes an empty commit"}
 					menuLabel="Commit options"
@@ -637,7 +640,7 @@ export const CommitForm: FC<{
 										projectId,
 										message: commitTextareaRef.current?.value ?? "",
 									});
-									setIsExpanded(false);
+									onExpandedChange(false);
 									setOpen(false);
 									focusScope("uncommitted-files");
 								}}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -93,10 +93,15 @@
 
 .docked {
 	visibility: hidden;
-	position: absolute;
-	inset-inline: 0;
-	bottom: 0;
+	position: fixed;
+	/* A tall file list can keep the marker's containing block below the viewport. */
+	position-anchor: --workspace-scroller;
+	inset-inline: anchor(start) anchor(end);
+	bottom: anchor(bottom);
+	min-block-size: 0;
+	max-block-size: anchor-size(block);
 	padding-block: 4px;
+	overflow: clip;
 	border-block-start: 1px solid var(--border-section);
 	background-color: var(--bg-2);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -8,7 +8,72 @@
 .lists {
 	display: flex;
 	flex-direction: column;
+	min-height: 0;
 	background-color: var(--bg-2);
+}
+
+.commitGroup {
+	flex: 1;
+	min-height: 0;
+}
+
+.commitPanel,
+.workspaceScroller {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.workspaceScroller {
+	anchor-name: --workspace-scroller;
+	anchor-scope: --workspace-scroller;
+
+	flex: 1;
+	& > * {
+		flex-shrink: 0;
+	}
+}
+
+.workspaceScroller[data-commit-mode="true"] {
+	overflow: hidden;
+}
+
+.commitHead,
+.commitMode {
+	height: 100%;
+	min-height: 0;
+}
+
+.commitMode {
+	container-type: size;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	.cardHead,
+	.commitRow {
+		position: static;
+		flex-shrink: 0;
+	}
+
+	.fileArea {
+		flex: 1;
+	}
+
+	.commitForm textarea {
+		max-height: min(10lh, calc(100cqh - var(--commit-dock-top) - 90px));
+	}
+
+	.stub {
+		display: none;
+	}
+}
+
+.commitRow {
+	z-index: 1;
+	position: sticky;
+	bottom: var(--commit-dock-bottom);
+	background-color: var(--bg-1);
 }
 
 .header {

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -62,6 +62,8 @@ import {
 	type ReactNode,
 	type RefObject,
 } from "react";
+import { Group, Panel, usePanelRef } from "react-resizable-panels";
+import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import styles from "./WorkspaceLists.module.css";
 import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
 import { Section } from "../Graph/Section.tsx";
@@ -135,17 +137,19 @@ DryRunWorkspaceContext.displayName = "DryRunWorkspaceContext";
  */
 const noLanes: ReadonlyArray<Worktree> = [];
 
-const useHeight = (): [ref: (element: HTMLElement | null) => void, height: number] => {
+const useHeight = (
+	enabled = true,
+): [ref: (element: HTMLElement | null) => void, height: number] => {
 	const [element, setElement] = useState<HTMLElement | null>(null);
 	const [height, setHeight] = useState(0);
 	useLayoutEffect(() => {
-		if (element === null) return;
+		if (element === null || !enabled) return;
 		const measure = () => setHeight(element.offsetHeight);
 		measure();
 		const observer = new ResizeObserver(measure);
 		observer.observe(element);
 		return () => observer.disconnect();
-	}, [element]);
+	}, [element, enabled]);
 	return [setElement, height];
 };
 
@@ -175,6 +179,8 @@ const UncommittedChanges: FC<
 		/** The card's head, measured by the parent, which docks a stand-in as soon as the head is pushed. */
 		headRef: (element: HTMLElement | null) => void;
 		headHeight: number;
+		commitMode: boolean;
+		changeCommitMode: (expanded: boolean) => void;
 	} & Omit<ComponentProps<"div">, "children">
 > = ({
 	addressSpace,
@@ -191,6 +197,8 @@ const UncommittedChanges: FC<
 	footDock,
 	headRef,
 	headHeight,
+	commitMode,
+	changeCommitMode,
 	...props
 }) => {
 	const dispatch = useAppDispatch();
@@ -225,13 +233,18 @@ const UncommittedChanges: FC<
 	const folded = useAppSelector((state) =>
 		projectSlice.selectors.selectUncommittedFolded(state, projectId),
 	);
-	const toggleFolded = () => dispatch(projectSlice.actions.toggleUncommittedFolded({ projectId }));
+	const toggleFolded = () => {
+		if (commitMode) changeCommitMode(false);
+		dispatch(projectSlice.actions.toggleUncommittedFolded({ projectId }));
+	};
 	// Loaded and holding nothing, as opposed to not loaded yet: the header takes
 	// over the empty wording, so it must not say it before the answer is in.
 	const isClean = worktreeChanges !== undefined && worktreeChanges.changes.length === 0;
 
 	const cardRef = useRef<HTMLDivElement>(null);
 	const fileListRef = useRef<HTMLDivElement>(null);
+	const filesScrollRef = useRef<HTMLDivElement>(null);
+	const filesScrollElementRef = commitMode ? filesScrollRef : scrollElementRef;
 	// The list's start in the scroller, which the card heads: the rows above the
 	// list come and go with the filter and the worktree, so the card's size says
 	// when to measure again.
@@ -243,14 +256,19 @@ const UncommittedChanges: FC<
 			const list = fileListRef.current;
 			if (list === null) return;
 			setListOffset(
-				Math.max(0, list.getBoundingClientRect().top - card.getBoundingClientRect().top),
+				Math.max(
+					0,
+					list.getBoundingClientRect().top -
+						(filesScrollElementRef.current?.getBoundingClientRect().top ?? 0) +
+						(filesScrollElementRef.current?.scrollTop ?? 0),
+				),
 			);
 		};
 		measure();
 		const observer = new ResizeObserver(measure);
 		observer.observe(card);
 		return () => observer.disconnect();
-	}, []);
+	}, [filesScrollElementRef]);
 	const fileFilter = useListFilter({
 		filter,
 		setFilter: (filter) =>
@@ -273,7 +291,12 @@ const UncommittedChanges: FC<
 	return (
 		<div
 			{...props}
-			className={classes(props.className, styles.uncommittedCard)}
+			className={classes(props.className, styles.uncommittedCard, commitMode && styles.commitMode)}
+			style={{
+				...props.style,
+				"--commit-dock-bottom": `${footDock}px`,
+				"--commit-dock-top": `${headHeight}px`,
+			}}
 			ref={useMergedRefs(props.ref, cardRef)}
 		>
 			<div ref={headRef} className={styles.cardHead}>
@@ -304,57 +327,62 @@ const UncommittedChanges: FC<
 			    than unmounted, as with the sidebar's own pages, so the list comes back
 			    scrolled and filtered the way it was left. */}
 			<Activity mode={folded ? "hidden" : "visible"}>
-				{isClean && (
-					<Row interactive={false}>
-						{trunk}
-						<RowLabelContainer>
-							<LastCommitLine projectId={projectId} />
-						</RowLabelContainer>
-					</Row>
-				)}
+				<div
+					ref={filesScrollRef}
+					data-uncommitted-scroll=""
+					className={classes(styles.fileArea, commitMode && uiStyles.scroller)}
+				>
+					{isClean && (
+						<Row interactive={false}>
+							{trunk}
+							<RowLabelContainer>
+								<LastCommitLine projectId={projectId} />
+							</RowLabelContainer>
+						</Row>
+					)}
 
-				{/* A clean worktree drops the list as well: the header says so now, and
+					{/* A clean worktree drops the list as well: the header says so now, and
 				    an empty row under it would only say it twice. An unloaded one drops
 				    it too — its rows are empty for want of an answer, not because there
 				    is none, and the empty row would otherwise flash "No matching files"
 				    under a header still reading "Uncommitted". */}
-				<Activity mode={isClean || worktreeChanges === undefined ? "hidden" : "visible"}>
-					<FilesTree
-						className={styles.uncommittedFiles}
-						aria-labelledby={uncommittedChangesHeadingId}
-						canUncommit={false}
-						data-preview-source={activeList === "uncommitted"}
-						focusScope="uncommitted-files"
-						fileParent={uncommittedChangesFileParent}
-						reviewedPaths={reviewedUncommittedPaths}
-						rows={fileRows}
-						ageBadgeNow={recentFirst ? ageBadgeNow : null}
-						collapsedDirectories={collapsedDirectories}
-						onToggleDirectoryCollapsed={(path) =>
-							dispatch(
-								projectSlice.actions.toggleUncommittedFilesDirectoryCollapsed({
-									projectId,
-									path,
-								}),
-							)
-						}
-						addressSpace={addressSpace}
-						onRowSelection={selectActiveFile}
-						onEdgeSpill={spillEdge}
-						projectId={projectId}
-						ref={useMergedRefs(fileListRef, useAutofocusScope(activeList === "uncommitted"))}
-						selection={fileSelection}
-						rail={trunk}
-						scrollElementRef={scrollElementRef}
-						scrollMargin={listOffset}
-						scrollPaddingStart={headHeight}
-						scrollPaddingEnd={footDock}
-						// Override the tree's inset to keep the rows on the uncommitted card's trunk.
-						style={{ "--row-padding-inline-start": "var(--graph-trunk-inset)" }}
-					/>
-				</Activity>
-
-				<Row interactive={false}>
+					<Activity mode={isClean || worktreeChanges === undefined ? "hidden" : "visible"}>
+						<FilesTree
+							className={styles.uncommittedFiles}
+							aria-labelledby={uncommittedChangesHeadingId}
+							canUncommit={false}
+							data-preview-source={activeList === "uncommitted"}
+							focusScope="uncommitted-files"
+							fileParent={uncommittedChangesFileParent}
+							reviewedPaths={reviewedUncommittedPaths}
+							rows={fileRows}
+							ageBadgeNow={recentFirst ? ageBadgeNow : null}
+							collapsedDirectories={collapsedDirectories}
+							onToggleDirectoryCollapsed={(path) =>
+								dispatch(
+									projectSlice.actions.toggleUncommittedFilesDirectoryCollapsed({
+										projectId,
+										path,
+									}),
+								)
+							}
+							addressSpace={addressSpace}
+							onRowSelection={selectActiveFile}
+							onEdgeSpill={spillEdge}
+							projectId={projectId}
+							ref={useMergedRefs(fileListRef, useAutofocusScope(activeList === "uncommitted"))}
+							selection={fileSelection}
+							rail={trunk}
+							scrollElementRef={filesScrollElementRef}
+							scrollMargin={listOffset}
+							scrollPaddingStart={commitMode ? 0 : headHeight}
+							scrollPaddingEnd={commitMode ? 14 : footDock + 44}
+							// Override the tree's inset to keep the rows on the uncommitted card's trunk.
+							style={{ "--row-padding-inline-start": "var(--graph-trunk-inset)" }}
+						/>
+					</Activity>
+				</div>
+				<Row interactive={false} className={styles.commitRow}>
 					{trunk}
 					<CommitForm
 						projectId={projectId}
@@ -364,6 +392,8 @@ const UncommittedChanges: FC<
 						startCommitButtonId={startCommitButtonId}
 						commitMessageInputId={commitMessageInputId}
 						className={styles.commitForm}
+						isExpanded={commitMode}
+						onExpandedChange={changeCommitMode}
 						onAmendCommit={amendCommit}
 						canAmendCommit={canAmendCommit}
 						worktreeChanges={worktreeChanges}
@@ -1077,8 +1107,8 @@ const Stacks: FC<{
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
 	onEdgeSpill: (offset: -1 | 1) => void;
-	/** The uncommitted files card, which heads the trunk above the stack cards. */
-	head: ReactNode;
+	headHeight: number;
+	commitMode: boolean;
 	/** Stands in for the card at the scroller's head while the card is scrolled out above. */
 	dock: ReactNode;
 	/** How far down the dock's mark sticks: the card's head height, so the stand-in takes over as the head is pushed. */
@@ -1093,7 +1123,8 @@ const Stacks: FC<{
 	onAmendCommit,
 	canAmendCommit,
 	onEdgeSpill,
-	head,
+	headHeight,
+	commitMode,
 	dock,
 	dockOffset,
 	scrollElementRef,
@@ -1159,12 +1190,10 @@ const Stacks: FC<{
 	);
 	const retainScrollElement = useCallback(
 		(element: HTMLDivElement | null) => {
-			if (element) scrollElementRef.current = element;
+			if (element) scrollElementRef.current = element.parentElement as HTMLDivElement;
 		},
 		[scrollElementRef],
 	);
-	// The cards start under the uncommitted files card and the gap below it.
-	const [headRef, headHeight] = useHeight();
 	const scrollMargin = headHeight + CARD_GAP;
 	const getStackKey = useCallback((index: number) => stacks[index]?.id ?? index, [stacks]);
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
@@ -1258,7 +1287,7 @@ const Stacks: FC<{
 		rangeExtractor: rangeExtractorWithSelected,
 		scrollMargin,
 		// The head clears the docked uncommitted files row, the foot the docked target row.
-		scrollPaddingStart: HEAD_DOCKED_HEIGHT,
+		scrollPaddingStart: commitMode ? 0 : HEAD_DOCKED_HEIGHT,
 		scrollPaddingEnd,
 	});
 
@@ -1326,16 +1355,17 @@ const Stacks: FC<{
 		<DryRunWorkspaceContext value={dryRunWorkspace}>
 			<div
 				ref={retainScrollElement}
-				className={classes(uiStyles.scroller, styles.stacksScroller)}
+				className={styles.stacksScroller}
 				style={{
 					"--row-padding-inline-start": `${ROW_INSET}px`,
 					"--graph-trunk-inset": `${GRAPH_TRUNK_INSET}px`,
 				}}
 			>
-				{/* Its own tree: the files walk with their own cursor, and the arrow
-				    keys spill into the cards' tree at its edge. */}
-				<div ref={headRef}>{head}</div>
-				<div className={styles.dock} style={{ "--dock-offset": `${dockOffset}px` }}>
+				<div
+					hidden={commitMode}
+					className={styles.dock}
+					style={{ "--dock-offset": `${dockOffset}px` }}
+				>
 					{dock}
 				</div>
 				<GraphGap height={CARD_GAP} />
@@ -1574,6 +1604,58 @@ export const WorkspaceLists: FC<
 		focusScope("uncommitted-files");
 	};
 	const scrollElementRef = useRef<HTMLDivElement>(null);
+	const stacksScrollRef = useRef<HTMLDivElement>(null);
+	const groupElementRef = useRef<HTMLDivElement>(null);
+	const commitPanelRef = usePanelRef();
+	const [commitHeight, setCommitHeight] = useState<number | null>(null);
+	const commitMode = commitHeight !== null;
+	const openingPosition = useRef<{ buttonBottom: number; scrollTop: number } | null>(null);
+	const changeCommitMode = (expanded: boolean) => {
+		if (expanded) {
+			const button = document.getElementById(startCommitButtonId);
+			const group = groupElementRef.current;
+			if (!button || !group) return;
+			const buttonBottom = button.getBoundingClientRect().bottom;
+			openingPosition.current = {
+				buttonBottom,
+				scrollTop: scrollElementRef.current?.scrollTop ?? 0,
+			};
+			setCommitHeight(Math.max(160, buttonBottom - group.getBoundingClientRect().top + 20));
+		} else {
+			const files = scrollElementRef.current?.querySelector<HTMLDivElement>(
+				"[data-uncommitted-scroll]",
+			);
+			if (openingPosition.current && files) openingPosition.current.scrollTop = files.scrollTop;
+			setCommitHeight(null);
+		}
+	};
+	useLayoutEffect(() => {
+		const opening = openingPosition.current;
+		const scroller = scrollElementRef.current;
+		if (!scroller || !opening) return;
+		if (commitHeight === null) {
+			const frame = requestAnimationFrame(() => {
+				scroller.scrollTop = opening.scrollTop;
+				openingPosition.current = null;
+			});
+			return () => cancelAnimationFrame(frame);
+		}
+		commitPanelRef.current?.resize(commitHeight);
+		scroller.scrollTop = 0;
+		const frame = requestAnimationFrame(() => {
+			const submit = scroller.querySelector<HTMLButtonElement>('button[type="submit"]');
+			const panel = commitPanelRef.current;
+			if (submit && panel) {
+				panel.resize(
+					panel.getSize().inPixels + opening.buttonBottom - submit.getBoundingClientRect().bottom,
+				);
+			}
+			const files = scroller.querySelector<HTMLDivElement>("[data-uncommitted-scroll]");
+			if (files) files.scrollTop = opening.scrollTop;
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [commitHeight, commitPanelRef]);
+	const [uncommittedRef, uncommittedHeight] = useHeight(!commitMode);
 	// Rows scrolled into view clear the docked target row, or the foot's gradient.
 	const footDock = graph.plan.header !== null ? DOCKED_HEIGHT : 0;
 	const scrollPaddingEnd = Math.max(footDock, 14);
@@ -1607,10 +1689,41 @@ export const WorkspaceLists: FC<
 							footDock={footDock}
 							headRef={cardHeadRef}
 							headHeight={cardHeadHeight}
+							commitMode={commitMode}
+							changeCommitMode={changeCommitMode}
 						/>
 					}
 				/>
 			}
+		/>
+	);
+
+	const stacksView = (
+		<Stacks
+			projectId={projectId}
+			graph={graph}
+			newBranch={newBranch}
+			checkCommit={checkCommit}
+			onAmendCommit={amendCommit}
+			canAmendCommit={canAmendCommit}
+			onEdgeSpill={spillIntoUncommittedChanges}
+			headHeight={commitMode ? 0 : uncommittedHeight}
+			commitMode={commitMode}
+			dockOffset={cardHeadHeight}
+			dock={
+				<UncommittedChangesRow
+					changes={worktreeChanges?.changes ?? []}
+					isClean={worktreeChanges !== undefined && worktreeChanges.changes.length === 0}
+					projectId={projectId}
+					mode={{
+						kind: "docked",
+						onSelect: () => scrollElementRef.current?.scrollTo({ top: 0 }),
+					}}
+					className={styles.dockRow}
+				/>
+			}
+			scrollElementRef={commitMode ? stacksScrollRef : scrollElementRef}
+			scrollPaddingEnd={scrollPaddingEnd}
 		/>
 	);
 
@@ -1625,31 +1738,44 @@ export const WorkspaceLists: FC<
 					className={styles.header}
 					actions={stacksHeaderActions}
 				/>
-				<Stacks
-					projectId={projectId}
-					graph={graph}
-					newBranch={newBranch}
-					checkCommit={checkCommit}
-					onAmendCommit={amendCommit}
-					canAmendCommit={canAmendCommit}
-					onEdgeSpill={spillIntoUncommittedChanges}
-					head={uncommitted}
-					dockOffset={cardHeadHeight}
-					dock={
-						<UncommittedChangesRow
-							changes={worktreeChanges?.changes ?? []}
-							isClean={worktreeChanges !== undefined && worktreeChanges.changes.length === 0}
-							projectId={projectId}
-							mode={{
-								kind: "docked",
-								onSelect: () => scrollElementRef.current?.scrollTo({ top: 0 }),
+				<Group orientation="vertical" className={styles.commitGroup} elementRef={groupElementRef}>
+					<Panel
+						id="commit-files"
+						panelRef={commitPanelRef}
+						minSize={commitMode ? 160 : "100%"}
+						defaultSize="100%"
+						className={styles.commitPanel}
+						style={{ overflow: "hidden" }}
+					>
+						<div
+							ref={scrollElementRef}
+							className={classes(styles.workspaceScroller, !commitMode && uiStyles.scroller)}
+							data-commit-mode={commitMode}
+							style={{
+								"--row-padding-inline-start": `${ROW_INSET}px`,
+								"--graph-trunk-inset": `${GRAPH_TRUNK_INSET}px`,
 							}}
-							className={styles.dockRow}
-						/>
-					}
-					scrollElementRef={scrollElementRef}
-					scrollPaddingEnd={scrollPaddingEnd}
-				/>
+						>
+							<div ref={uncommittedRef} className={commitMode ? styles.commitHead : undefined}>
+								{uncommitted}
+							</div>
+							{!commitMode && stacksView}
+						</div>
+					</Panel>
+					{commitMode && (
+						<>
+							<ResizeHandle aria-label="Resize uncommitted files and workspace" />
+							<Panel id="commit-stacks" minSize={24} className={styles.commitPanel}>
+								<div
+									ref={stacksScrollRef}
+									className={classes(styles.workspaceScroller, uiStyles.scroller)}
+								>
+									{stacksView}
+								</div>
+							</Panel>
+						</>
+					)}
+				</Group>
 			</div>
 		</WorkspaceListsProvider>
 	);


### PR DESCRIPTION
## 🧢 Changes

Starting a commit splits the Workspace into a resizable upper pane for uncommitted files and the composer, and an independently scrolling lower pane for stacks. The initial split keeps the commit button in place; canceling preserves the visible file position and draft. The collapsed commit button remains sticky and slides beneath the Uncommitted files header.

## ☕️ Reasoning

Keep files and commit controls accessible while browsing stacks, with minimal movement when entering or leaving commit mode. Reuse the existing panel and resize-handle components.

Validation: Lite typecheck, lint, formatting, both Knip checks, focused commit-form, stack scrolling, and keyboard-focus E2E tests.