### PR TITLE
Use Next channel names for application log folders

### DIFF
--- a/apps/lite/electron/src/logging.ts
+++ b/apps/lite/electron/src/logging.ts
@@ -34,13 +34,11 @@ export const initLogging = (): void => {
 		// persist to main.log too (they still echo to the terminal).
 		Object.assign(console, log.functions);
 
-		// The Rust side resolves the per-platform log folder for our bundle identifier
-		// (the electron-builder appId in package.json, with the desktop app's `.dev`
-		// channel convention for unpackaged builds) and installs the tracing
-		// subscriber; electron-log then writes to the same folder.
+		// Rust resolves the per-platform log folder for the Next channel and installs
+		// the tracing subscriber; electron-log then writes to the same folder.
 		app.setAppLogsPath(
 			initTracing(
-				app.isPackaged ? "com.gitbutler.lite" : "com.gitbutler.lite.dev",
+				app.isPackaged ? "com.gitbutler.next.nightly" : "com.gitbutler.next.dev",
 				!app.isPackaged,
 			),
 		);


### PR DESCRIPTION
Write packaged app logs under com.gitbutler.next.nightly and development logs under com.gitbutler.next.dev to match the Next rename. Rust and Electron continue sharing the same log folder; existing logs remain in their previous locations.