### PR TITLE
Keep collapsed upstream chevrons clear of the mainline

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -113,6 +113,14 @@
 	--row-label-offset: calc(-3px + var(--row-fold-chevron-offset, 0px));
 }
 
+.collapsedBranchHeader {
+	/* Clear the branch lane around the chevron while keeping the trunk continuous. */
+	--row-fold-mask-inset: 5px;
+	/* Keep the label fixed while adjusting the collapsed chevron. */
+	--row-fold-chevron-offset: 0.5px;
+	--row-label-offset: -3px;
+}
+
 /* Centred on the label line, so the row keeps its height. */
 .action {
 	display: flex;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -329,7 +329,6 @@ export const Section: FC<{
 	if (target === null) return null;
 	const branched = target.incoming > 0;
 	const expanded = branched && plan.incomingExpanded;
-	const continuesToHistory = expanded && plan.historyAvailable;
 	/** The target's row. The docked stand-in, with no line to show, wears a chevron instead of the rail. */
 	const header = (docked = false) => (
 		<Header
@@ -359,12 +358,12 @@ export const Section: FC<{
 					<span className={styles.chevron}>
 						{branched && <Icon name={plan.incomingExpanded ? "chevron-down" : "chevron-right"} />}
 					</span>
-				) : expanded ? (
+				) : branched ? (
 					<GraphSegment glyph="forkRight" status="Upstream" behind={1} />
 				) : (
 					<GraphSegment
-						glyph={branched ? "notch" : "space"}
-						status={branched ? "Upstream" : "LocalOnly"}
+						glyph="space"
+						status="LocalOnly"
 						behind={1}
 						folded={!plan.historyAvailable}
 					/>
@@ -373,7 +372,8 @@ export const Section: FC<{
 			toolbar={<Fetch projectId={projectId} />}
 			className={classes(
 				styles.header,
-				!expanded && styles.trunkHeader,
+				!branched && styles.trunkHeader,
+				!docked && branched && !expanded && styles.collapsedBranchHeader,
 				docked && styles.docked,
 				!docked && expanded && styles.cardHead,
 			)}
@@ -412,10 +412,7 @@ export const Section: FC<{
 							)}
 						</div>
 					</Fold>
-					<GraphGap
-						height={expanded ? CARD_GAP : LEG_GAP}
-						bend={continuesToHistory ? "LocalOnly" : expanded ? "Upstream" : undefined}
-					/>
+					<GraphGap height={expanded ? CARD_GAP : LEG_GAP} bend="Upstream" />
 				</>
 			)}
 			{plan.historyAvailable && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -180,13 +180,19 @@
 		--chevron-ink-top: 10.5px;
 		--chevron-ink-bottom: 17px;
 
-		mask-image: linear-gradient(
-			to bottom,
-			black calc(var(--chevron-ink-top) - var(--chevron-clearance)),
-			transparent calc(var(--chevron-ink-top) - var(--chevron-clearance)),
-			transparent calc(var(--chevron-ink-bottom) + var(--chevron-clearance)),
-			black calc(var(--chevron-ink-bottom) + var(--chevron-clearance))
-		);
+		mask-image:
+			linear-gradient(
+				to right,
+				black var(--row-fold-mask-inset, 0px),
+				transparent var(--row-fold-mask-inset, 0px)
+			),
+			linear-gradient(
+				to bottom,
+				black calc(var(--chevron-ink-top) - var(--chevron-clearance)),
+				transparent calc(var(--chevron-ink-top) - var(--chevron-clearance)),
+				transparent calc(var(--chevron-ink-bottom) + var(--chevron-clearance)),
+				black calc(var(--chevron-ink-bottom) + var(--chevron-clearance))
+			);
 	}
 
 	.foldToggle[data-chevron="always"][aria-expanded="false"] & {


### PR DESCRIPTION
## 🧢 Changes

Show incoming upstream commits as a branch even when collapsed. Keep the grey mainline continuous beside the chevron and use the upstream yellow for the full connector back to it.

Adjust the collapsed chevron's spacing while keeping the label stationary and the expanded chevron aligned with the commit line.

## ☕️ Reasoning

Make the collapsed branch relationship clear without interrupting the mainline or shifting the expanded card's alignment.

Validation: verified collapsed and expanded states over CDP; Lite typecheck, lint, formatting, both Knip checks, and Graph Section tests passed before this unchanged commit was split out of #15917.