### PR TITLE
Use Next app identity and explicit release channel

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -33,6 +33,7 @@ export type LiteElectronApi = SDK & {
 	/** The settings shared with the other surfaces through the settings file. */
 	getAppSettings: () => Promise<AppSettings>;
 	getVersion: () => Promise<string>;
+	isPackaged: () => Promise<boolean>;
 	isFullScreen: () => Promise<boolean>;
 	onFullScreenChange: (callback: (fullScreen: boolean) => void) => () => void;
 	/** A click on a desktop notification, by the id it was shown with. */
@@ -83,6 +84,7 @@ export const localEndpoints = [
 	"getAppSettings",
 	"getVersion",
 	"isFullScreen",
+	"isPackaged",
 	"notificationClick",
 	"openInWebBrowser",
 	"pathJoin",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -623,8 +623,14 @@ export const start = async (shellEnvironment: Promise<Record<string, string>>): 
 	initLogging();
 	Object.assign(process.env, await shellEnvironment);
 	await initApplicationNamespace(null);
-	if (app.isPackaged || reportTelemetryInDev)
-		await initMetrics(app.getVersion(), app.isPackaged ? "production" : "development");
+	if (app.isPackaged || reportTelemetryInDev) {
+		const channel = process.env.CHANNEL;
+		await initMetrics(
+			app.getVersion(),
+			app.isPackaged ? "production" : "development",
+			app.isPackaged && (channel === "nightly" || channel === "release") ? channel : "dev",
+		);
+	}
 
 	applyGUISettings(await readSettings());
 	configureAskpass();

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -1,4 +1,4 @@
-import { posthogHost, reportTelemetryInDev } from "./telemetry.js";
+import { posthogHost } from "./telemetry.js";
 import { checkForUpdates, registerUpdater, setAutoUpdateEnabled } from "./updater.js";
 import WatcherManager from "./watcher.js";
 import * as sdk from "@gitbutler/but-sdk";
@@ -307,6 +307,7 @@ const electronHandlerOverrides = {
 	clipboardWriteText: (text) => clipboard.writeText(text),
 	getAppSettings: () => sdk.getAppSettings(),
 	getVersion: () => app.getVersion(),
+	isPackaged: () => app.isPackaged,
 	openInWebBrowser: (url) => {
 		// shell.openExternal() is powerful and dangerous. For example, on macOS you can launch a
 		// program with shell.openExternal("file:///Applications/Numbers.app"). Similarly bad
@@ -623,12 +624,12 @@ export const start = async (shellEnvironment: Promise<Record<string, string>>): 
 	initLogging();
 	Object.assign(process.env, await shellEnvironment);
 	await initApplicationNamespace(null);
-	if (app.isPackaged || reportTelemetryInDev) {
+	if (app.isPackaged) {
 		const channel = process.env.CHANNEL;
 		await initMetrics(
 			app.getVersion(),
-			app.isPackaged ? "production" : "development",
-			app.isPackaged && (channel === "nightly" || channel === "release") ? channel : "dev",
+			"production",
+			channel === "nightly" || channel === "release" ? channel : "dev",
 		);
 	}
 

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -83,7 +83,8 @@ const configureFailureLimit = async (metricsClient: PostHog): Promise<void> => {
 
 /**
  * Reads the shared app settings and starts the client when metrics or error
- * reporting is enabled. Never throws: telemetry must not prevent startup.
+ * reporting is enabled. Dev builds send nothing. Never throws: telemetry
+ * must not prevent startup.
  *
  * Await this before registering IPC handlers, so the first commands of the
  * session are captured and a launch via a login link cannot race the
@@ -94,6 +95,8 @@ export const initMetrics = async (
 	environment: "development" | "production",
 	channel: "dev" | "nightly" | "release",
 ): Promise<void> => {
+	if (channel !== "nightly" && channel !== "release") return;
+
 	try {
 		const telemetry = (await getAppSettings()).telemetry;
 		metricsEnabled = telemetry.appMetricsEnabled;

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -25,12 +25,12 @@ import { apiCommandFailureLimitConfig, createApiCommandSampler } from "./api-com
  * still describes only the retained call.
  */
 
-const APP_NAME = "gitbutler-lite";
+const APP_NAME = "gitbutler-next";
 const CONTAINER = "electron";
 const SHUTDOWN_TIMEOUT_MS = 2000;
 const ACTIVE_API_COMMAND_SHUTDOWN_GRACE_MS = SHUTDOWN_TIMEOUT_MS / 2;
-const FAILURE_LIMIT_FLAG = "lite-api-command-failure-limit";
-const FAILURE_LIMIT_CONFIG_ID = "gitbutler-lite-failure-limit";
+const FAILURE_LIMIT_FLAG = "next-api-command-failure-limit";
+const FAILURE_LIMIT_CONFIG_ID = "gitbutler-next-failure-limit";
 const FAILURE_LIMIT_CONFIG_TIMEOUT_MS = 1_000;
 
 let client: PostHog | null = null;
@@ -38,6 +38,7 @@ let distinctId = "";
 let appVersion = "";
 let metricsEnabled = false;
 let errorsEnabled = false;
+let appChannel: "dev" | "nightly" | "release";
 let failureLimit = apiCommandFailureLimitConfig(undefined);
 let apiCommandSampler = createApiCommandSampler({ failureLimit });
 let shutdownPromise: Promise<void> | null = null;
@@ -91,6 +92,7 @@ const configureFailureLimit = async (metricsClient: PostHog): Promise<void> => {
 export const initMetrics = async (
 	version: string,
 	environment: "development" | "production",
+	channel: "dev" | "nightly" | "release",
 ): Promise<void> => {
 	try {
 		const telemetry = (await getAppSettings()).telemetry;
@@ -99,6 +101,7 @@ export const initMetrics = async (
 		if (!metricsEnabled && !telemetry.appErrorReportingEnabled) return;
 
 		appVersion = version;
+		appChannel = channel;
 		// The client exists from here on even if resolving the identity below
 		// fails; a session then captures under the stored or fresh id.
 		setDistinctId(telemetry.appDistinctId ?? randomUUID());
@@ -114,6 +117,7 @@ export const initMetrics = async (
 						...event.properties,
 						appName: APP_NAME,
 						appVersion,
+						appChannel,
 						container: CONTAINER,
 						process: "main",
 						environment,
@@ -153,6 +157,7 @@ const capture = (event: string, properties: Record<string, unknown>): void => {
 			...properties,
 			appName: APP_NAME,
 			appVersion,
+			appChannel,
 			container: CONTAINER,
 			// Only events for a logged-in account may create a PostHog person
 			// profile; anonymous installs stay person-less (and cheaper).

--- a/apps/lite/electron/src/telemetry.ts
+++ b/apps/lite/electron/src/telemetry.ts
@@ -4,7 +4,3 @@ export const getPosthogProjectToken = (environment: "development" | "production"
 	environment === "development"
 		? "phc_t7VDC9pQELnYep9IiDTxrq2HLseY5wyT7pn0EpHM7rr"
 		: "phc_yJx46mXv6kA5KTuM2eEQ6IwNTgl5YW3feKV5gi7mfGG";
-
-/** Flip this to send metrics and errors to the dev project, for example during QA. */
-// oxlint-disable-next-line typescript/no-inferrable-types
-export const reportTelemetryInDev: boolean = false;

--- a/apps/lite/electron/vite.main.config.ts
+++ b/apps/lite/electron/vite.main.config.ts
@@ -32,12 +32,15 @@ export default defineConfig({
 				projectId: "2812",
 				host: "https://eu.posthog.com",
 				sourcemaps: {
-					releaseName: "gitbutler-lite",
+					releaseName: "gitbutler-next",
 					releaseVersion: process.env.VERSION || "dev",
 					deleteAfterUpload: true,
 				},
 			}),
 	],
+	define: {
+		"process.env.CHANNEL": JSON.stringify(process.env.CHANNEL ?? "dev"),
+	},
 	build: {
 		outDir: path.join(here, "../dist/electron"),
 		// The preload build (vite.config.ts) runs first and empties the dir.

--- a/apps/lite/harness/deepseek/cli.mjs
+++ b/apps/lite/harness/deepseek/cli.mjs
@@ -51,6 +51,7 @@ const defaultAiConfiguration = () => ({
 
 const hostOverrides = {
 	getVersion: () => "gitbutler-harness",
+	isPackaged: () => false,
 	// The harness cannot open the user's browser; the panel degrades silently.
 	openInWebBrowser: () => undefined,
 	pickDirectory: () => null,

--- a/apps/lite/harness/tests/metrics.test.ts
+++ b/apps/lite/harness/tests/metrics.test.ts
@@ -39,13 +39,13 @@ const profile = (id: number): UserProfile => ({
 	githubUsername: null,
 });
 
-const initMetrics = async (failureLimit?: {
-	bucketSize: number;
-	refillIntervalSeconds: number;
-}) => {
+const initMetrics = async (
+	failureLimit?: { bucketSize: number; refillIntervalSeconds: number },
+	channel: "dev" | "nightly" | "release" = "nightly",
+) => {
 	mocks.client.getFeatureFlagPayload.mockResolvedValue(failureLimit);
 	const metrics = await import("../../electron/src/metrics.ts");
-	await metrics.initMetrics("1.2.3", "development");
+	await metrics.initMetrics("1.2.3", "production", channel);
 	// The failure limit lands a few microtasks after init returns; a tick drains
 	// them, and unlike a timer it still fires under fake timers.
 	await new Promise((resolve) => process.nextTick(resolve));
@@ -64,24 +64,31 @@ describe("api command metrics", () => {
 		mocks.client.shutdown.mockResolvedValue(undefined);
 	});
 
-	test("captures successful commands with their sampling rate", async () => {
-		const metrics = await initMetrics();
-		const handler = vi.fn().mockResolvedValue("result");
+	test.each(["dev", "nightly", "release"] as const)(
+		"captures successful commands for %s",
+		async (channel) => {
+			const metrics = await initMetrics(undefined, channel);
+			const handler = vi.fn().mockResolvedValue("result");
 
-		await expect(metrics.withApiCommandCapture("commitCreate", handler)(null)).resolves.toBe(
-			"result",
-		);
-		const captured = mocks.client.capture.mock.lastCall?.[0];
-		expect(captured?.distinctId).toBe("user_1");
-		expect(captured?.event).toBe("api_command");
-		expect(captured?.properties).toMatchObject({
-			command: "commitCreate",
-			failure: false,
-			samplingRate: 1,
-		});
-		expect(captured?.properties).not.toHaveProperty("occurrenceCount");
-		await metrics.shutdownMetrics();
-	});
+			await expect(metrics.withApiCommandCapture("commitCreate", handler)(null)).resolves.toBe(
+				"result",
+			);
+			const captured = mocks.client.capture.mock.lastCall?.[0];
+			expect(captured?.distinctId).toBe("user_1");
+			expect(captured?.event).toBe("api_command");
+			expect(captured?.properties).toMatchObject({
+				appName: "gitbutler-next",
+				appVersion: "1.2.3",
+				appChannel: channel,
+				container: "electron",
+				command: "commitCreate",
+				failure: false,
+				samplingRate: 1,
+			});
+			expect(captured?.properties).not.toHaveProperty("occurrenceCount");
+			await metrics.shutdownMetrics();
+		},
+	);
 
 	test("applies failure limits, rethrows errors, and flushes before resetting on login", async () => {
 		const metrics = await initMetrics({ bucketSize: 1, refillIntervalSeconds: 10 });
@@ -93,8 +100,8 @@ describe("api command metrics", () => {
 
 		await expect(wrapped(null)).rejects.toBe(error);
 		expect(mocks.client.getFeatureFlagPayload).toHaveBeenCalledWith(
-			"lite-api-command-failure-limit",
-			"gitbutler-lite-failure-limit",
+			"next-api-command-failure-limit",
+			"gitbutler-next-failure-limit",
 		);
 		const capturedFailure = mocks.client.capture.mock.lastCall?.[0];
 		expect(capturedFailure?.distinctId).toBe("user_1");

--- a/apps/lite/harness/tests/metrics.test.ts
+++ b/apps/lite/harness/tests/metrics.test.ts
@@ -10,6 +10,7 @@ interface CapturedEvent {
 const mocks = vi.hoisted(() => ({
 	client: {
 		capture: vi.fn<(event: CapturedEvent) => void>(),
+		captureException: vi.fn(),
 		getFeatureFlagPayload: vi.fn(),
 		shutdown: vi.fn(),
 	},
@@ -57,14 +58,66 @@ describe("api command metrics", () => {
 		vi.resetModules();
 		vi.clearAllMocks();
 		mocks.getAppSettings.mockResolvedValue({
-			telemetry: { appMetricsEnabled: true, appDistinctId: "user_1" },
+			telemetry: {
+				appMetricsEnabled: true,
+				appErrorReportingEnabled: true,
+				appDistinctId: "user_1",
+			},
 		});
 		mocks.getUserProfileLocal.mockResolvedValue(null);
 		mocks.updateTelemetryDistinctId.mockResolvedValue(undefined);
 		mocks.client.shutdown.mockResolvedValue(undefined);
 	});
 
-	test.each(["dev", "nightly", "release"] as const)(
+	test("preserves error reporting when command collection is disabled", async () => {
+		mocks.getAppSettings.mockResolvedValue({
+			telemetry: {
+				appMetricsEnabled: false,
+				appErrorReportingEnabled: true,
+				appDistinctId: "user_1",
+			},
+		});
+		const metrics = await initMetrics();
+		await metrics.withApiCommandCapture("commitCreate", () => "result")(null);
+		const error = new Error("failed");
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			metrics.reportError(error, "test");
+			expect(mocks.client.captureException).toHaveBeenCalledWith(error, "user_1", {
+				context: "test",
+			});
+			expect(mocks.client.capture).not.toHaveBeenCalled();
+			expect(mocks.client.getFeatureFlagPayload).not.toHaveBeenCalled();
+		} finally {
+			consoleError.mockRestore();
+			await metrics.shutdownMetrics();
+		}
+	});
+
+	test("dev builds never start a client or send events", async () => {
+		const metrics = await initMetrics(undefined, "dev");
+		const { PostHog } = await import("posthog-node");
+		const handler = vi.fn().mockResolvedValue("result");
+		await expect(metrics.withApiCommandCapture("commitCreate", handler)(null)).resolves.toBe(
+			"result",
+		);
+		const error = new Error("failed");
+		await expect(
+			metrics.withApiCommandCapture("commitCreate", vi.fn().mockRejectedValue(error))(null),
+		).rejects.toBe(error);
+		await metrics.metricsOnLogin(profile(2));
+
+		expect(PostHog).not.toHaveBeenCalled();
+		expect(mocks.getAppSettings).not.toHaveBeenCalled();
+		expect(mocks.getUserProfileLocal).not.toHaveBeenCalled();
+		expect(mocks.updateTelemetryDistinctId).not.toHaveBeenCalled();
+		expect(mocks.client.getFeatureFlagPayload).not.toHaveBeenCalled();
+		expect(mocks.client.capture).not.toHaveBeenCalled();
+		expect(metrics.shutdownMetrics()).toBeNull();
+		expect(mocks.client.shutdown).not.toHaveBeenCalled();
+	});
+
+	test.each(["nightly", "release"] as const)(
 		"captures successful commands for %s",
 		async (channel) => {
 			const metrics = await initMetrics(undefined, channel);

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -721,3 +721,8 @@ export const versionQueryOptions = queryOptions({
 	queryKey: ["version"],
 	queryFn: () => window.lite.getVersion(),
 });
+
+export const isPackagedQueryOptions = queryOptions({
+	queryKey: ["isPackaged"],
+	queryFn: () => window.lite.isPackaged(),
+});

--- a/apps/lite/ui/src/api/query-keys.ts
+++ b/apps/lite/ui/src/api/query-keys.ts
@@ -20,6 +20,7 @@ export type GlobalQueryKey =
 	| "userProfile"
 	| "projects"
 	| "guiSettings"
+	| "isPackaged"
 	| "markdownTokens"
 	| "version";
 

--- a/apps/lite/ui/src/error-reporting.test.ts
+++ b/apps/lite/ui/src/error-reporting.test.ts
@@ -1,0 +1,102 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	init: vi.fn(),
+	register: vi.fn(),
+	settings: vi.fn(),
+	isPackaged: vi.fn(),
+}));
+
+vi.mock("posthog-js/dist/module.no-external", () => ({
+	default: { init: mocks.init, register: mocks.register },
+}));
+vi.mock("posthog-js/dist/exception-autocapture", () => ({}));
+vi.mock("#ui/api/queries.ts", () => ({
+	appSettingsQueryOptions: { queryKey: ["settings"], queryFn: mocks.settings },
+	isPackagedQueryOptions: { queryKey: ["isPackaged"], queryFn: mocks.isPackaged },
+	versionQueryOptions: { queryKey: ["version"], queryFn: async () => "1.2.3" },
+	userProfileQueryOptions: { queryKey: ["profile"], queryFn: async () => null },
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.stubEnv("DEV", false);
+	// Vitest converts process.env defines to mutable env values, so this overrides the Vite default.
+	vi.stubEnv("CHANNEL", "nightly");
+	mocks.isPackaged.mockResolvedValue(true);
+	mocks.settings.mockResolvedValue({
+		telemetry: { appErrorReportingEnabled: true, appDistinctId: "install-id" },
+	});
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+test.each(["nightly", "release"])(
+	"does not initialize a production %s UI in unpackaged Electron",
+	async (channel) => {
+		vi.stubEnv("CHANNEL", channel);
+		mocks.isPackaged.mockResolvedValue(false);
+		const { initErrorReporting } = await import("./error-reporting.ts");
+		await initErrorReporting(new QueryClient());
+
+		expect(mocks.settings).not.toHaveBeenCalled();
+		expect(mocks.init).not.toHaveBeenCalled();
+	},
+);
+
+test.each([undefined, "", "dev", "unexpected"])(
+	"does not initialize reporting for packaged channel %s",
+	async (channel) => {
+		vi.stubEnv("CHANNEL", channel);
+		const { initErrorReporting } = await import("./error-reporting.ts");
+		await initErrorReporting(new QueryClient());
+
+		expect(mocks.settings).not.toHaveBeenCalled();
+		expect(mocks.init).not.toHaveBeenCalled();
+	},
+);
+
+test("does not initialize reporting in the dev server even with a nightly channel", async () => {
+	vi.stubEnv("DEV", true);
+	const { initErrorReporting } = await import("./error-reporting.ts");
+	await initErrorReporting(new QueryClient());
+
+	expect(mocks.settings).not.toHaveBeenCalled();
+	expect(mocks.init).not.toHaveBeenCalled();
+});
+
+test.each(["nightly", "release"])("keeps exception reporting for %s", async (channel) => {
+	vi.stubEnv("CHANNEL", channel);
+	const { initErrorReporting } = await import("./error-reporting.ts");
+	await initErrorReporting(new QueryClient());
+
+	expect(mocks.init).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.objectContaining({
+			bootstrap: { distinctID: "install-id" },
+			capture_exceptions: {
+				capture_unhandled_errors: true,
+				capture_unhandled_rejections: true,
+				capture_console_errors: false,
+			},
+		}),
+	);
+	expect(mocks.register).toHaveBeenCalledWith({
+		appName: "gitbutler-next",
+		appVersion: "1.2.3",
+		appChannel: channel,
+		container: "electron",
+		process: "renderer",
+		environment: "production",
+	});
+});
+
+test("respects disabled error reporting in a nightly build", async () => {
+	mocks.settings.mockResolvedValue({ telemetry: { appErrorReportingEnabled: false } });
+	const { initErrorReporting } = await import("./error-reporting.ts");
+	await initErrorReporting(new QueryClient());
+
+	expect(mocks.settings).toHaveBeenCalledOnce();
+	expect(mocks.init).not.toHaveBeenCalled();
+});

--- a/apps/lite/ui/src/error-reporting.ts
+++ b/apps/lite/ui/src/error-reporting.ts
@@ -3,19 +3,19 @@ import posthog from "posthog-js/dist/module.no-external";
 import "posthog-js/dist/exception-autocapture";
 import {
 	appSettingsQueryOptions,
+	isPackagedQueryOptions,
 	userProfileQueryOptions,
 	versionQueryOptions,
 } from "#ui/api/queries.ts";
-import {
-	getPosthogProjectToken,
-	posthogHost,
-	reportTelemetryInDev,
-} from "../../electron/src/telemetry.ts";
+import { getPosthogProjectToken, posthogHost } from "../../electron/src/telemetry.ts";
 
 export const initErrorReporting = async (queryClient: QueryClient): Promise<void> => {
-	if (import.meta.env.DEV && !reportTelemetryInDev) return;
+	const channel = process.env.CHANNEL;
+	if (import.meta.env.DEV || (channel !== "nightly" && channel !== "release")) return;
 
 	try {
+		if (!(await queryClient.fetchQuery(isPackagedQueryOptions))) return;
+
 		const [settings, version, profile] = await Promise.all([
 			queryClient.fetchQuery(appSettingsQueryOptions),
 			queryClient.fetchQuery(versionQueryOptions),
@@ -24,7 +24,7 @@ export const initErrorReporting = async (queryClient: QueryClient): Promise<void
 
 		if (!settings.telemetry.appErrorReportingEnabled) return;
 
-		const environment = import.meta.env.DEV ? "development" : "production";
+		const environment = "production";
 		posthog.init(getPosthogProjectToken(environment), {
 			api_host: posthogHost,
 			persistence: "memory",
@@ -56,11 +56,10 @@ export const initErrorReporting = async (queryClient: QueryClient): Promise<void
 			},
 		});
 
-		const channel = process.env.CHANNEL;
 		const properties = {
 			appName: "gitbutler-next",
 			appVersion: version,
-			appChannel: channel === "nightly" || channel === "release" ? channel : "dev",
+			appChannel: channel,
 			container: "electron",
 			process: "renderer",
 			environment,

--- a/apps/lite/ui/src/error-reporting.ts
+++ b/apps/lite/ui/src/error-reporting.ts
@@ -56,9 +56,11 @@ export const initErrorReporting = async (queryClient: QueryClient): Promise<void
 			},
 		});
 
+		const channel = process.env.CHANNEL;
 		const properties = {
-			appName: "gitbutler-lite",
+			appName: "gitbutler-next",
 			appVersion: version,
+			appChannel: channel === "nightly" || channel === "release" ? channel : "dev",
 			container: "electron",
 			process: "renderer",
 			environment,

--- a/apps/lite/ui/vite.config.ts
+++ b/apps/lite/ui/vite.config.ts
@@ -11,6 +11,9 @@ const currentDirPath = path.dirname(currentFilePath);
 
 export default defineConfig(({ command }) => ({
 	root: currentDirPath,
+	define: {
+		"process.env.CHANNEL": JSON.stringify(process.env.CHANNEL ?? "dev"),
+	},
 	plugins: [
 		{
 			name: "posthog-sourcemap-warning",
@@ -30,7 +33,7 @@ export default defineConfig(({ command }) => ({
 				projectId: "2812",
 				host: "https://eu.posthog.com",
 				sourcemaps: {
-					releaseName: "gitbutler-lite",
+					releaseName: "gitbutler-next",
 					releaseVersion: process.env.VERSION || "dev",
 					deleteAfterUpload: true,
 				},


### PR DESCRIPTION
Replace the Lite app name and failure-limit flag keys with Next names. Embed CHANNEL during the Electron build and start collection only for packaged nightly and release builds; development builds send nothing, including packaged dev builds.

The new remote flag uses the existing limit. The legacy flag remains active for older builds.
