### PR TITLE
Key review thread hunks by content for Pierre's highlight cache

### DIFF
--- a/apps/lite/ui/src/review-threads.test.ts
+++ b/apps/lite/ui/src/review-threads.test.ts
@@ -1,5 +1,5 @@
 import {
-	forgeHunkPatch,
+	forgeHunkDiff,
 	threadsByPathForScope,
 	threadStillAnchored,
 	threadStillAnchoredInFile,
@@ -187,41 +187,45 @@ describe("threadStillAnchored", () => {
 	});
 });
 
-describe("forgeHunkPatch", () => {
+describe("forgeHunkDiff", () => {
 	it("re-tallies the counts the forge left behind", () => {
 		// The header claims six and twelve lines; three and four were sent,
 		// because the hunk stops at the line the comment sits on.
 		const truncated = "@@ -527,6 +527,12 @@ CREATE TABLE\n a\n b\n+c\n d";
+		const diff = forgeHunkDiff("src/lib.rs", truncated);
 
-		expect(forgeHunkPatch("src/lib.rs", truncated)).toBe(
-			[
-				"diff --git a/src/lib.rs b/src/lib.rs",
-				"--- a/src/lib.rs",
-				"+++ b/src/lib.rs",
-				"@@ -527,3 +527,4 @@",
-				" a",
-				" b",
-				"+c",
-				" d",
-				"",
-			].join("\n"),
-		);
+		expect(diff?.hunks[0]?.hunkSpecs).toBe("@@ -527,3 +527,4 @@\n");
+		expect(diff?.deletionLines).toEqual(["a\n", "b\n", "d\n"]);
+		expect(diff?.additionLines).toEqual(["a\n", "b\n", "c\n", "d\n"]);
 	});
 
 	it("keeps a blank context line, which is a space rather than nothing", () => {
-		const patch = forgeHunkPatch("f.ts", "@@ -1,9 +1,9 @@\n a\n \n+b\n");
+		const diff = forgeHunkDiff("f.ts", "@@ -1,9 +1,9 @@\n a\n \n+b\n");
 
-		expect(patch?.split("\n").slice(4, -1)).toEqual([" a", " ", "+b"]);
+		expect(diff?.deletionLines).toEqual(["a\n", "\n"]);
+		expect(diff?.additionLines).toEqual(["a\n", "\n", "b\n"]);
 	});
 
 	it("declines anything that is not a hunk", () => {
-		expect(forgeHunkPatch("f.ts", "no header here")).toBeNull();
+		expect(forgeHunkDiff("f.ts", "no header here")).toBeNull();
+	});
+
+	it("keys the parsed diff by content, not file name", () => {
+		// Two threads on one file: the forge truncates each hunk at its own
+		// comment line, so the same path carries different lines.
+		const short = forgeHunkDiff("f.ts", "@@ -1,3 +1,3 @@\n a\n+b\n");
+		const long = forgeHunkDiff("f.ts", "@@ -1,3 +1,3 @@\n a\n+b\n+c\n");
+
+		expect(short?.cacheKey).toBeDefined();
+		expect(short?.cacheKey).not.toBe(long?.cacheKey);
+		expect(forgeHunkDiff("f.ts", "@@ -1,3 +1,3 @@\n a\n+b\n")?.cacheKey).toBe(short?.cacheKey);
 	});
 
 	it("drops the no-newline marker a file's unterminated end carries", () => {
-		const patch = forgeHunkPatch("f.ts", "@@ -1,2 +1,2 @@\n a\n+b\n\\ No newline at end of file");
+		const diff = forgeHunkDiff("f.ts", "@@ -1,2 +1,2 @@\n a\n+b\n\\ No newline at end of file");
 
-		expect(patch?.split("\n").slice(3, -1)).toEqual(["@@ -1,1 +1,2 @@", " a", "+b"]);
+		expect(diff?.hunks[0]?.hunkSpecs).toBe("@@ -1,1 +1,2 @@\n");
+		expect(diff?.additionLines).toEqual(["a\n", "b\n"]);
 	});
 });
 

--- a/apps/lite/ui/src/review-threads.ts
+++ b/apps/lite/ui/src/review-threads.ts
@@ -8,8 +8,9 @@
  */
 
 import type { FileParent } from "#ui/addresses.ts";
+import { hash } from "#ui/hash.ts";
 import type { ForgeReviewThread } from "@gitbutler/but-sdk";
-import type { AnnotationSide } from "@pierre/diffs";
+import { type AnnotationSide, type FileDiffMetadata, processFile } from "@pierre/diffs";
 
 /** A thread with the diff position the view can hang it on. */
 export type AnchoredThread = {
@@ -146,7 +147,7 @@ export const threadStillAnchored = (
  * counts are re-tallied from what actually arrived; the start lines are
  * untouched, since the truncation only ever drops the tail.
  */
-export const forgeHunkPatch = (path: string, diffHunk: string): string | null => {
+const forgeHunkPatch = (path: string, diffHunk: string): string | null => {
 	const [header = "", ...rest] = diffHunk.split("\n");
 	const starts = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(header);
 	const [, oldStart, newStart] = starts ?? [];
@@ -169,6 +170,22 @@ export const forgeHunkPatch = (path: string, diffHunk: string): string | null =>
 		...lines,
 		"",
 	].join("\n");
+};
+
+/**
+ * The forge's hunk parsed for Pierre, keyed by its content.
+ *
+ * Pierre caches highlighted lines under the diff's `cacheKey`, and stamps a
+ * missing one with the file name alone. Every thread on a file would then
+ * share one entry, so the lines highlighted for the first thread's hunk are
+ * handed to the others — and a longer hunk reads past the end and throws.
+ * Keying on the content keeps each hunk's lines its own, as the diff view
+ * does for whole files.
+ */
+export const forgeHunkDiff = (path: string, diffHunk: string): FileDiffMetadata | null => {
+	const patch = forgeHunkPatch(path, diffHunk);
+	if (patch === null) return null;
+	return processFile(patch, { cacheKey: `review-hunk:${hash(patch)}` }) ?? null;
 };
 
 /**

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -65,13 +65,13 @@ import type {
 import { ReviewThreadReply } from "#ui/routes/project/$id/workspace/ReviewThreadReply.tsx";
 import { encodeBytes } from "#ui/api/bytes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
-import { forgeHunkPatch, threadStillAnchoredInFile } from "#ui/review-threads.ts";
+import { forgeHunkDiff, threadStillAnchoredInFile } from "#ui/review-threads.ts";
 import { isAgent } from "#ui/review-users.ts";
 import { defaultSettings } from "#ui/settings.ts";
 import { pullRequestHotkeys } from "#ui/hotkeys.ts";
 import { FreshBadge, RegisterFreshItems } from "#ui/review-arrival.tsx";
 import { useHotkeys } from "@tanstack/react-hotkeys";
-import { PatchDiff } from "@pierre/diffs/react";
+import { FileDiff } from "@pierre/diffs/react";
 import { useQuery } from "@tanstack/react-query";
 import { clearReviewFocus, useRequestedComment } from "#ui/review-focus.ts";
 import {
@@ -422,7 +422,9 @@ export const ThreadComment: FC<{ comment: ForgeReviewThreadComment; compact?: bo
  * The code a thread hangs off, rendered by the same engine as the diff view
  * so it carries real line numbers and the app's diff settings. Pierre parses
  * a whole patch, and the forge sends only the `@@` hunk, so the file headers
- * are put back on — the same shape `synthesizeFilePatch` builds.
+ * are put back on — the same shape `synthesizeFilePatch` builds — and the
+ * parsed diff is keyed by its content so threads on one file do not share
+ * Pierre's highlight cache.
  */
 const ThreadHunk: FC<{
 	projectId: string;
@@ -494,15 +496,15 @@ const ThreadHunk: FC<{
 		);
 	};
 
-	const patch = useMemo(() => forgeHunkPatch(path, diffHunk), [path, diffHunk]);
+	const fileDiff = useMemo(() => forgeHunkDiff(path, diffHunk), [path, diffHunk]);
 
 	// Nothing to draw from a hunk no parser would take.
-	if (patch === null) return null;
+	if (fileDiff === null) return null;
 
 	return (
 		<div className={styles.hunk} onContextMenu={onContextMenu}>
-			<PatchDiff
-				patch={patch}
+			<FileDiff
+				fileDiff={fileDiff}
 				options={{
 					// Unified whatever the diff view is set to: a comment card is too
 					// narrow for two columns, and a thread hangs on one line anyway.


### PR DESCRIPTION
Review thread hunks in the Lite pull request tab intermittently rendered `DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null, something is wrong` in place of the code.

Pierre stamps a parsed patch that carries no `cacheKey` with the file name alone, and its worker pool caches highlighted lines under that key. Every thread on one file therefore shared a single cache entry: each thread's hunk is truncated at its own comment line, so the lines highlighted for one hunk were handed to the others, and a hunk longer than the cached one indexed past the end. Which hunk's worker result landed last decided whether a given thread broke, hence the flakiness.

The forge hunk is now parsed with `processFile` and keyed by a hash of the patch, the same scheme the diff view uses for whole files, and rendered through `FileDiff` since `PatchDiff` offers no way to pass a key.