### PR TITLE
Stop worktree history at its shared base

### DIFF
--- a/crates/but-graph/src/init/types.rs
+++ b/crates/but-graph/src/init/types.rs
@@ -81,12 +81,17 @@ impl Limit {
         {
             return false;
         }
-        // Do not let *any* non-goal tip consume gas as long as there is still anything with a goal in the queue
-        // that need to meet their local branches.
-        // This is effectively only affecting the entrypoint tips, which isn't setup with a goal.
-        // TODO(perf): could we remember that we are a tip and look for our specific counterpart by matching the goal?
-        //             That way unrelated tips wouldn't cause us to keep traversing.
-        if self.goal_unset() && next.iter().any(|(_, _, _, limit)| !limit.goal_reached()) {
+        // Keep entrypoints alive while other tips seek them. A tip that reached its own goals
+        // must also keep going when an unconnected tip still needs its ancestry, so a target
+        // cannot stop before an older worktree fork connects to its history. Tips already in
+        // the workspace or integrated history don't need this extension.
+        if next.iter().any(|(_, pending_flags, _, limit)| {
+            !limit.goal_reached()
+                && (self.goal_unset()
+                    || (!pending_flags
+                        .intersects(CommitFlags::InWorkspace | CommitFlags::Integrated)
+                        && flags.intersects(limit.goal_flags())))
+        }) {
             return false;
         }
         if self.inner.is_some_and(|l| l == 0) {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1402,6 +1402,28 @@ EOF
     git worktree add ../worktree-ahead-checkout-feature wt-feature
   )
 
+  # The worktree fork predates the target, beyond its normal traversal allowance.
+  git init worktree-behind-target
+  (cd worktree-behind-target
+    commit init
+    tick
+    commit base
+    git branch wt-feature
+    for n in $(seq 1 6); do
+      tick
+      commit "M$n"
+    done
+    setup_target_to_match_main
+    create_workspace_commit_once main
+    git worktree add ../worktree-behind-target-feature wt-feature
+    (cd ../worktree-behind-target-feature
+      tick
+      commit W1
+      tick
+      commit W2
+    )
+  )
+
   git init target-shared-with-unapplied-and-origin-head
   (cd target-shared-with-unapplied-and-origin-head
     commit init

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -8665,6 +8665,43 @@ fn worktree_tip_in_workspace_priority_mode() -> anyhow::Result<()> {
 }
 
 #[test]
+fn worktree_fork_below_the_target_stays_connected_with_a_limit() -> anyhow::Result<()> {
+    let (repo, mut meta, mut db) = read_only_in_memory_scenario("ws/worktree-behind-target")?;
+    add_workspace(&mut meta);
+    db.worktree_meta_mut().mark_adopted()?;
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        default_project_meta(&repo),
+        &mut db,
+        but_graph::init::Options {
+            worktrees: true,
+            ..but_graph::init::Options::limited().with_limit_hint(1)
+        },
+    )?
+    .validated()?;
+    let workspace = graph.into_workspace()?;
+    let base = id_by_rev(&repo, "wt-feature~2").detach();
+    assert_eq!(
+        workspace.worktrees[0].base,
+        Some(but_graph::workspace::WorktreeBase::Outside(base)),
+        "the target walk must reach the older worktree fork before stopping"
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on 67b6d03
+└── 📁worktree-behind-target-feature on 07695fd
+    └── :wt-feature[📁worktree-behind-target-feature]
+        ├── ·1c99085
+        └── ·5845a6a
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
 fn workspace_traversal_with_extra_tips() -> anyhow::Result<()> {
     let (repo, mut meta, mut db) = read_only_in_memory_scenario("ws/worktree-ahead")?;
     snapbox::assert_data_eq!(


### PR DESCRIPTION
Worktrees branching below the target could lose their base and display the repository's entire history. Keep the target traversal alive while a disconnected tip still needs its ancestry, preserving existing cutoffs for tips already in workspace or integrated history.

Adds a regression fixture with an older worktree fork and a small traversal limit. Validated with 226 graph, workspace, and CLI status tests, plus the running Lite app: 13,272 worktree commits reduced to 2.