### PR TITLE
Simplify Lite UI code and review activity storage

### DIFF
--- a/apps/lite/e2e/tests/sidebar.spec.ts
+++ b/apps/lite/e2e/tests/sidebar.spec.ts
@@ -97,24 +97,45 @@ test("keeps unread PR activity off the Workspace tab", async ({ appWindow, elect
 	await expect(pages.getByRole("button", { name: "Workspace", exact: true })).toHaveText(
 		"Workspace",
 	);
-	await appWindow.evaluate(() => {
+	await appWindow.evaluate(async () => {
 		const projectId = location.pathname.split("/")[2];
 		if (projectId === undefined) throw new Error("No project in the URL");
-		const key = `pr_activity_inbox:v1:${projectId}`;
-		const entries = JSON.parse(localStorage.getItem(key) ?? "[]") as Array<{
-			id: string;
-			author: string | null;
-			snippet: string | null;
-		}>;
-		const first = entries[0];
-		if (first === undefined) throw new Error("No seeded notification");
-		entries.push({
-			...first,
-			id: "bot-1",
-			author: "copilot-pull-request-reviewer",
-			snippet: "Bot review",
+		await new Promise<void>((resolve, reject) => {
+			const open = indexedDB.open("keyval-store");
+			open.onerror = () => reject(open.error);
+			open.onsuccess = () => {
+				const db = open.result;
+				const transaction = db.transaction("keyval", "readwrite");
+				transaction.oncomplete = () => {
+					db.close();
+					resolve();
+				};
+				transaction.onabort = () => {
+					db.close();
+					reject(transaction.error);
+				};
+				const store = transaction.objectStore("keyval");
+				const key = `pr_activity:v1:${projectId}`;
+				const read = store.get(key);
+				read.onsuccess = () => {
+					const state = read.result as {
+						inbox: Array<{ id: string; author: string | null; snippet: string | null }>;
+					};
+					const first = state.inbox[0];
+					if (first === undefined) {
+						transaction.abort();
+						return;
+					}
+					state.inbox.push({
+						...first,
+						id: "bot-1",
+						author: "copilot-pull-request-reviewer",
+						snippet: "Bot review",
+					});
+					store.put(state, key);
+				};
+			};
 		});
-		localStorage.setItem(key, JSON.stringify(entries));
 	});
 	await appWindow.reload();
 	await appWindow.getByRole("button", { name: "Notifications, 2 unread" }).click();

--- a/apps/lite/harness/browser/index.tsx
+++ b/apps/lite/harness/browser/index.tsx
@@ -1,3 +1,4 @@
+import { watchReviewState } from "#ui/review-state.ts";
 // oxlint-disable react/only-export-components -- The composition root hosts its helper components by design.
 /**
  * The harness panel's composition root: builds the api over the plugin
@@ -145,8 +146,10 @@ export default function createPanel({
 		);
 	};
 
+	let stopWatchingReviewState: (() => void) | undefined;
 	return {
 		mount: (container) => {
+			stopWatchingReviewState = watchReviewState(queryClient);
 			root = createRoot(container);
 			render();
 		},
@@ -154,6 +157,7 @@ export default function createPanel({
 			render();
 		},
 		unmount: () => {
+			stopWatchingReviewState?.();
 			// Closing the panel is not a navigation, so the route's onLeave never
 			// runs; the binding calls watcherStopAll host-side instead.
 			root?.unmount();

--- a/apps/lite/harness/tests/panel.test.tsx
+++ b/apps/lite/harness/tests/panel.test.tsx
@@ -1,5 +1,7 @@
-import type { WatcherEvent, WorktreeChanges } from "@gitbutler/but-sdk";
-import { expect, test, vi } from "vitest";
+import "fake-indexeddb/auto";
+import * as idb from "idb-keyval";
+import type { ForgeReview, WatcherEvent, WorktreeChanges } from "@gitbutler/but-sdk";
+import { beforeEach, expect, test, vi } from "vitest";
 import createPanel from "../browser/index.tsx";
 import { createFakeTransport, createWatcherHandlers, type FakeHandlers } from "./fake-transport.ts";
 import {
@@ -29,24 +31,20 @@ const PROJECT_ID = "fixture-project";
  */
 const settle = { timeout: 15_000 } as const;
 
-/**
- * @param seenMarks watermarks to start from, as the app would have stamped on
- * an earlier run. Local storage is shared across the tests in this file, so it
- * is cleared either way.
- */
-/** The inbox as the detector wrote it, straight from the store's key. */
-const inboxEntries = (): Array<{
-	kind: string;
-	review: number;
-	author: string | null;
-	seen: boolean;
-}> =>
-	JSON.parse(localStorage.getItem(`pr_activity_inbox:v1:${PROJECT_ID}`) ?? "[]") as Array<{
-		kind: string;
-		review: number;
-		author: string | null;
-		seen: boolean;
-	}>;
+beforeEach(() => idb.clear());
+
+const inboxEntries = async () =>
+	(
+		await idb.get<{
+			inbox: Array<{ kind: string; review: number; author: string | null; seen: boolean }>;
+		}>(`pr_activity:v1:${PROJECT_ID}`)
+	)?.inbox ?? [];
+
+const waitForBaseline = (review: ForgeReview) =>
+	vi.waitFor(async () => {
+		const state = await idb.get<{ marks: Record<number, string> }>(`pr_activity:v1:${PROJECT_ID}`);
+		expect(state?.marks[review.number]).toBe(review.modifiedAt);
+	}, settle);
 
 const mountPanel = (handlers: FakeHandlers, seenMarks?: Record<number, string>) => {
 	localStorage.clear();
@@ -183,10 +181,9 @@ test("someone else's review activity files one coalesced inbox entry and the unr
 		listReviewTimelineEvents: () => [],
 	});
 
-	// The PR chip proves the baseline listing landed; nothing is filed yet —
-	// history must never replay as notifications.
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
-	expect(inboxEntries()).toHaveLength(0);
+	// Hydrate and stamp the first listing before simulating the next poll.
+	await waitForBaseline(review);
+	expect(await inboxEntries()).toHaveLength(0);
 
 	// Someone comments; the forge bumps the review and a fetch notices.
 	review = { ...review, modifiedAt: "2026-01-01T11:00:00Z" };
@@ -207,8 +204,8 @@ test("someone else's review activity files one coalesced inbox entry and the unr
 	panel.push(eventChannel, event);
 
 	// One coalesced, attributed inbox entry.
-	await vi.waitFor(() => expect(inboxEntries()).toHaveLength(1), settle);
-	expect(inboxEntries()[0]).toMatchObject({ kind: "comment", review: 7, author: "alice" });
+	await vi.waitFor(async () => expect(await inboxEntries()).toHaveLength(1), settle);
+	expect((await inboxEntries())[0]).toMatchObject({ kind: "comment", review: 7, author: "alice" });
 
 	panel.unmount();
 });
@@ -233,7 +230,7 @@ test("a mention left on a diff line is filed like any other", async () => {
 		listReviewTimelineEvents: () => [],
 	});
 
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await waitForBaseline(review);
 
 	review = { ...review, modifiedAt: "2026-01-01T11:00:00Z" };
 	threads = [
@@ -266,7 +263,7 @@ test("a mention left on a diff line is filed like any other", async () => {
 	panel.push(eventChannel, event);
 
 	await vi.waitFor(
-		() => expect(inboxEntries()[0]).toMatchObject({ kind: "mention", review: 7 }),
+		async () => expect((await inboxEntries())[0]).toMatchObject({ kind: "mention", review: 7 }),
 		settle,
 	);
 
@@ -297,7 +294,7 @@ test("a mention toasts even when the review's branch is not in the workspace", a
 		listReviewTimelineEvents: () => [],
 	});
 
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await waitForBaseline(outside);
 
 	outside = { ...outside, modifiedAt: "2026-01-01T11:00:00Z" };
 	comments = [
@@ -319,8 +316,10 @@ test("a mention toasts even when the review's branch is not in the workspace", a
 	} satisfies WatcherEvent);
 
 	await vi.waitFor(
-		() =>
-			expect(inboxEntries().find((entry) => entry.review === 8)).toMatchObject({ kind: "mention" }),
+		async () =>
+			expect((await inboxEntries()).find((entry) => entry.review === 8)).toMatchObject({
+				kind: "mention",
+			}),
 		settle,
 	);
 
@@ -347,11 +346,9 @@ test("loud activity is offered to the desktop, and its click lands on the entry"
 			shown.push(notice);
 		},
 	});
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await waitForBaseline(review);
 
 	review = { ...review, modifiedAt: "2026-01-01T12:00:00Z" };
-	// Its own minute: entry ids carry the time, and the inbox module keeps an
-	// in-memory copy across tests that would file a repeat id as old news.
 	comments = [
 		{
 			id: 3,
@@ -380,7 +377,10 @@ test("loud activity is offered to the desktop, and its click lands on the entry"
 	const [notice] = shown;
 	if (notice === undefined) throw new Error("no notice shown");
 	panel.push("notificationClick", notice.id);
-	await vi.waitFor(() => expect(inboxEntries()[0]).toMatchObject({ seen: true }), settle);
+	await vi.waitFor(
+		async () => expect((await inboxEntries())[0]).toMatchObject({ seen: true }),
+		settle,
+	);
 
 	panel.unmount();
 });

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -190,6 +190,7 @@
 		"electron": "^44.0.0",
 		"electron-builder": "^26.16.1",
 		"eslint-plugin-react-you-might-not-need-an-effect": "^1.0.0",
+		"fake-indexeddb": "^6.2.5",
 		"fast-check": "^4.9.0",
 		"jsdom": "28.1.0",
 		"storybook": "^10.3.3",

--- a/apps/lite/ui/src/api/query-keys.ts
+++ b/apps/lite/ui/src/api/query-keys.ts
@@ -37,7 +37,8 @@ type LocalQueryKey =
 	| "prMergeMethod"
 	| "prDraft"
 	| "projectAiSettings"
-	| "reviewedFiles";
+	| "reviewedFiles"
+	| "reviewState";
 
 export type QueryKeyPrefix =
 	| [projectId: string, ProjectQueryKey]

--- a/apps/lite/ui/src/branch.ts
+++ b/apps/lite/ui/src/branch.ts
@@ -75,9 +75,9 @@ const MIN_SEARCH_LENGTH = 2;
  */
 export const searchStacks = (stacks: Array<ListedStack>, query: string): Array<ListedStack> => {
 	const trimmed = query.trim();
-	const reviewNumber = /^([#!])(\d+)$/.exec(trimmed);
-	if (reviewNumber) {
-		const [, symbol, number] = reviewNumber;
+	const reviewReferenceMatch = /^([#!])(\d+)$/.exec(trimmed);
+	if (reviewReferenceMatch) {
+		const [, symbol, number] = reviewReferenceMatch;
 		return stacks.filter((stack) =>
 			stack.branches.some(
 				({ review }) =>

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -63,9 +63,6 @@
 		transform var(--transition-popup) var(--easing-popup),
 		opacity var(--transition-popup) var(--easing-popup);
 
-	/* Only reached when the caller keeps the modal mounted and toggles `open`. A caller that
-	   renders it already open — `{shown && <Picker open />}` — mounts past the starting state, and
-	   the modal appears without animating. */
 	&[data-starting-style],
 	&[data-ending-style] {
 		transform: translateY(-0.5rem) scale(0.97);

--- a/apps/lite/ui/src/components/Popup.tsx
+++ b/apps/lite/ui/src/components/Popup.tsx
@@ -239,35 +239,18 @@ export const PopupSearch: FC<{ onClear?: () => void } & useRender.ComponentProps
 	);
 };
 
-/**
- * What a popup's list shows when it has no rows: one line under a drawing, the "Empty state" block
- * sized for a list rather than a panel — the line sits closer under the illustration and there is
- * no counterweight, since a line under a light drawing has no weight to lift.
- *
- * Which drawing and which line follow the branches tab's rule. The shrugging character and
- * `nothingFound` are for a search that came up empty; a list with nothing in it before anything
- * was typed gets the cactus and `nothingToList`, since nothing was searched for and "found" would
- * be the wrong word. Pass the `query` the list is filtered on — the deferred one, where the caller defers — so
- * the block and the rows it stands in for agree.
- *
- * Both lines are one short line, no full stop, like every other line of their length in Lite:
- * "No hotkeys found", "Nothing to restore yet".
- *
- * For a popup as wide as a picker. A dropdown no wider than its trigger — the commit target
- * combobox — keeps a plain line, since the illustration would fill it.
- *
- * @public
- */
+/** Pass the same query used to filter the rows, including any deferral. */
 export const PopupEmpty: FC<{ query: string; nothingFound: string; nothingToList: string }> = ({
 	query,
 	nothingFound,
 	nothingToList,
-}) =>
-	query === "" ? (
-		<EmptyState illustration="cactus" description={nothingToList} className={styles.empty} />
-	) : (
-		<EmptyState illustration="shrugging" description={nothingFound} className={styles.empty} />
-	);
+}) => (
+	<EmptyState
+		illustration={query === "" ? "cactus" : "shrugging"}
+		description={query === "" ? nothingToList : nothingFound}
+		className={styles.empty}
+	/>
+);
 
 /**
  * A run of {@link PopupItem}s under an optional heading. Sections divide from one another, so a
@@ -290,9 +273,7 @@ export const PopupSection: FC<{ label?: ReactNode } & useRender.ComponentProps<"
 			className: styles.section,
 			children: (
 				<>
-					{label !== undefined && (
-						<div className={classes("text-12", styles.sectionLabel)}>{label}</div>
-					)}
+					{label !== undefined && <PopupSectionLabel>{label}</PopupSectionLabel>}
 					<div className={styles.sectionItems}>{children}</div>
 				</>
 			),

--- a/apps/lite/ui/src/main.tsx
+++ b/apps/lite/ui/src/main.tsx
@@ -9,6 +9,7 @@ import { createRoot } from "react-dom/client";
 import "./global.css";
 import { Toast } from "@base-ui/react";
 import { errorMessageForToast } from "#ui/errors.ts";
+import { watchReviewState } from "#ui/review-state.ts";
 
 const toastManager = Toast.createToastManager();
 
@@ -52,6 +53,9 @@ const queryClient: QueryClient = new QueryClient({
 		},
 	}),
 });
+
+const stopWatchingReviewState = watchReviewState(queryClient);
+import.meta.hot?.dispose(stopWatchingReviewState);
 
 // By default React Query uses `visibilitychange`, but this doesn't seem to work
 // well in Electron.

--- a/apps/lite/ui/src/review-activity.test.ts
+++ b/apps/lite/ui/src/review-activity.test.ts
@@ -69,6 +69,9 @@ const verdict = (
 ): ReviewActivityItem => ({ kind: "verdict", id: 900 + atMs, author, state, body, atMs });
 
 describe("attentionOf", () => {
+	it("recognizes the same bot account across REST and GraphQL logins", () => {
+		expect(attentionOf(comment("Reviewer[bot]", 1), "reviewer")).toBe("silent");
+	});
 	it("treats someone else's comment as loud", () => {
 		expect(attentionOf(comment("alice", 1), "me")).toBe("loud");
 	});

--- a/apps/lite/ui/src/review-activity.ts
+++ b/apps/lite/ui/src/review-activity.ts
@@ -6,7 +6,7 @@
  * it live listings and turns its verdicts into toasts.
  */
 
-import { isAgent } from "#ui/review-users.ts";
+import { isAgent, sameLogin } from "#ui/review-users.ts";
 
 import type {
 	ForgeReview,
@@ -42,10 +42,6 @@ export type ReviewActivityItem = { authorIsBot?: boolean } & (
 );
 
 type Attention = "loud" | "quiet" | "silent";
-
-/** Forge logins compare case-insensitively. */
-const sameLogin = (a: string | null, b: string | null): boolean =>
-	a !== null && b !== null && a.toLowerCase() === b.toLowerCase();
 
 /**
  * Whether the item's text @-mentions the login. Login characters may follow

--- a/apps/lite/ui/src/review-arrival.tsx
+++ b/apps/lite/ui/src/review-arrival.tsx
@@ -1,3 +1,6 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { reviewStateQueryOptions } from "#ui/review-state.ts";
+import { sameLogin } from "#ui/review-users.ts";
 /**
  * @file Marking what arrived since the user last looked.
  *
@@ -47,19 +50,18 @@ export const FreshBadge: FC<{
 	itemKey?: string;
 }> = ({ timestamp, author, itemKey }) => {
 	const { sinceMs, selfLogin, projectId, reviewNumber } = useContext(SeenOnArrivalContext);
+	const client = useQueryClient();
 	const ref = useRef<HTMLSpanElement | null>(null);
 	// Decided at mount and held: store writes must not pull the marker out
 	// from under the reader mid-visit. The next visit re-decides.
 	const [show] = useState(() => {
 		// The reader's own actions post-date arrival by definition; not news.
-		const own =
-			author != null &&
-			selfLogin !== null &&
-			author.login.toLowerCase() === selfLogin.toLowerCase();
+		const own = sameLogin(author?.login, selfLogin);
 		if (own || timestamp === null) return false;
+		const state = client.getQueryData(reviewStateQueryOptions(projectId).queryKey);
 		return (
 			timestamp > sinceMs ||
-			(itemKey !== undefined && isItemSkipped(projectId, reviewNumber, itemKey))
+			(itemKey !== undefined && state !== undefined && isItemSkipped(state, reviewNumber, itemKey))
 		);
 	});
 
@@ -71,7 +73,7 @@ export const FreshBadge: FC<{
 		const arm = () => {
 			clearTimeout(timer);
 			timer = window.setTimeout(() => {
-				if (document.hasFocus()) markItemSeen(projectId, reviewNumber, itemKey);
+				if (document.hasFocus()) void markItemSeen(client, projectId, reviewNumber, itemKey);
 			}, seenBeatMs);
 		};
 		const observer = new IntersectionObserver(([entry]) => {
@@ -90,7 +92,7 @@ export const FreshBadge: FC<{
 			observer.disconnect();
 			window.removeEventListener("focus", onFocus);
 		};
-	}, [show, itemKey, projectId, reviewNumber]);
+	}, [show, itemKey, projectId, reviewNumber, client]);
 
 	if (!show) return null;
 	return (

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -27,7 +27,7 @@ import {
 } from "#ui/review-inbox.ts";
 import { usePrNotificationsLevel } from "#ui/review-seen.ts";
 import { Dropdown } from "#ui/components/Popup.tsx";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import styles from "./review-inbox-bell.module.css";
 
@@ -59,12 +59,13 @@ const Entry: FC<{
 	/** The panel closes itself once a click has somewhere to go. */
 	onNavigate: () => void;
 }> = ({ projectId, entry, appliedRefs, onNavigate }) => {
+	const client = useQueryClient();
 	const open = () => {
 		// Still loading is not "not in the workspace": acting now could open
 		// the forge for a local branch, and eat the unread mark doing it.
 		if (appliedRefs === undefined) return;
 		onNavigate();
-		openInboxEntry(projectId, entry, appliedRefs);
+		openInboxEntry(client, projectId, entry, appliedRefs);
 	};
 
 	return (
@@ -108,10 +109,10 @@ const Entry: FC<{
  * without forge review support, or below the loud dial.
  */
 export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
+	const client = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [tab, setTab] = useState<NotificationType>("humans");
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
-	// Unconditional: behind `&&` the hook count would change mid-mount.
 	const level = usePrNotificationsLevel();
 	const shown = level === "loud" && !!forgeInfo?.capabilities.prService;
 	const allEntries = useInboxEntries(projectId, shown);
@@ -176,7 +177,8 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 					<button
 						className={classes("text-12", styles.markAll)}
 						onClick={() =>
-							markInboxSeen(
+							void markInboxSeen(
+								client,
 								projectId,
 								entries.map((entry) => entry.id),
 							)

--- a/apps/lite/ui/src/review-inbox.test.ts
+++ b/apps/lite/ui/src/review-inbox.test.ts
@@ -406,3 +406,16 @@ it("retires a migrated alias when a human entry claims its ID", async () => {
 	expect(await findInboxEntry(client, projectId, id)).toBeUndefined();
 	expect(await findInboxEntry(client, projectId, `${id}:bot`)).toBeDefined();
 });
+
+it("finds another window's notification before its invalidation arrives", async () => {
+	const projectId = freshProject();
+	await client.fetchQuery(reviewStateQueryOptions(projectId));
+	const notice = entry("from-another-window", 30);
+	const other = new QueryClient();
+	try {
+		await addInboxEntries(other, projectId, [notice]);
+		expect(await findInboxEntry(client, projectId, notice.id)).toEqual(notice);
+	} finally {
+		other.clear();
+	}
+});

--- a/apps/lite/ui/src/review-inbox.test.ts
+++ b/apps/lite/ui/src/review-inbox.test.ts
@@ -1,4 +1,8 @@
 /** @vitest-environment jsdom */
+import "fake-indexeddb/auto";
+import { QueryClient } from "@tanstack/react-query";
+import { reviewStateQueryOptions } from "./review-state.ts";
+const client = new QueryClient();
 import {
 	addInboxEntries,
 	desktopNotices,
@@ -11,17 +15,11 @@ import {
 } from "./review-inbox.ts";
 import { describe, expect, it } from "vitest";
 
-/**
- * The module caches per storage key, so each test gets its own project id
- * rather than sharing a window-wide reset.
- */
 let nextProject = 0;
 const freshProject = () => `test-project-${nextProject++}`;
 
 const stored = (projectId: string): Array<InboxEntry> =>
-	JSON.parse(
-		localStorage.getItem(`pr_activity_inbox:v1:${projectId}`) ?? "[]",
-	) as Array<InboxEntry>;
+	client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.inbox ?? [];
 
 const at = (minute: number) => `2026-08-30T10:${String(minute).padStart(2, "0")}:00.000Z`;
 
@@ -42,22 +40,22 @@ const entry = (id: string, minute: number, overrides: Partial<InboxEntry> = {}):
 });
 
 describe("addInboxEntries", () => {
-	it("keeps the list ordered by each entry's own time, across polls", () => {
+	it("keeps the list ordered by each entry's own time, across polls", async () => {
 		const projectId = freshProject();
-		addInboxEntries(projectId, [entry("a", 30)]);
+		await addInboxEntries(client, projectId, [entry("a", 30)]);
 		// A later poll files an entry whose newest item is older — it must
 		// sort by its time, not jump the queue for arriving late.
-		addInboxEntries(projectId, [entry("b", 10), entry("c", 40)]);
+		await addInboxEntries(client, projectId, [entry("b", 10), entry("c", 40)]);
 
 		expect(stored(projectId).map((e) => e.id)).toEqual(["c", "a", "b"]);
 	});
 
-	it("leaves an already-filed id exactly where it is, seen state and all", () => {
+	it("leaves an already-filed id exactly where it is, seen state and all", async () => {
 		const projectId = freshProject();
-		addInboxEntries(projectId, [entry("a", 10)]);
-		markInboxSeen(projectId, ["a"]);
+		await addInboxEntries(client, projectId, [entry("a", 10)]);
+		await markInboxSeen(client, projectId, ["a"]);
 		// The review bumped again but this kind's bucket did not change.
-		addInboxEntries(projectId, [entry("a", 10), entry("b", 20)]);
+		await addInboxEntries(client, projectId, [entry("a", 10), entry("b", 20)]);
 
 		expect(stored(projectId).map((e) => [e.id, e.seen])).toEqual([
 			["b", false],
@@ -65,17 +63,20 @@ describe("addInboxEntries", () => {
 		]);
 	});
 
-	it("returns only the entries that were new", () => {
+	it("returns only the entries that were new", async () => {
 		const projectId = freshProject();
-		expect(addInboxEntries(projectId, [entry("a", 10)]).map((e) => e.id)).toEqual(["a"]);
-		expect(addInboxEntries(projectId, [entry("a", 10), entry("b", 20)]).map((e) => e.id)).toEqual([
-			"b",
+		expect((await addInboxEntries(client, projectId, [entry("a", 10)])).map((e) => e.id)).toEqual([
+			"a",
 		]);
+		expect(
+			(await addInboxEntries(client, projectId, [entry("a", 10), entry("b", 20)])).map((e) => e.id),
+		).toEqual(["b"]);
 	});
 
-	it("drops the oldest past the cap", () => {
+	it("drops the oldest past the cap", async () => {
 		const projectId = freshProject();
-		addInboxEntries(
+		await addInboxEntries(
+			client,
 			projectId,
 			Array.from({ length: 105 }, (_, i) =>
 				entry(`e${i}`, 0, { at: new Date(1756500000000 + i * 60000).toISOString() }),
@@ -100,10 +101,10 @@ describe("retention per notification type", () => {
 
 	it.each([false, true])(
 		"keeps older notifications when the other type floods the inbox (agents first: %s)",
-		(agentsFirst) => {
+		async (agentsFirst) => {
 			const projectId = freshProject();
-			addInboxEntries(projectId, batch(agentsFirst, 0));
-			addInboxEntries(projectId, batch(!agentsFirst, 200));
+			await addInboxEntries(client, projectId, batch(agentsFirst, 0));
+			await addInboxEntries(client, projectId, batch(!agentsFirst, 200));
 			const kept = stored(projectId);
 			expect(kept).toHaveLength(200);
 			expect(kept.filter(isBotEntry)).toHaveLength(100);
@@ -115,13 +116,13 @@ describe("retention per notification type", () => {
 		},
 	);
 
-	it("retains both types when reading persisted entries", () => {
+	it("retains both types when reading persisted entries", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(
 			`pr_activity_inbox:v1:${projectId}`,
 			JSON.stringify([...batch(false, 0), ...batch(true, 200)]),
 		);
-		markInboxSeen(projectId);
+		await markInboxSeen(client, projectId);
 		const kept = stored(projectId);
 		expect(kept).toHaveLength(200);
 		expect(kept.filter(isBotEntry)).toHaveLength(100);
@@ -131,19 +132,13 @@ describe("retention per notification type", () => {
 	});
 });
 
-const marksOf = (projectId: string): Record<string, string> =>
-	JSON.parse(localStorage.getItem(`pr_activity_seen:v1:${projectId}`) ?? "{}") as Record<
-		string,
-		string
-	>;
-const unseenOf = (projectId: string): Record<string, unknown> =>
-	JSON.parse(localStorage.getItem(`pr_activity_unseen:v1:${projectId}`) ?? "{}") as Record<
-		string,
-		unknown
-	>;
+const marksOf = (projectId: string) =>
+	client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.marks ?? {};
+const unseenOf = (projectId: string) =>
+	client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.unseen ?? {};
 
 describe("markInboxSeen without ids", () => {
-	it("advances each review's watermark to its newest inbox entry, clearing its skips", () => {
+	it("advances each review's watermark to its newest inbox entry, clearing its skips", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(
 			`pr_activity_seen:v1:${projectId}`,
@@ -153,9 +148,13 @@ describe("markInboxSeen without ids", () => {
 			`pr_activity_unseen:v1:${projectId}`,
 			JSON.stringify({ 7: [["c:1", at(3)]], 9: [["c:2", at(3)]] }),
 		);
-		addInboxEntries(projectId, [entry("a", 5), entry("b", 10), entry("c", 20, { review: 8 })]);
+		await addInboxEntries(client, projectId, [
+			entry("a", 5),
+			entry("b", 10),
+			entry("c", 20, { review: 8 }),
+		]);
 
-		markInboxSeen(projectId);
+		await markInboxSeen(client, projectId);
 
 		expect(stored(projectId).every((e) => e.seen)).toBe(true);
 		expect(marksOf(projectId)).toEqual({ 7: at(10), 8: at(20) });
@@ -165,34 +164,34 @@ describe("markInboxSeen without ids", () => {
 		expect(unseenOf(projectId)).toEqual({ 9: [["c:2", at(3)]] });
 	});
 
-	it("still advances a stale watermark when every entry is already seen", () => {
+	it("still advances a stale watermark when every entry is already seen", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
-		addInboxEntries(projectId, [entry("a", 10, { seen: true })]);
+		await addInboxEntries(client, projectId, [entry("a", 10, { seen: true })]);
 
-		markInboxSeen(projectId);
+		await markInboxSeen(client, projectId);
 
 		expect(marksOf(projectId)[7]).toBe(at(10));
 	});
 
-	it("never moves a watermark backwards", () => {
+	it("never moves a watermark backwards", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(30) }));
-		addInboxEntries(projectId, [entry("a", 10)]);
+		await addInboxEntries(client, projectId, [entry("a", 10)]);
 
-		markInboxSeen(projectId);
+		await markInboxSeen(client, projectId);
 
 		expect(marksOf(projectId)[7]).toBe(at(30));
 	});
 
-	it("leaves other projects alone", () => {
+	it("leaves other projects alone", async () => {
 		const projectId = freshProject();
 		const other = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${other}`, JSON.stringify({ 7: at(0) }));
-		addInboxEntries(other, [entry("a", 10)]);
-		addInboxEntries(projectId, [entry("a", 10)]);
+		await addInboxEntries(client, other, [entry("a", 10)]);
+		await addInboxEntries(client, projectId, [entry("a", 10)]);
 
-		markInboxSeen(projectId);
+		await markInboxSeen(client, projectId);
 
 		expect(marksOf(other)[7]).toBe(at(0));
 		expect(stored(other)[0]?.seen).toBe(false);
@@ -200,16 +199,16 @@ describe("markInboxSeen without ids", () => {
 });
 
 describe("markInboxSeen with ids", () => {
-	it("marks only those entries, leaving review watermarks and skips as they were", () => {
+	it("marks only those entries, leaving review watermarks and skips as they were", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
 		localStorage.setItem(
 			`pr_activity_unseen:v1:${projectId}`,
 			JSON.stringify({ 7: [["c:1", at(3)]] }),
 		);
-		addInboxEntries(projectId, [entry("a", 5), entry("b", 10)]);
+		await addInboxEntries(client, projectId, [entry("a", 5), entry("b", 10)]);
 
-		markInboxSeen(projectId, ["b"]);
+		await markInboxSeen(client, projectId, ["b"]);
 
 		expect(stored(projectId).map((e) => [e.id, e.seen])).toEqual([
 			["b", true],
@@ -221,7 +220,7 @@ describe("markInboxSeen with ids", () => {
 });
 
 describe("entryHeadline", () => {
-	it("leads with what happened, then by whom", () => {
+	it("leads with what happened, then by whom", async () => {
 		expect(entryHeadline(entry("a", 0, { kind: "changesRequested" }))).toBe(
 			"Changes requested by alice",
 		);
@@ -234,14 +233,14 @@ describe("entryHeadline", () => {
 		);
 	});
 
-	it("stands alone when the actor is unknown", () => {
+	it("stands alone when the actor is unknown", async () => {
 		expect(entryHeadline(entry("a", 0, { kind: "merged", author: null }))).toBe("Merged");
 		expect(entryHeadline(entry("a", 0, { kind: "comment", author: null }))).toBe("Comment");
 	});
 });
 
 describe("desktopNotices", () => {
-	it("announces loud entries one by one, with the branch and snippet as the body", () => {
+	it("announces loud entries one by one, with the branch and snippet as the body", async () => {
 		const notices = desktopNotices([
 			entry("a", 0, { kind: "approved" }),
 			entry("b", 0, { kind: "comment", snippet: "Looks off to me" }),
@@ -253,7 +252,7 @@ describe("desktopNotices", () => {
 		]);
 	});
 
-	it("collapses a catch-up into one summary", () => {
+	it("collapses a catch-up into one summary", async () => {
 		const notices = desktopNotices(
 			["a", "b", "c", "d"].map((id, i) => entry(id, i, { review: i % 2 === 0 ? 7 : 8 })),
 		);
@@ -262,13 +261,13 @@ describe("desktopNotices", () => {
 		]);
 	});
 
-	it("says nothing for quiet news", () => {
+	it("says nothing for quiet news", async () => {
 		expect(desktopNotices([entry("a", 0, { kind: "merged" })])).toEqual([]);
 	});
 });
 
 describe("bot notifications", () => {
-	it("recognizes forge flags and legacy bot logins without hiding unknown authors", () => {
+	it("recognizes forge flags and legacy bot logins without hiding unknown authors", async () => {
 		expect(isBotEntry(entry("flagged", 1, { author: "copilot", authorIsBot: true }))).toBe(true);
 		expect(isBotEntry(entry("legacy", 1, { author: "renovate[bot]" }))).toBe(true);
 		expect(isBotEntry(entry("reviewer", 1, { author: "copilot-pull-request-reviewer" }))).toBe(
@@ -282,9 +281,9 @@ describe("bot notifications", () => {
 		expect(isBotEntry(entry("human", 1))).toBe(false);
 	});
 
-	it("retains bot metadata in persisted entries", () => {
+	it("retains bot metadata in persisted entries", async () => {
 		const projectId = freshProject();
-		addInboxEntries(projectId, [entry("bot", 1, { authorIsBot: true })]);
+		await addInboxEntries(client, projectId, [entry("bot", 1, { authorIsBot: true })]);
 		expect(stored(projectId)[0]?.authorIsBot).toBe(true);
 	});
 });
@@ -292,7 +291,7 @@ describe("bot notifications", () => {
 describe("rediscovered activity", () => {
 	it.each([false, true])(
 		"deduplicates a legacy agent entry without changing its seen state (%s)",
-		(seen) => {
+		async (seen) => {
 			const projectId = freshProject();
 			const id = `7:comment:${at(1)}`;
 			localStorage.setItem(
@@ -300,60 +299,61 @@ describe("rediscovered activity", () => {
 				JSON.stringify([entry(id, 1, { author: "copilot-pull-request-reviewer", seen })]),
 			);
 			expect(
-				addInboxEntries(projectId, [
+				await addInboxEntries(client, projectId, [
 					entry(`${id}:bot`, 1, { author: "copilot-pull-request-reviewer", authorIsBot: true }),
 				]),
 			).toEqual([]);
-			addInboxEntries(projectId, [entry("unrelated", 2)]);
-			addInboxEntries(freshProject(), [entry("other", 1)]);
-			expect(findInboxEntry(projectId, id)?.seen).toBe(seen);
+			await addInboxEntries(client, projectId, [entry("unrelated", 2)]);
+			client.removeQueries({ queryKey: reviewStateQueryOptions(projectId).queryKey });
+			expect((await findInboxEntry(client, projectId, id))?.seen).toBe(seen);
 		},
 	);
 
-	it("does not confuse a human entry with an agent entry at the same timestamp", () => {
+	it("does not confuse a human entry with an agent entry at the same timestamp", async () => {
 		const projectId = freshProject();
 		const id = `7:comment:${at(1)}`;
-		addInboxEntries(projectId, [entry(id, 1)]);
-		expect(addInboxEntries(projectId, [entry(`${id}:bot`, 1, { authorIsBot: true })])).toHaveLength(
-			1,
-		);
+		await addInboxEntries(client, projectId, [entry(id, 1)]);
+		expect(
+			await addInboxEntries(client, projectId, [entry(`${id}:bot`, 1, { authorIsBot: true })]),
+		).toHaveLength(1);
 		expect(stored(projectId)).toHaveLength(2);
 	});
 
-	it("does not announce replayed activity that falls outside the retained history", () => {
+	it("does not announce replayed activity that falls outside the retained history", async () => {
 		const projectId = freshProject();
 		const old = entry("old", 0);
-		addInboxEntries(projectId, [old]);
-		markInboxSeen(projectId, [old.id]);
-		addInboxEntries(
+		await addInboxEntries(client, projectId, [old]);
+		await markInboxSeen(client, projectId, [old.id]);
+		await addInboxEntries(
+			client,
 			projectId,
 			Array.from({ length: 100 }, (_, i) =>
 				entry(`new-${i}`, 1, { at: new Date(Date.parse(at(1)) + i * 60000).toISOString() }),
 			),
 		);
-		// Reading another project evicts the in-memory cache, as a reload would.
-		addInboxEntries(freshProject(), [entry("other", 1)]);
-		expect(addInboxEntries(projectId, [old])).toEqual([]);
+		// Reopening the project must preserve retention and seen state.
+		client.removeQueries({ queryKey: reviewStateQueryOptions(projectId).queryKey });
+		expect(await addInboxEntries(client, projectId, [old])).toEqual([]);
 		expect(stored(projectId).some((item) => item.id === old.id)).toBe(false);
 	});
 });
 
-it("keeps a human notification that shares a legacy agent timestamp", () => {
+it("keeps a human notification that shares a legacy agent timestamp", async () => {
 	const projectId = freshProject();
 	const id = `7:comment:${at(1)}`;
 	localStorage.setItem(
 		`pr_activity_inbox:v1:${projectId}`,
 		JSON.stringify([entry(id, 1, { author: "copilot-pull-request-reviewer", seen: true })]),
 	);
-	expect(addInboxEntries(projectId, [entry(id, 1)])).toHaveLength(1);
+	expect(await addInboxEntries(client, projectId, [entry(id, 1)])).toHaveLength(1);
 	expect(stored(projectId)).toHaveLength(2);
-	expect(findInboxEntry(projectId, id)?.author).toBe("alice");
-	expect(findInboxEntry(projectId, `${id}:bot`)?.seen).toBe(true);
-	addInboxEntries(freshProject(), [entry("other", 1)]);
-	expect(findInboxEntry(projectId, `${id}:bot`)?.seen).toBe(true);
+	expect((await findInboxEntry(client, projectId, id))?.author).toBe("alice");
+	expect((await findInboxEntry(client, projectId, `${id}:bot`))?.seen).toBe(true);
+	client.removeQueries({ queryKey: reviewStateQueryOptions(projectId).queryKey });
+	expect((await findInboxEntry(client, projectId, `${id}:bot`))?.seen).toBe(true);
 });
 
-it("merges already duplicated legacy agent entries without losing read state", () => {
+it("merges already duplicated legacy agent entries without losing read state", async () => {
 	const projectId = freshProject();
 	const id = `7:comment:${at(1)}`;
 	localStorage.setItem(
@@ -363,41 +363,46 @@ it("merges already duplicated legacy agent entries without losing read state", (
 			entry(id, 1, { author: "copilot-pull-request-reviewer", seen: true }),
 		]),
 	);
-	addInboxEntries(projectId, [entry("another", 2)]);
+	await addInboxEntries(client, projectId, [entry("another", 2)]);
 	expect(stored(projectId)).toHaveLength(2);
-	expect(findInboxEntry(projectId, id)?.seen).toBe(true);
-	expect(findInboxEntry(projectId, id)?.authorIsBot).toBe(true);
+	expect((await findInboxEntry(client, projectId, id))?.seen).toBe(true);
+	expect((await findInboxEntry(client, projectId, id))?.authorIsBot).toBe(true);
 });
 
-it("does not resolve an evicted human desktop notice to an agent", () => {
+it("does not resolve an evicted human desktop notice to an agent", async () => {
 	const projectId = freshProject();
 	const id = `7:comment:${at(0)}`;
-	addInboxEntries(projectId, [entry(id, 0), entry(`${id}:bot`, 0, { authorIsBot: true })]);
-	addInboxEntries(
+	await addInboxEntries(client, projectId, [
+		entry(id, 0),
+		entry(`${id}:bot`, 0, { authorIsBot: true }),
+	]);
+	await addInboxEntries(
+		client,
 		projectId,
 		Array.from({ length: 100 }, (_, i) =>
 			entry(`human-${i}`, 1, { at: new Date(Date.parse(at(1)) + i * 60000).toISOString() }),
 		),
 	);
-	expect(findInboxEntry(projectId, id)).toBeUndefined();
-	expect(findInboxEntry(projectId, `${id}:bot`)).toBeDefined();
+	expect(await findInboxEntry(client, projectId, id)).toBeUndefined();
+	expect(await findInboxEntry(client, projectId, `${id}:bot`)).toBeDefined();
 });
 
-it("retires a migrated alias when a human entry claims its ID", () => {
+it("retires a migrated alias when a human entry claims its ID", async () => {
 	const projectId = freshProject();
 	const id = `7:comment:${at(0)}`;
 	localStorage.setItem(
 		`pr_activity_inbox:v1:${projectId}`,
 		JSON.stringify([entry(id, 0, { author: "copilot-pull-request-reviewer" })]),
 	);
-	addInboxEntries(projectId, [entry(id, 0)]);
-	addInboxEntries(
+	await addInboxEntries(client, projectId, [entry(id, 0)]);
+	await addInboxEntries(
+		client,
 		projectId,
 		Array.from({ length: 100 }, (_, i) =>
 			entry(`human-${i}`, 1, { at: new Date(Date.parse(at(1)) + i * 60000).toISOString() }),
 		),
 	);
-	addInboxEntries(freshProject(), [entry("other", 1)]);
-	expect(findInboxEntry(projectId, id)).toBeUndefined();
-	expect(findInboxEntry(projectId, `${id}:bot`)).toBeDefined();
+	client.removeQueries({ queryKey: reviewStateQueryOptions(projectId).queryKey });
+	expect(await findInboxEntry(client, projectId, id)).toBeUndefined();
+	expect(await findInboxEntry(client, projectId, `${id}:bot`)).toBeDefined();
 });

--- a/apps/lite/ui/src/review-inbox.ts
+++ b/apps/lite/ui/src/review-inbox.ts
@@ -159,7 +159,10 @@ export const findInboxEntry = async (
 	projectId: string,
 	id: string,
 ): Promise<InboxEntry | undefined> => {
-	const { inbox: entries } = await client.fetchQuery(reviewStateQueryOptions(projectId));
+	const { inbox: entries } = await client.fetchQuery({
+		...reviewStateQueryOptions(projectId),
+		staleTime: 0,
+	});
 	// Only migrated entries can answer to an old desktop notification ID.
 	return entries.find((entry) => entry.id === id) ?? entries.find((entry) => entry.legacyId === id);
 };

--- a/apps/lite/ui/src/review-inbox.ts
+++ b/apps/lite/ui/src/review-inbox.ts
@@ -1,57 +1,14 @@
-/**
- * @file The notification inbox behind the bell.
- *
- * One entry per review, kind and poll — the detector writes what happened,
- * structured, and the bell renders it richly. Same store discipline as the
- * watermarks: local storage, disposable, capped, validated at parse, pure
- * in-memory snapshots.
- */
-
-import { isAgent } from "#ui/review-users.ts";
+import {
+	capInboxEntries,
+	reviewStateQueryOptions,
+	updateReviewState,
+	type InboxEntry,
+	type InboxKind,
+} from "#ui/review-state.ts";
+export { isBotEntry, type InboxEntry, type InboxKind } from "#ui/review-state.ts";
 import type { ShowNotificationParams } from "#electron/ipc.ts";
-import { markReviewsSeenUpTo } from "#ui/review-seen.ts";
-import { useSyncExternalStore } from "react";
-
-export type InboxKind =
-	| "comment"
-	| "mention"
-	| "approved"
-	| "changesRequested"
-	| "reviewRequested"
-	| "committed"
-	| "merged"
-	| "closed";
-
-export type InboxEntry = {
-	id: string;
-	legacyId?: string;
-	kind: InboxKind;
-	review: number;
-	reviewTitle: string;
-	unitSymbol: string;
-	sourceBranch: string;
-	htmlUrl: string;
-	author: string | null;
-	authorIsBot?: boolean;
-	/** How many items this entry coalesces — "3 comments". */
-	count: number;
-	/** The comment a click should land on, when the entry is about comments. */
-	commentId?: number | null;
-	snippet: string | null;
-	at: string;
-	seen: boolean;
-};
-
-const inboxKinds: ReadonlyArray<string> = [
-	"comment",
-	"mention",
-	"approved",
-	"changesRequested",
-	"reviewRequested",
-	"committed",
-	"merged",
-	"closed",
-];
+import { reviewsSeenUpTo } from "#ui/review-seen.ts";
+import { useQuery, type QueryClient } from "@tanstack/react-query";
 
 /**
  * Loud kinds have a human waiting on the user; quiet ones are news the bell
@@ -129,152 +86,6 @@ export const desktopNotices = (fresh: ReadonlyArray<InboxEntry>): Array<ShowNoti
 	];
 };
 
-export const isBotEntry = (entry: InboxEntry): boolean =>
-	isAgent({ login: entry.author ?? "", isBot: entry.authorIsBot === true });
-
-const storageKey = (projectId: string) => `pr_activity_inbox:v1:${projectId}`;
-
-/** Each tab keeps its own history so agent traffic cannot crowd out humans. */
-const inboxCapPerType = 100;
-
-const capEntries = (entries: Array<InboxEntry>): Array<InboxEntry> => {
-	let humans = 0;
-	let agents = 0;
-	return entries.filter((entry) =>
-		isBotEntry(entry) ? ++agents <= inboxCapPerType : ++humans <= inboxCapPerType,
-	);
-};
-
-const listeners = new Set<() => void>();
-let cached: { key: string; entries: Array<InboxEntry> } | null = null;
-
-// Storage can throw — disabled, partitioned, or over quota — and a throw
-// here would crash every subscriber's render. The inbox degrades instead.
-const storageGet = (key: string): string | null => {
-	try {
-		return localStorage.getItem(key);
-	} catch {
-		return null;
-	}
-};
-const storageSet = (key: string, value: string): void => {
-	try {
-		localStorage.setItem(key, value);
-	} catch {
-		// The in-memory copy still serves this session.
-	}
-};
-
-const migrateEntries = (entries: Array<InboxEntry>): Array<InboxEntry> => {
-	const byId = new Map<string, InboxEntry>();
-	for (const stored of entries) {
-		const legacyAgent =
-			stored.authorIsBot === undefined &&
-			isBotEntry(stored) &&
-			stored.id === `${stored.review}:${stored.kind}:${stored.at}`;
-		const entry = legacyAgent ? { ...stored, id: `${stored.id}:bot`, legacyId: stored.id } : stored;
-		const previous = byId.get(entry.id);
-		byId.set(
-			entry.id,
-			previous
-				? {
-						...entry,
-						seen: previous.seen || entry.seen,
-						authorIsBot: entry.authorIsBot ?? previous.authorIsBot,
-						legacyId: entry.legacyId ?? previous.legacyId,
-					}
-				: entry,
-		);
-	}
-	return [...byId.values()].map((entry) =>
-		entry.legacyId !== undefined && byId.has(entry.legacyId)
-			? { ...entry, legacyId: undefined }
-			: entry,
-	);
-};
-
-const parseEntries = (raw: string | null): Array<InboxEntry> => {
-	if (raw === null) return [];
-	try {
-		const stored: unknown = JSON.parse(raw);
-		if (!Array.isArray(stored)) return [];
-		// Ordered here, not just at write time: a list stored by an older
-		// build keeps whatever order it had until something new files.
-		return capEntries(
-			migrateEntries(
-				stored.filter((entry): entry is InboxEntry => {
-					if (typeof entry !== "object" || entry === null) return false;
-					const e = entry as Record<string, unknown>;
-					return (
-						typeof e.id === "string" &&
-						(e.legacyId === undefined || typeof e.legacyId === "string") &&
-						typeof e.kind === "string" &&
-						inboxKinds.includes(e.kind) &&
-						typeof e.review === "number" &&
-						typeof e.reviewTitle === "string" &&
-						typeof e.unitSymbol === "string" &&
-						typeof e.sourceBranch === "string" &&
-						typeof e.htmlUrl === "string" &&
-						(e.author === null || typeof e.author === "string") &&
-						(e.authorIsBot === undefined || typeof e.authorIsBot === "boolean") &&
-						typeof e.count === "number" &&
-						(e.commentId === undefined ||
-							e.commentId === null ||
-							typeof e.commentId === "number") &&
-						(e.snippet === null || typeof e.snippet === "string") &&
-						typeof e.at === "string" &&
-						!Number.isNaN(Date.parse(e.at)) &&
-						typeof e.seen === "boolean"
-					);
-				}),
-			).sort((a, b) => Date.parse(b.at) - Date.parse(a.at)),
-		);
-	} catch {
-		return [];
-	}
-};
-
-const readEntries = (projectId: string): Array<InboxEntry> => {
-	const key = storageKey(projectId);
-	if (cached?.key === key) return cached.entries;
-	const entries = parseEntries(storageGet(key));
-	cached = { key, entries };
-	return entries;
-};
-
-const notify = (): void => {
-	for (const listener of listeners) listener();
-};
-
-const writeEntries = (projectId: string, entries: Array<InboxEntry>): void => {
-	storageSet(storageKey(projectId), JSON.stringify(entries));
-	cached = { key: storageKey(projectId), entries };
-	notify();
-};
-
-let watchingStorage = false;
-
-const onStorage = (event: StorageEvent): void => {
-	// A null key is a wholesale clear; other keys are someone else's business.
-	if (event.key !== null && !event.key.startsWith("pr_activity_")) return;
-	cached = null;
-	notify();
-};
-
-const subscribeInbox = (listener: () => void): (() => void) => {
-	// On first use, so merely importing this module listens to nothing.
-	if (!watchingStorage) {
-		watchingStorage = true;
-		window.addEventListener("storage", onStorage);
-	}
-	// A first subscriber is a fresh surface: re-read whatever storage holds.
-	if (listeners.size === 0) cached = null;
-	listeners.add(listener);
-	return () => listeners.delete(listener);
-};
-
-const subscribeNothing = (): (() => void) => () => {};
-
 /**
  * File the poll's entries, keeping the list ordered by each entry's own
  * time. An id already filed is left exactly where it is, seen state and
@@ -282,28 +93,33 @@ const subscribeNothing = (): (() => void) => () => {};
  * Returns new entries that survive retention, so replaying evicted history
  * cannot announce stale activity again.
  */
-export const addInboxEntries = (
+export const addInboxEntries = async (
+	client: QueryClient,
 	projectId: string,
 	entries: Array<InboxEntry>,
-): Array<InboxEntry> => {
+): Promise<Array<InboxEntry>> => {
 	if (entries.length === 0) return [];
-	const existing = readEntries(projectId);
-	const known = new Set(existing.map((entry) => entry.id));
-	const fresh = entries.filter((entry) => !known.has(entry.id));
-	if (fresh.length === 0) return [];
-	const claimedIds = new Set(fresh.map((entry) => entry.id));
-	const retainedExisting = existing.map((entry) =>
-		entry.legacyId !== undefined && claimedIds.has(entry.legacyId)
-			? { ...entry, legacyId: undefined }
-			: entry,
-	);
-	const next = capEntries(
-		[...fresh, ...retainedExisting].sort((a, b) => Date.parse(b.at) - Date.parse(a.at)),
-	);
-	const retained = new Set(next);
-	const filed = fresh.filter((entry) => retained.has(entry));
-	if (filed.length === 0) return [];
-	writeEntries(projectId, next);
+	let filed: Array<InboxEntry> = [];
+	await updateReviewState(client, projectId, (state) => {
+		filed = [];
+		const existing = state.inbox;
+		const known = new Set(existing.map((entry) => entry.id));
+		const fresh = entries.filter((entry) => !known.has(entry.id));
+		if (fresh.length === 0) return state;
+		const claimedIds = new Set(fresh.map((entry) => entry.id));
+		const retainedExisting = existing.map((entry) =>
+			entry.legacyId !== undefined && claimedIds.has(entry.legacyId)
+				? { ...entry, legacyId: undefined }
+				: entry,
+		);
+		const next = capInboxEntries(
+			[...fresh, ...retainedExisting].sort((a, b) => Date.parse(b.at) - Date.parse(a.at)),
+		);
+		const retained = new Set(next);
+		filed = fresh.filter((entry) => retained.has(entry));
+		if (filed.length === 0) return state;
+		return { ...state, inbox: next };
+	});
 	return filed;
 };
 
@@ -311,37 +127,51 @@ export const addInboxEntries = (
  * Mark the given entries seen; without ids, everything — which also
  * declares each represented review read up to its newest entry.
  */
-export const markInboxSeen = (projectId: string, ids?: ReadonlyArray<string>): void => {
-	const entries = readEntries(projectId);
-	// Every current entry, seen or not: a watermark can lag entries already
-	// seen, and the declaration must cover it.
-	if (ids === undefined) {
-		markReviewsSeenUpTo(
-			projectId,
-			entries.map((entry) => [entry.review, entry.at] as const),
-		);
-	}
-	const wanted = ids === undefined ? null : new Set(ids);
-	if (!entries.some((entry) => !entry.seen && (wanted === null || wanted.has(entry.id)))) return;
-	writeEntries(
-		projectId,
-		entries.map((entry) =>
-			!entry.seen && (wanted === null || wanted.has(entry.id)) ? { ...entry, seen: true } : entry,
-		),
-	);
+export const markInboxSeen = async (
+	client: QueryClient,
+	projectId: string,
+	ids?: ReadonlyArray<string>,
+): Promise<void> => {
+	await updateReviewState(client, projectId, (state) => {
+		const { inbox } = state;
+		const next =
+			ids === undefined
+				? reviewsSeenUpTo(
+						state,
+						inbox.map((entry) => [entry.review, entry.at] as const),
+					)
+				: state;
+		const wanted = ids === undefined ? null : new Set(ids);
+		if (!inbox.some((entry) => !entry.seen && (wanted === null || wanted.has(entry.id))))
+			return next;
+		return {
+			...next,
+			inbox: inbox.map((entry) =>
+				!entry.seen && (wanted === null || wanted.has(entry.id)) ? { ...entry, seen: true } : entry,
+			),
+		};
+	});
 };
 
 /** The entry a desktop notification was shown for, if it is still filed. */
-export const findInboxEntry = (projectId: string, id: string): InboxEntry | undefined => {
-	const entries = readEntries(projectId);
+export const findInboxEntry = async (
+	client: QueryClient,
+	projectId: string,
+	id: string,
+): Promise<InboxEntry | undefined> => {
+	const { inbox: entries } = await client.fetchQuery(reviewStateQueryOptions(projectId));
 	// Only migrated entries can answer to an old desktop notification ID.
 	return entries.find((entry) => entry.id === id) ?? entries.find((entry) => entry.legacyId === id);
 };
 
 /** The inbox, newest first — a stable array identity between writes. */
-export const useInboxEntries = (projectId: string, enabled: boolean): Array<InboxEntry> =>
-	useSyncExternalStore(enabled ? subscribeInbox : subscribeNothing, () =>
-		enabled ? readEntries(projectId) : emptyInbox,
-	);
+export const useInboxEntries = (projectId: string, enabled: boolean): Array<InboxEntry> => {
+	const { data } = useQuery({
+		...reviewStateQueryOptions(projectId),
+		enabled,
+		select: (state) => state.inbox,
+	});
+	return enabled ? (data ?? emptyInbox) : emptyInbox;
+};
 
 const emptyInbox: Array<InboxEntry> = [];

--- a/apps/lite/ui/src/review-notifications.test.ts
+++ b/apps/lite/ui/src/review-notifications.test.ts
@@ -1,7 +1,21 @@
 /** @vitest-environment jsdom */
-import { describe, expect, it } from "vitest";
+import "fake-indexeddb/auto";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { reviewStateQueryOptions } from "./review-state.ts";
+const client = new QueryClient();
+import { describe, expect, it, vi } from "vitest";
 import type { ForgeReview } from "@gitbutler/but-sdk";
-import { coalesceInboxEntries } from "./review-notifications.ts";
+import { coalesceInboxEntries, useReviewActivityInbox } from "./review-notifications.ts";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import {
+	currentForgeLoginQueryOptions,
+	forgeInfoOptions,
+	guiSettingsQueryOptions,
+	headInfoQueryOptions,
+	listReviewsQueryOptions,
+} from "./api/queries.ts";
+import type { ReviewState } from "./review-state.ts";
 import { addInboxEntries } from "./review-inbox.ts";
 
 const review = (overrides: Partial<ForgeReview> = {}): ForgeReview => ({
@@ -32,7 +46,7 @@ const review = (overrides: Partial<ForgeReview> = {}): ForgeReview => ({
 });
 
 describe("coalesceInboxEntries", () => {
-	it("files human and agent comments from one poll separately, even at the same timestamp", () => {
+	it("files human and agent comments from one poll separately, even at the same timestamp", async () => {
 		const atMs = Date.parse("2026-08-28T11:00:00Z");
 		const items = coalesceInboxEntries(
 			review(),
@@ -68,9 +82,74 @@ describe("coalesceInboxEntries", () => {
 			snippet: "Agent note",
 		});
 		const projectId = "coalescing-test";
-		expect(addInboxEntries(projectId, items)).toHaveLength(2);
-		expect(
-			JSON.parse(localStorage.getItem(`pr_activity_inbox:v1:${projectId}`) ?? "[]"),
-		).toHaveLength(2);
+		expect(await addInboxEntries(client, projectId, items)).toHaveLength(2);
+		expect(client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.inbox).toHaveLength(2);
 	});
+});
+
+it("retains the first listing while storage hydrates, so the next poll remains new", async () => {
+	globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+	const projectId = "hydrating-detector";
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+	});
+	const ready = Promise.withResolvers<ReviewState>();
+	const hydration = client.fetchQuery({
+		...reviewStateQueryOptions(projectId),
+		queryFn: () => ready.promise,
+	});
+	const listingKey = listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }).queryKey;
+	client.setQueryData(guiSettingsQueryOptions.queryKey, {
+		version: 1,
+		prNotifications: "loud",
+		desktopNotifications: false,
+	});
+	client.setQueryData(currentForgeLoginQueryOptions(projectId).queryKey, "me");
+	client.setQueryData(listingKey, [review()]);
+	vi.stubGlobal("lite", {
+		forgeInfo: async () => ({ capabilities: { prService: true, reviewComments: true } }),
+		headInfo: async () => ({ stacks: [] }),
+		listReviewComments: async () => [
+			{
+				id: 1,
+				body: "Please look @me",
+				createdAt: "2026-08-28T10:30:00Z",
+				author: { login: "alice", isBot: false },
+				reactions: [],
+			},
+		],
+		listReviewSubmissions: async () => [],
+		listReviewThreads: async () => [],
+		listReviewTimelineEvents: async () => [],
+		onNotificationClick: () => () => {},
+	});
+	await client.fetchQuery(forgeInfoOptions(projectId));
+	await client.fetchQuery(headInfoQueryOptions(projectId));
+	const root = createRoot(document.createElement("div"));
+	const Observe = () => {
+		useReviewActivityInbox(projectId);
+		return null;
+	};
+	try {
+		await act(async () => {
+			root.render(createElement(QueryClientProvider, { client }, createElement(Observe)));
+		});
+		await act(async () => {
+			client.setQueryData(listingKey, [review({ modifiedAt: "2026-08-28T11:00:00Z" })]);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		await act(async () => {
+			ready.resolve({ marks: {}, unseen: {}, inbox: [] });
+			await hydration;
+		});
+		await vi.waitFor(() =>
+			expect(client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.inbox).toMatchObject(
+				[{ kind: "mention", review: 7 }],
+			),
+		);
+	} finally {
+		await act(async () => root.unmount());
+		client.clear();
+		vi.unstubAllGlobals();
+	}
 });

--- a/apps/lite/ui/src/review-notifications.test.ts
+++ b/apps/lite/ui/src/review-notifications.test.ts
@@ -153,3 +153,79 @@ it("retains the first listing while storage hydrates, so the next poll remains n
 		vi.unstubAllGlobals();
 	}
 });
+
+it("waits for fresh marks when enabling the detector with an invalidated cache", async () => {
+	globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+	const projectId = "stale-detector";
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+	});
+	const options = reviewStateQueryOptions(projectId);
+	client.setQueryData(options.queryKey, {
+		marks: { 7: "2026-08-28T09:00:00Z" },
+		unseen: {},
+		inbox: [],
+	});
+	client.setQueryData(guiSettingsQueryOptions.queryKey, {
+		version: 1,
+		prNotifications: "off",
+		desktopNotifications: false,
+	});
+	client.setQueryData(currentForgeLoginQueryOptions(projectId).queryKey, "me");
+	client.setQueryData(listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }).queryKey, [
+		review(),
+	]);
+	const comments = vi.fn(async () => [
+		{
+			id: 1,
+			body: "@me already read this",
+			createdAt: "2026-08-28T09:30:00Z",
+			author: { login: "alice", isBot: false },
+			reactions: [],
+		},
+	]);
+	vi.stubGlobal("lite", {
+		forgeInfo: async () => ({ capabilities: { prService: true, reviewComments: true } }),
+		headInfo: async () => ({ stacks: [] }),
+		listReviewComments: comments,
+		listReviewSubmissions: async () => [],
+		listReviewThreads: async () => [],
+		listReviewTimelineEvents: async () => [],
+		onNotificationClick: () => () => {},
+	});
+	await client.fetchQuery(forgeInfoOptions(projectId));
+	await client.fetchQuery(headInfoQueryOptions(projectId));
+	const root = createRoot(document.createElement("div"));
+	const Observe = () => {
+		useReviewActivityInbox(projectId);
+		return null;
+	};
+	const ready = Promise.withResolvers<ReviewState>();
+	try {
+		await act(async () => {
+			root.render(createElement(QueryClientProvider, { client }, createElement(Observe)));
+		});
+		await client.invalidateQueries({ queryKey: options.queryKey });
+		const refresh = client.fetchQuery({ ...options, staleTime: 0, queryFn: () => ready.promise });
+		await act(async () => {
+			client.setQueryData(guiSettingsQueryOptions.queryKey, {
+				version: 1,
+				prNotifications: "loud",
+				desktopNotifications: false,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		expect(comments).not.toHaveBeenCalled();
+		await act(async () => {
+			ready.resolve({ marks: { 7: "2026-08-28T10:00:00Z" }, unseen: {}, inbox: [] });
+			await refresh;
+		});
+		expect(comments).not.toHaveBeenCalled();
+		expect(client.getQueryData(options.queryKey)?.inbox).toEqual([]);
+	} finally {
+		ready.resolve({ marks: {}, unseen: {}, inbox: [] });
+		await act(async () => root.unmount());
+		client.clear();
+		vi.unstubAllGlobals();
+	}
+});

--- a/apps/lite/ui/src/review-notifications.ts
+++ b/apps/lite/ui/src/review-notifications.ts
@@ -1,3 +1,4 @@
+import { reviewStateQueryOptions } from "#ui/review-state.ts";
 /**
  * @file Turning review activity into inbox entries.
  *
@@ -41,14 +42,10 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { requestReviewFocus } from "#ui/review-focus.ts";
 import { store } from "#ui/store.ts";
 import { setActiveList, setCursor, setPage } from "#ui/use-cursor.ts";
-import {
-	readSeenMarks,
-	useDesktopNotifications,
-	usePrNotificationsLevel,
-} from "#ui/review-seen.ts";
+import { useDesktopNotifications, usePrNotificationsLevel } from "#ui/review-seen.ts";
 import { selfMergedNumbers } from "#ui/api/mutations.ts";
 import type { ForgeReview, RefInfo } from "@gitbutler/but-sdk";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { useEffect, useEffectEvent, useRef } from "react";
 
 /** Applied branches by display name, each with the ref bytes a cursor needs. */
@@ -72,11 +69,12 @@ export const appliedRefsByName = (headInfo: RefInfo): AppliedRefs =>
  * outside the workspace has no local branch to select.
  */
 export const openInboxEntry = (
+	client: QueryClient,
 	projectId: string,
 	entry: InboxEntry,
 	appliedRefs: AppliedRefs,
 ): void => {
-	markInboxSeen(projectId, [entry.id]);
+	void markInboxSeen(client, projectId, [entry.id]);
 	const branchRef = appliedRefs.get(entry.sourceBranch);
 	if (branchRef === undefined) {
 		void window.lite.openInWebBrowser(entry.htmlUrl);
@@ -267,10 +265,12 @@ export const useReviewActivityInbox = (projectId: string): void => {
 
 	const observe = useEffectEvent(async (listing: Array<ForgeReview>) => {
 		if (!appliedRefs) return;
+		// Keep this listing while hydrating; waiting for another render can skip the first poll.
+		const { marks } = await client.ensureQueryData(reviewStateQueryOptions(projectId));
 		if (ledger.current === null) {
 			// Seeded from what has actually been seen, so activity that landed
 			// while the app was closed still speaks up.
-			ledger.current = seenLedger(listing, readSeenMarks(projectId));
+			ledger.current = seenLedger(listing, marks);
 		}
 		const { changed, next } = observeReviews(ledger.current, listing);
 		ledger.current = next;
@@ -289,7 +289,7 @@ export const useReviewActivityInbox = (projectId: string): void => {
 				}),
 			)
 		).flat();
-		const fresh = addInboxEntries(projectId, entries);
+		const fresh = await addInboxEntries(client, projectId, entries);
 		if (desktop)
 			for (const notice of desktopNotices(fresh)) void window.lite.showNotification(notice);
 	});
@@ -302,14 +302,14 @@ export const useReviewActivityInbox = (projectId: string): void => {
 
 	// The main process has focused the window by now; a summary, or an entry
 	// since dropped from the inbox, leaves the reader at the lit bell.
-	const onNotificationClick = useEffectEvent((id: string) => {
+	const onNotificationClick = useEffectEvent(async (id: string) => {
 		if (appliedRefs === undefined) return;
-		const entry = findInboxEntry(projectId, id);
-		if (entry !== undefined) openInboxEntry(projectId, entry, appliedRefs);
+		const entry = await findInboxEntry(client, projectId, id);
+		if (entry !== undefined) openInboxEntry(client, projectId, entry, appliedRefs);
 	});
 	useEffect(() => {
 		if (!enabled) return;
-		return window.lite.onNotificationClick(onNotificationClick);
+		return window.lite.onNotificationClick((id) => void onNotificationClick(id));
 	}, [enabled]);
 
 	// `appliedRefs` in the deps takes the baseline as soon as both the

--- a/apps/lite/ui/src/review-notifications.ts
+++ b/apps/lite/ui/src/review-notifications.ts
@@ -265,13 +265,12 @@ export const useReviewActivityInbox = (projectId: string): void => {
 
 	const observe = useEffectEvent(async (listing: Array<ForgeReview>) => {
 		if (!appliedRefs) return;
-		// Keep this listing while hydrating; waiting for another render can skip the first poll.
-		const { marks } = await client.ensureQueryData(reviewStateQueryOptions(projectId));
-		if (ledger.current === null) {
-			// Seeded from what has actually been seen, so activity that landed
-			// while the app was closed still speaks up.
-			ledger.current = seenLedger(listing, marks);
-		}
+		// Keep each listing while reading fresh marks, including another window's latest reads.
+		const { marks } = await client.fetchQuery({
+			...reviewStateQueryOptions(projectId),
+			staleTime: 0,
+		});
+		if (ledger.current === null) ledger.current = seenLedger(listing, marks);
 		const { changed, next } = observeReviews(ledger.current, listing);
 		ledger.current = next;
 		if (changed.length === 0) return;

--- a/apps/lite/ui/src/review-seen.test.ts
+++ b/apps/lite/ui/src/review-seen.test.ts
@@ -1,36 +1,33 @@
 /** @vitest-environment jsdom */
+import "fake-indexeddb/auto";
+import { QueryClient } from "@tanstack/react-query";
+import { reviewStateQueryOptions, updateReviewState } from "./review-state.ts";
+const client = new QueryClient();
 import {
 	isItemSkipped,
 	markItemSeen,
 	markReviewSeen,
-	markReviewsSeenUpTo,
+	reviewsSeenUpTo,
 	registerReviewItems,
 } from "./review-seen.ts";
 import { describe, expect, it } from "vitest";
 
-/**
- * The module caches per storage key, so each test gets its own project id
- * rather than sharing a window-wide reset.
- */
 let nextProject = 0;
 const freshProject = () => `test-project-${nextProject++}`;
 
-const unseenOf = (projectId: string): Record<string, Array<[string, string]>> =>
-	JSON.parse(localStorage.getItem(`pr_activity_unseen:v1:${projectId}`) ?? "{}") as Record<
-		string,
-		Array<[string, string]>
-	>;
-const marksOf = (projectId: string): Record<string, string> =>
-	JSON.parse(localStorage.getItem(`pr_activity_seen:v1:${projectId}`) ?? "{}") as Record<
-		string,
-		string
-	>;
+const unseenOf = (projectId: string) =>
+	client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.unseen ?? {};
+const marksOf = (projectId: string) =>
+	client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.marks ?? {};
+
+const markReviewsSeenUpTo = (projectId: string, latest: Iterable<readonly [number, string]>) =>
+	updateReviewState(client, projectId, (state) => reviewsSeenUpTo(state, latest));
 
 const at = (minute: number) => `2026-08-30T10:${String(minute).padStart(2, "0")}:00.000Z`;
 const atMs = (minute: number) => Date.parse(at(minute));
 
 describe("markReviewSeen", () => {
-	it("records registered items above the old watermark as skips", () => {
+	it("records registered items above the old watermark as skips", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
 		registerReviewItems(projectId, 7, "conversation", [
@@ -38,13 +35,13 @@ describe("markReviewSeen", () => {
 			{ key: "c:2", atMs: atMs(10) },
 		]);
 
-		markReviewSeen(projectId, 7, at(15));
+		await markReviewSeen(client, projectId, 7, at(15));
 
 		expect(marksOf(projectId)[7]).toBe(at(15));
 		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:1", "c:2"]);
 	});
 
-	it("does not skip items already below the watermark, or looked at first", () => {
+	it("does not skip items already below the watermark, or looked at first", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(6) }));
 		registerReviewItems(projectId, 7, "conversation", [
@@ -53,14 +50,14 @@ describe("markReviewSeen", () => {
 			{ key: "c:3", atMs: atMs(12) },
 		]);
 		// Looked at before the dwell fired: pre-empted, never a skip.
-		markItemSeen(projectId, 7, "c:3");
+		await markItemSeen(client, projectId, 7, "c:3");
 
-		markReviewSeen(projectId, 7, at(15));
+		await markReviewSeen(client, projectId, 7, at(15));
 
 		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:2"]);
 	});
 
-	it("keeps existing skips across further advances, capped oldest-first", () => {
+	it("keeps existing skips across further advances, capped oldest-first", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
 		registerReviewItems(
@@ -70,7 +67,7 @@ describe("markReviewSeen", () => {
 			Array.from({ length: 55 }, (_, i) => ({ key: `c:${i}`, atMs: atMs(1) + i * 1000 })),
 		);
 
-		markReviewSeen(projectId, 7, at(15));
+		await markReviewSeen(client, projectId, 7, at(15));
 
 		const kept = unseenOf(projectId)[7] ?? [];
 		expect(kept).toHaveLength(50);
@@ -78,20 +75,20 @@ describe("markReviewSeen", () => {
 		expect(kept[0]?.[0]).toBe("c:5");
 	});
 
-	it("merges what several surfaces registered", () => {
+	it("merges what several surfaces registered", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
 		registerReviewItems(projectId, 7, "conversation", [{ key: "c:1", atMs: atMs(5) }]);
 		registerReviewItems(projectId, 7, "timeline", [{ key: "e:committed:x", atMs: atMs(6) }]);
 
-		markReviewSeen(projectId, 7, at(15));
+		await markReviewSeen(client, projectId, 7, at(15));
 
 		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:1", "e:committed:x"]);
 	});
 });
 
 describe("markItemSeen", () => {
-	it("clears a recorded skip, and the review with the last of them", () => {
+	it("clears a recorded skip, and the review with the last of them", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(
 			`pr_activity_unseen:v1:${projectId}`,
@@ -103,18 +100,22 @@ describe("markItemSeen", () => {
 			}),
 		);
 
-		expect(isItemSkipped(projectId, 7, "c:1")).toBe(true);
-		markItemSeen(projectId, 7, "c:1");
-		expect(isItemSkipped(projectId, 7, "c:1")).toBe(false);
+		expect(
+			isItemSkipped(await client.fetchQuery(reviewStateQueryOptions(projectId)), 7, "c:1"),
+		).toBe(true);
+		await markItemSeen(client, projectId, 7, "c:1");
+		expect(
+			isItemSkipped(await client.fetchQuery(reviewStateQueryOptions(projectId)), 7, "c:1"),
+		).toBe(false);
 		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:2"]);
 
-		markItemSeen(projectId, 7, "c:2");
+		await markItemSeen(client, projectId, 7, "c:2");
 		expect(unseenOf(projectId)[7]).toBeUndefined();
 	});
 });
 
 describe("markReviewsSeenUpTo", () => {
-	it("advances each watermark monotonically and drops the review's skips", () => {
+	it("advances each watermark monotonically and drops the review's skips", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(
 			`pr_activity_seen:v1:${projectId}`,
@@ -125,7 +126,7 @@ describe("markReviewsSeenUpTo", () => {
 			JSON.stringify({ 7: [["c:1", at(5)]], 9: [["c:2", at(5)]] }),
 		);
 
-		markReviewsSeenUpTo(
+		await markReviewsSeenUpTo(
 			projectId,
 			new Map([
 				[7, at(10)],
@@ -134,11 +135,15 @@ describe("markReviewsSeenUpTo", () => {
 		);
 
 		expect(marksOf(projectId)).toEqual({ 7: at(10), 8: at(30), 9: at(0) });
-		expect(isItemSkipped(projectId, 7, "c:1")).toBe(false);
-		expect(isItemSkipped(projectId, 9, "c:2")).toBe(true);
+		expect(
+			isItemSkipped(await client.fetchQuery(reviewStateQueryOptions(projectId)), 7, "c:1"),
+		).toBe(false);
+		expect(
+			isItemSkipped(await client.fetchQuery(reviewStateQueryOptions(projectId)), 9, "c:2"),
+		).toBe(true);
 	});
 
-	it("clears skips at or before the cutoff and keeps those after it", () => {
+	it("clears skips at or before the cutoff and keeps those after it", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
 		localStorage.setItem(
@@ -153,7 +158,7 @@ describe("markReviewsSeenUpTo", () => {
 		);
 
 		// Repeated stamps settle on the newest as the cutoff, in either order.
-		markReviewsSeenUpTo(projectId, [
+		await markReviewsSeenUpTo(projectId, [
 			[7, at(10)],
 			[7, at(5)],
 		]);
@@ -162,28 +167,21 @@ describe("markReviewsSeenUpTo", () => {
 		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:3"]);
 	});
 
-	it("settles repeated stamps on the newest, and writes nothing when nothing changes", () => {
+	it("settles repeated stamps on the newest, and writes nothing when nothing changes", async () => {
 		const projectId = freshProject();
 		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
 
-		markReviewsSeenUpTo(projectId, [
+		await markReviewsSeenUpTo(projectId, [
 			[7, at(10)],
 			[7, at(5)],
 		]);
 		expect(marksOf(projectId)[7]).toBe(at(10));
 
-		localStorage.removeItem(`pr_activity_seen:v1:${projectId}`);
-		markReviewsSeenUpTo(projectId, [[7, at(5)]]);
-		// The cached mark was already past at(5): no write, so storage stays clear.
-		expect(localStorage.getItem(`pr_activity_seen:v1:${projectId}`)).toBeNull();
-
-		// A skip-only change writes the skips, not the marks.
-		localStorage.setItem(
-			`pr_activity_unseen:v1:${projectId}`,
-			JSON.stringify({ 7: [["c:1", at(5)]] }),
-		);
-		markReviewsSeenUpTo(projectId, [[7, at(10)]]);
-		expect(isItemSkipped(projectId, 7, "c:1")).toBe(false);
-		expect(localStorage.getItem(`pr_activity_seen:v1:${projectId}`)).toBeNull();
+		const previous = await client.fetchQuery(reviewStateQueryOptions(projectId));
+		expect(reviewsSeenUpTo(previous, [[7, at(5)]])).toBe(previous);
+		const withSkip = { ...previous, unseen: { 7: [["c:1", at(5)] as [string, string]] } };
+		const next = reviewsSeenUpTo(withSkip, [[7, at(10)]]);
+		expect(next.unseen).toEqual({});
+		expect(next.marks).toEqual(previous.marks);
 	});
 });

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -1,12 +1,3 @@
-/**
- * @file Which review activity the user has seen.
- *
- * One watermark per review — "everything up to this `modifiedAt` has been
- * seen" — in local storage: disposable, per-machine, and synchronous, so a
- * plain external store rather than a query. Every hook returns a primitive,
- * so React skips the render when a write leaves it unchanged.
- */
-
 import {
 	currentForgeLoginQueryOptions,
 	forgeInfoOptions,
@@ -14,8 +5,21 @@ import {
 	listReviewsQueryOptions,
 } from "#ui/api/queries.ts";
 import { defaultSettings } from "#ui/settings.ts";
-import { useQuery } from "@tanstack/react-query";
-import { createContext, useEffect, useEffectEvent, useState, useSyncExternalStore } from "react";
+import {
+	useQuery,
+	useQueryClient,
+	useSuspenseQuery,
+	type QueryClient,
+} from "@tanstack/react-query";
+import {
+	reviewStateQueryOptions,
+	updateReviewState,
+	unseenCap,
+	type ReviewState,
+	type SeenMarks,
+	type UnseenEntries,
+} from "#ui/review-state.ts";
+import { createContext, useEffect, useEffectEvent, useState } from "react";
 
 /**
  * The PR-notifications dial: loud files activity into the bell, quiet
@@ -38,117 +42,6 @@ export const useDesktopNotifications = (): boolean => {
 	return enabled ?? defaultSettings.desktopNotifications;
 };
 
-/** Watermark by review number, as the ISO stamps the forge reports. */
-type SeenMarks = Record<number, string>;
-
-const storageKey = (projectId: string) => `pr_activity_seen:v1:${projectId}`;
-
-const listeners = new Set<() => void>();
-// Snapshot reads are pure in-memory lookups — a write fans out to one per
-// branch row. Storage is touched only on a miss, a write, or invalidation.
-let cached: { key: string; marks: SeenMarks } | null = null;
-
-// Storage can throw — disabled, partitioned, or over quota — and a throw
-// here would crash every subscriber's render. Tracking degrades instead.
-const storageGet = (key: string): string | null => {
-	try {
-		return localStorage.getItem(key);
-	} catch {
-		return null;
-	}
-};
-const storageSet = (key: string, value: string): void => {
-	try {
-		localStorage.setItem(key, value);
-	} catch {
-		// The in-memory copy still serves this session.
-	}
-};
-
-/**
- * Only valid watermarks survive the parse: a foreign entry or unparseable
- * stamp would baseline the detector at epoch and replay history as news.
- */
-const parseMarks = (raw: string | null): SeenMarks => {
-	if (raw === null) return {};
-	try {
-		const stored: unknown = JSON.parse(raw);
-		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
-		const marks: SeenMarks = {};
-		for (const [number, seen] of Object.entries(stored)) {
-			if (typeof seen === "string" && /^\d+$/.test(number) && !Number.isNaN(Date.parse(seen)))
-				marks[Number(number)] = seen;
-		}
-		return marks;
-	} catch {
-		return {};
-	}
-};
-
-const readMarks = (projectId: string): SeenMarks => {
-	const key = storageKey(projectId);
-	if (cached?.key === key) return cached.marks;
-	const marks = parseMarks(storageGet(key));
-	cached = { key, marks };
-	return marks;
-};
-
-/**
- * Items the reader jumped over: below the watermark yet still unread. The
- * complement is stored on purpose — a list of *read* items would grow with
- * everything ever read once one stubborn item pinned the mark, while skipped
- * items stay few by nature and dropping one merely reads as seen.
- */
-type UnseenEntries = Record<number, Array<[key: string, at: string]>>;
-
-const unseenStorageKey = (projectId: string) => `pr_activity_unseen:v1:${projectId}`;
-let cachedUnseen: { key: string; entries: UnseenEntries } | null = null;
-
-/** Skipped items per review, oldest first; dropping the overflow reads as seen. */
-const unseenCap = 50;
-
-const parseUnseen = (raw: string | null): UnseenEntries => {
-	if (raw === null) return {};
-	try {
-		const stored: unknown = JSON.parse(raw);
-		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
-		const entries: UnseenEntries = {};
-		for (const [number, list] of Object.entries(stored)) {
-			if (!/^\d+$/.test(number) || !Array.isArray(list)) continue;
-			const kept = list.filter(
-				(entry): entry is [string, string] =>
-					Array.isArray(entry) &&
-					typeof entry[0] === "string" &&
-					typeof entry[1] === "string" &&
-					!Number.isNaN(Date.parse(entry[1])),
-			);
-			// The newest survive the cap, as the writer keeps them.
-			if (kept.length > 0) entries[Number(number)] = kept.slice(-unseenCap);
-		}
-		return entries;
-	} catch {
-		return {};
-	}
-};
-
-const readUnseen = (projectId: string): UnseenEntries => {
-	const key = unseenStorageKey(projectId);
-	if (cachedUnseen?.key === key) return cachedUnseen.entries;
-	const entries = parseUnseen(storageGet(key));
-	cachedUnseen = { key, entries };
-	return entries;
-};
-
-const setUnseen = (projectId: string, entries: UnseenEntries): void => {
-	storageSet(unseenStorageKey(projectId), JSON.stringify(entries));
-	cachedUnseen = { key: unseenStorageKey(projectId), entries };
-};
-
-const writeUnseen = (projectId: string, entries: UnseenEntries): void => {
-	setUnseen(projectId, entries);
-	notify();
-};
-
 /**
  * What the PR view is showing, so the dwell knows which items above the old
  * watermark were on offer, and which the reader already looked at. In memory
@@ -160,8 +53,8 @@ const pendingSeen = new Map<string, Set<string>>();
 const reviewSlot = (projectId: string, reviewNumber: number) => `${projectId}:${reviewNumber}`;
 
 /** Whether one item is recorded as skipped — unread below the watermark. */
-export const isItemSkipped = (projectId: string, reviewNumber: number, key: string): boolean =>
-	(readUnseen(projectId)[reviewNumber] ?? []).some(([k]) => k === key);
+export const isItemSkipped = (state: ReviewState, reviewNumber: number, key: string): boolean =>
+	(state.unseen[reviewNumber] ?? []).some(([k]) => k === key);
 
 /**
  * Tell the store which unread-eligible items one surface of the review is
@@ -199,78 +92,34 @@ export const unregisterReviewItems = (
  * One item was actually looked at. Before the dwell has advanced the
  * watermark it pre-empts the skip; after, it clears the skip.
  */
-export const markItemSeen = (projectId: string, reviewNumber: number, key: string): void => {
-	const entries = readUnseen(projectId);
-	const skipped = entries[reviewNumber];
-	if (skipped?.some(([k]) => k === key)) {
-		const next = { ...entries };
+export const markItemSeen = async (
+	client: QueryClient,
+	projectId: string,
+	reviewNumber: number,
+	key: string,
+): Promise<void> => {
+	const cached = client.getQueryData(reviewStateQueryOptions(projectId).queryKey);
+	// Register pre-dwell reads synchronously, before the storage write can yield.
+	if (cached === undefined || !isItemSkipped(cached, reviewNumber, key)) {
+		const slot = reviewSlot(projectId, reviewNumber);
+		const pending = pendingSeen.get(slot) ?? new Set<string>();
+		pending.add(key);
+		pendingSeen.set(slot, pending);
+	}
+	await updateReviewState(client, projectId, (state) => {
+		const skipped = state.unseen[reviewNumber];
+		if (!skipped?.some(([k]) => k === key)) return state;
+		const unseen = { ...state.unseen };
 		const kept = skipped.filter(([k]) => k !== key);
-		if (kept.length > 0) next[reviewNumber] = kept;
-		else delete next[reviewNumber];
-		writeUnseen(projectId, next);
-		return;
-	}
-	const slot = reviewSlot(projectId, reviewNumber);
-	const pending = pendingSeen.get(slot) ?? new Set<string>();
-	pending.add(key);
-	pendingSeen.set(slot, pending);
+		if (kept.length > 0) unseen[reviewNumber] = kept;
+		else delete unseen[reviewNumber];
+		return { ...state, unseen };
+	});
 };
-
-const notify = (): void => {
-	for (const listener of listeners) listener();
-};
-
-const writeMarks = (projectId: string, marks: SeenMarks): void => {
-	storageSet(storageKey(projectId), JSON.stringify(marks));
-	cached = { key: storageKey(projectId), marks };
-	notify();
-};
-
-let watchingStorage = false;
-
-/** A write from another window arrives as a storage event. */
-const onStorage = (event: StorageEvent): void => {
-	// A null key is a wholesale clear; anything else outside this feature's
-	// keys is someone else's business.
-	if (event.key !== null && !event.key.startsWith("pr_activity_")) return;
-	cached = null;
-	cachedUnseen = null;
-	notify();
-};
-
-const subscribeMarks = (listener: () => void): (() => void) => {
-	// On first use, so merely importing this module listens to nothing.
-	if (!watchingStorage) {
-		watchingStorage = true;
-		window.addEventListener("storage", onStorage);
-	}
-	// A first subscriber is a fresh surface: re-read whatever storage holds.
-	if (listeners.size === 0) {
-		cached = null;
-		cachedUnseen = null;
-	}
-	listeners.add(listener);
-	return () => listeners.delete(listener);
-};
-
-/** A disabled hook stays out of the fan-out entirely. */
-const subscribeNothing = (): (() => void) => () => {};
-
-/** The stored watermarks, for the activity detector's startup baseline. */
-export const readSeenMarks = (projectId: string): Record<number, string> => readMarks(projectId);
 
 /** Whether activity at `modifiedAt` is newer than the watermark. */
 const pastMark = (modifiedAt: string | null, seen: string | undefined): boolean =>
 	modifiedAt !== null && seen !== undefined && Date.parse(modifiedAt) > Date.parse(seen);
-
-/** Unread: the review moved past the watermark, or skipped items remain. */
-const isUnread = (
-	projectId: string,
-	number: number,
-	modifiedAt: string | null,
-	marks: SeenMarks,
-): boolean =>
-	pastMark(modifiedAt, marks[number]) || (readUnseen(projectId)[number]?.length ?? 0) > 0;
 
 /**
  * Whether one review has unread activity — a boolean, so a watermark moving
@@ -282,9 +131,13 @@ const useReviewUnread = (
 	enabled: boolean,
 ): boolean => {
 	const { number, modifiedAt } = review;
-	return useSyncExternalStore(enabled ? subscribeMarks : subscribeNothing, () =>
-		enabled ? isUnread(projectId, number, modifiedAt, readMarks(projectId)) : false,
-	);
+	const { data: unread = false } = useQuery({
+		...reviewStateQueryOptions(projectId),
+		enabled,
+		select: (state) =>
+			pastMark(modifiedAt, state.marks[number]) || (state.unseen[number]?.length ?? 0) > 0,
+	});
+	return enabled && unread;
 };
 
 /**
@@ -293,8 +146,8 @@ const useReviewUnread = (
  * after first sight count as unread. Mounted once per project surface.
  */
 export const useStampReviewsSeen = (projectId: string): void => {
+	const client = useQueryClient();
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
-	// Unconditional: behind `&&` the hook count would change mid-mount.
 	const level = usePrNotificationsLevel();
 	const enabled = !!forgeInfo?.capabilities.prService && level !== "off";
 	const { data: listed } = useQuery({
@@ -306,28 +159,28 @@ export const useStampReviewsSeen = (projectId: string): void => {
 	});
 
 	const reconcile = useEffectEvent((reviews: NonNullable<typeof listed>) => {
-		const marks = readMarks(projectId);
-		const next: SeenMarks = {};
-		let stamped = false;
-		for (const { number, modifiedAt } of reviews) {
-			const seen = marks[number];
-			if (seen !== undefined) {
-				next[number] = seen;
-			} else if (modifiedAt !== null) {
-				next[number] = modifiedAt;
-				stamped = true;
+		void updateReviewState(client, projectId, (state) => {
+			const { marks, unseen } = state;
+			const next: SeenMarks = {};
+			let stamped = false;
+			for (const { number, modifiedAt } of reviews) {
+				const seen = marks[number];
+				if (seen !== undefined) {
+					next[number] = seen;
+				} else if (modifiedAt !== null) {
+					next[number] = modifiedAt;
+					stamped = true;
+				}
 			}
-		}
-		// A mark whose review is gone from the listing is dead weight.
-		const pruned = Object.keys(next).length !== Object.keys(marks).length;
-		if (stamped || pruned) writeMarks(projectId, next);
-
-		const unseen = readUnseen(projectId);
-		const keptUnseen: UnseenEntries = {};
-		for (const [number, entries] of Object.entries(unseen))
-			if (Number(number) in next) keptUnseen[Number(number)] = entries;
-		if (Object.keys(keptUnseen).length !== Object.keys(unseen).length)
-			writeUnseen(projectId, keptUnseen);
+			// A mark whose review is gone from the listing is dead weight.
+			const pruned = Object.keys(next).length !== Object.keys(marks).length;
+			const keptUnseen: UnseenEntries = {};
+			for (const [number, entries] of Object.entries(unseen))
+				if (Number(number) in next) keptUnseen[Number(number)] = entries;
+			return stamped || pruned || Object.keys(keptUnseen).length !== Object.keys(unseen).length
+				? { ...state, marks: next, unseen: keptUnseen }
+				: state;
+		});
 	});
 
 	useEffect(() => {
@@ -356,11 +209,14 @@ export const SeenOnArrivalContext = createContext<SeenOnArrival>({
  * must not vanish under the reader. The next visit starts clean.
  */
 export const useSeenOnArrival = (projectId: string, reviewNumber: number): SeenOnArrival => {
+	const { data: mark } = useSuspenseQuery({
+		...reviewStateQueryOptions(projectId),
+		select: (state) => state.marks[reviewNumber] ?? null,
+	});
 	const { data: selfLogin } = useQuery(currentForgeLoginQueryOptions(projectId));
 	const level = usePrNotificationsLevel();
 	const [sinceMs] = useState(() => {
-		const mark = readMarks(projectId)[reviewNumber];
-		const ms = mark === undefined ? Number.NaN : Date.parse(mark);
+		const ms = mark === null ? Number.NaN : Date.parse(mark);
 		// No watermark means the review was never tracked; nothing is new.
 		return Number.isNaN(ms) ? Infinity : ms;
 	});
@@ -376,28 +232,42 @@ export const useSeenOnArrival = (projectId: string, reviewNumber: number): SeenO
  *
  * @public exported for the store transitions in the test suite.
  */
-export const markReviewSeen = (projectId: string, number: number, modifiedAt: string): void => {
-	const floor = readMarks(projectId)[number];
-	const floorMs = floor === undefined ? Infinity : Date.parse(floor);
+export const markReviewSeen = async (
+	client: QueryClient,
+	projectId: string,
+	number: number,
+	modifiedAt: string,
+): Promise<void> => {
 	const slot = reviewSlot(projectId, number);
 	const pending = pendingSeen.get(slot) ?? new Set<string>();
-	const skipped = new Map((readUnseen(projectId)[number] ?? []).map(([k, at]) => [k, at]));
-	for (const item of [...(shownItems.get(slot)?.values() ?? [])].flat()) {
-		if (item.atMs > floorMs && !pending.has(item.key) && !skipped.has(item.key))
-			skipped.set(item.key, new Date(item.atMs).toISOString());
-	}
 	pendingSeen.delete(slot);
-	const entries = [...skipped]
-		.sort(([, a], [, b]) => Date.parse(a) - Date.parse(b))
-		// Beyond the cap the oldest are dropped: reading as seen is the safe
-		// failure, and a skip that old was never getting read.
-		.slice(-unseenCap);
-	const nextUnseen = { ...readUnseen(projectId) };
-	if (entries.length > 0) nextUnseen[number] = entries;
-	else delete nextUnseen[number];
-	// One notify for both writes: each fans out to a snapshot per row.
-	setUnseen(projectId, nextUnseen);
-	writeMarks(projectId, { ...readMarks(projectId), [number]: modifiedAt });
+	const offered = [...(shownItems.get(slot)?.values() ?? [])].flat();
+	await updateReviewState(client, projectId, (state) => {
+		const floor = state.marks[number];
+		const floorMs = floor === undefined ? Infinity : Date.parse(floor);
+		const skipped = new Map((state.unseen[number] ?? []).map(([k, at]) => [k, at]));
+		for (const item of offered) {
+			if (item.atMs > floorMs && !pending.has(item.key) && !skipped.has(item.key))
+				skipped.set(item.key, new Date(item.atMs).toISOString());
+		}
+		const entries = [...skipped]
+			.sort(([, a], [, b]) => Date.parse(a) - Date.parse(b))
+			// Beyond the cap the oldest are dropped: reading as seen is the safe
+			// failure, and a skip that old was never getting read.
+			.slice(-unseenCap);
+		const nextUnseen = { ...state.unseen };
+		if (entries.length > 0) nextUnseen[number] = entries;
+		else delete nextUnseen[number];
+		return {
+			...state,
+			unseen: nextUnseen,
+			marks: {
+				...state.marks,
+				[number]:
+					floor !== undefined && Date.parse(floor) > Date.parse(modifiedAt) ? floor : modifiedAt,
+			},
+		};
+	});
 };
 
 /**
@@ -406,12 +276,12 @@ export const markReviewSeen = (projectId: string, number: number, modifiedAt: st
  * may already have moved it further — and the review's skips at or before
  * that newest stamp are dropped. A skip after it is still unread.
  */
-export const markReviewsSeenUpTo = (
-	projectId: string,
+export const reviewsSeenUpTo = (
+	state: ReviewState,
 	latest: Iterable<readonly [number, string]>,
-): void => {
-	const marks = { ...readMarks(projectId) };
-	const unseen = { ...readUnseen(projectId) };
+): ReviewState => {
+	const marks = { ...state.marks };
+	const unseen = { ...state.unseen };
 	let marksChanged = false;
 	let unseenChanged = false;
 	// Order-free: the advance is monotonic and the skip filters compose, so
@@ -431,10 +301,7 @@ export const markReviewsSeenUpTo = (
 		else delete unseen[number];
 		unseenChanged = true;
 	}
-	// One notify for both writes, as in `markReviewSeen`.
-	if (unseenChanged) setUnseen(projectId, unseen);
-	if (marksChanged) writeMarks(projectId, marks);
-	else if (unseenChanged) notify();
+	return marksChanged || unseenChanged ? { ...state, marks, unseen } : state;
 };
 
 /** A beat, so flicking past a review does not eat its unread state. */
@@ -450,13 +317,14 @@ export const useMarkReviewSeenOnView = (
 	review: { number: number; modifiedAt: string | null },
 	enabled: boolean,
 ): void => {
+	const client = useQueryClient();
 	const { number, modifiedAt } = review;
 	// Nothing unread means nothing to write, on remount or with tracking off.
 	const behind = useReviewUnread(projectId, review, enabled);
 
 	const mark = useEffectEvent(() => {
 		if (modifiedAt === null || !behind || !document.hasFocus()) return;
-		markReviewSeen(projectId, number, modifiedAt);
+		void markReviewSeen(client, projectId, number, modifiedAt);
 	});
 
 	// `behind` in the deps re-arms the dwell once the watermarks load.

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -5,12 +5,7 @@ import {
 	listReviewsQueryOptions,
 } from "#ui/api/queries.ts";
 import { defaultSettings } from "#ui/settings.ts";
-import {
-	useQuery,
-	useQueryClient,
-	useSuspenseQuery,
-	type QueryClient,
-} from "@tanstack/react-query";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import {
 	reviewStateQueryOptions,
 	updateReviewState,
@@ -98,13 +93,15 @@ export const markItemSeen = async (
 	reviewNumber: number,
 	key: string,
 ): Promise<void> => {
-	const cached = client.getQueryData(reviewStateQueryOptions(projectId).queryKey);
+	const queryKey = reviewStateQueryOptions(projectId).queryKey;
+	const cached = client.getQueryData(queryKey);
 	// Register pre-dwell reads synchronously, before the storage write can yield.
 	if (cached === undefined || !isItemSkipped(cached, reviewNumber, key)) {
 		const slot = reviewSlot(projectId, reviewNumber);
 		const pending = pendingSeen.get(slot) ?? new Set<string>();
 		pending.add(key);
 		pendingSeen.set(slot, pending);
+		if (cached !== undefined && !client.getQueryState(queryKey)?.isInvalidated) return;
 	}
 	await updateReviewState(client, projectId, (state) => {
 		const skipped = state.unseen[reviewNumber];
@@ -208,20 +205,26 @@ export const SeenOnArrivalContext = createContext<SeenOnArrival>({
  * dwell advances the live mark right after arrival and the "New" badges
  * must not vanish under the reader. The next visit starts clean.
  */
-export const useSeenOnArrival = (projectId: string, reviewNumber: number): SeenOnArrival => {
-	const { data: mark } = useSuspenseQuery({
+export const useSeenOnArrival = (projectId: string, reviewNumber: number): SeenOnArrival | null => {
+	const { data: mark, isFetchedAfterMount } = useQuery({
 		...reviewStateQueryOptions(projectId),
+		staleTime: 0,
+		refetchOnMount: "always",
+		// Only the first fresh read matters to this visit; live marks belong to the unread dots.
+		notifyOnChangeProps: ["isFetchedAfterMount"],
 		select: (state) => state.marks[reviewNumber] ?? null,
 	});
 	const { data: selfLogin } = useQuery(currentForgeLoginQueryOptions(projectId));
 	const level = usePrNotificationsLevel();
-	const [sinceMs] = useState(() => {
-		const ms = mark === null ? Number.NaN : Date.parse(mark);
+	const [sinceMs, setSinceMs] = useState<number | null>(null);
+	if (sinceMs === null && isFetchedAfterMount) {
+		const ms = mark == null ? Number.NaN : Date.parse(mark);
 		// No watermark means the review was never tracked; nothing is new.
-		return Number.isNaN(ms) ? Infinity : ms;
-	});
+		setSinceMs(Number.isNaN(ms) ? Infinity : ms);
+	}
 	// Off means off: no markers, and no seen-state writes from the observer.
 	if (level === "off") return { sinceMs: Infinity, selfLogin: null, projectId, reviewNumber: 0 };
+	if (sinceMs === null) return null;
 	return { sinceMs, selfLogin: selfLogin ?? null, projectId, reviewNumber };
 };
 

--- a/apps/lite/ui/src/review-state.test.tsx
+++ b/apps/lite/ui/src/review-state.test.tsx
@@ -7,7 +7,13 @@ import { createRoot } from "react-dom/client";
 import { afterEach, expect, it, vi } from "vitest";
 import { currentForgeLoginQueryOptions, guiSettingsQueryOptions } from "./api/queries.ts";
 import { defaultSettings } from "./settings.ts";
-import { useSeenOnArrival } from "./review-seen.ts";
+import {
+	markItemSeen,
+	markReviewSeen,
+	registerReviewItems,
+	unregisterReviewItems,
+	useSeenOnArrival,
+} from "./review-seen.ts";
 import { reviewStateQueryOptions, updateReviewState, watchReviewState } from "./review-state.ts";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -126,7 +132,12 @@ it("waits for hydration before capturing the arrival watermark, then holds that 
 	localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: earlier }));
 	const container = document.createElement("div");
 	const root = createRoot(container);
-	const Arrival = () => <span>{useSeenOnArrival(projectId, 7).sinceMs}</span>;
+	let renders = 0;
+	const Arrival = () => {
+		const arrival = useSeenOnArrival(projectId, 7);
+		renders++;
+		return <span>{arrival?.sinceMs}</span>;
+	};
 	try {
 		await act(async () => {
 			root.render(
@@ -138,15 +149,133 @@ it("waits for hydration before capturing the arrival watermark, then holds that 
 			);
 		});
 		await act(async () => {
-			await client.ensureQueryData(reviewStateQueryOptions(projectId));
+			await client.getQueryCache().find({ queryKey: reviewStateQueryOptions(projectId).queryKey })
+				?.promise;
+			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 		expect(container.textContent).toBe(String(Date.parse(earlier)));
+		const initialRenders = renders;
 		await act(async () => {
 			await updateReviewState(client, projectId, (state) => ({ ...state, marks: { 7: later } }));
+			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 		expect(container.textContent).toBe(String(Date.parse(earlier)));
+		expect(renders).toBe(initialRenders);
+		await act(async () => root.render(null));
+		await act(async () => {
+			root.render(
+				<QueryClientProvider client={client}>
+					<Arrival />
+				</QueryClientProvider>,
+			);
+		});
+		await act(async () => {
+			await client.getQueryCache().find({ queryKey: reviewStateQueryOptions(projectId).queryKey })
+				?.promise;
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		expect(container.textContent).toBe(String(Date.parse(later)));
 	} finally {
 		await act(async () => root.unmount());
 		client.clear();
+	}
+});
+
+it("does not write or broadcast an unchanged transition", async () => {
+	const projectId = project();
+	const client = new QueryClient();
+	const state = await client.fetchQuery(reviewStateQueryOptions(projectId));
+	const stop = watchReviewState(client);
+	const put = vi.spyOn(IDBObjectStore.prototype, "put");
+	const publish = vi.spyOn(client, "setQueryData");
+	const broadcast = vi.spyOn(BroadcastChannel.prototype, "postMessage");
+	try {
+		expect(await updateReviewState(client, projectId, (current) => current)).toEqual(state);
+		expect(put).not.toHaveBeenCalled();
+		expect(publish).not.toHaveBeenCalled();
+		expect(broadcast).not.toHaveBeenCalled();
+	} finally {
+		stop();
+		client.clear();
+	}
+});
+
+it("records visible fresh items without storage transactions, and still pre-empts dwell skips", async () => {
+	const projectId = project();
+	const client = new QueryClient();
+	await updateReviewState(client, projectId, (state) => ({ ...state, marks: { 7: earlier } }));
+	const items = Array.from({ length: 30 }, (_, i) => ({ key: `c:${i}`, atMs: Date.parse(later) }));
+	registerReviewItems(projectId, 7, "test", items);
+	const transaction = vi.spyOn(IDBDatabase.prototype, "transaction");
+	try {
+		const pending = items.map(({ key }) => markItemSeen(client, projectId, 7, key));
+		await Promise.all(pending);
+		expect(transaction).not.toHaveBeenCalled();
+		await markReviewSeen(client, projectId, 7, later);
+		expect(client.getQueryData(reviewStateQueryOptions(projectId).queryKey)?.unseen).toEqual({});
+	} finally {
+		unregisterReviewItems(projectId, 7, "test");
+		client.clear();
+	}
+});
+
+it.each([false, true])(
+	"takes a fresh arrival snapshot even with cached marks (invalidated: %s)",
+	async (invalidated) => {
+		const projectId = project();
+		const client = new QueryClient({
+			defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+		});
+		const options = reviewStateQueryOptions(projectId);
+		client.setQueryData(guiSettingsQueryOptions.queryKey, { version: 1, ...defaultSettings });
+		client.setQueryData(currentForgeLoginQueryOptions(projectId).queryKey, "alice");
+		await updateReviewState(client, projectId, (state) => ({ ...state, marks: { 7: earlier } }));
+		await updateReviewState(new QueryClient(), projectId, (state) => ({
+			...state,
+			marks: { 7: later },
+		}));
+		if (invalidated) await client.invalidateQueries({ queryKey: options.queryKey });
+		const container = document.createElement("div");
+		const root = createRoot(container);
+		const Arrival = () => <span>{useSeenOnArrival(projectId, 7)?.sinceMs}</span>;
+		try {
+			await act(async () => {
+				root.render(
+					<QueryClientProvider client={client}>
+						<Suspense fallback="Loading">
+							<Arrival />
+						</Suspense>
+					</QueryClientProvider>,
+				);
+			});
+			await act(async () => {
+				await client.getQueryCache().find({ queryKey: options.queryKey })?.promise;
+				await new Promise((resolve) => setTimeout(resolve, 0));
+			});
+			expect(container.textContent).toBe(String(Date.parse(later)));
+		} finally {
+			await act(async () => root.unmount());
+			client.clear();
+		}
+	},
+);
+
+it("checks the durable state before treating a stale window's update as a no-op", async () => {
+	const projectId = project();
+	const first = new QueryClient();
+	const second = new QueryClient();
+	const options = reviewStateQueryOptions(projectId);
+	try {
+		await first.fetchQuery(options);
+		await updateReviewState(second, projectId, (state) => ({
+			...state,
+			unseen: { 7: [["c:1", later]] },
+		}));
+		await first.invalidateQueries({ queryKey: options.queryKey });
+		await markItemSeen(first, projectId, 7, "c:1");
+		expect((await second.fetchQuery({ ...options, staleTime: 0 })).unseen).toEqual({});
+	} finally {
+		first.clear();
+		second.clear();
 	}
 });

--- a/apps/lite/ui/src/review-state.test.tsx
+++ b/apps/lite/ui/src/review-state.test.tsx
@@ -1,0 +1,152 @@
+/** @vitest-environment jsdom */
+import "fake-indexeddb/auto";
+import * as idb from "idb-keyval";
+import { QueryClient, QueryClientProvider, QueryObserver } from "@tanstack/react-query";
+import { Suspense, act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+import { currentForgeLoginQueryOptions, guiSettingsQueryOptions } from "./api/queries.ts";
+import { defaultSettings } from "./settings.ts";
+import { useSeenOnArrival } from "./review-seen.ts";
+import { reviewStateQueryOptions, updateReviewState, watchReviewState } from "./review-state.ts";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+afterEach(() => vi.restoreAllMocks());
+let projectNumber = 0;
+const project = () => `migration-${projectNumber++}`;
+const earlier = "2026-09-01T10:00:00Z";
+const later = "2026-09-02T10:00:00Z";
+
+it("migrates validated legacy records before deleting the old keys", async () => {
+	const projectId = project();
+	localStorage.setItem(
+		`pr_activity_seen:v1:${projectId}`,
+		JSON.stringify({ 7: earlier, bad: later, 8: "invalid" }),
+	);
+	localStorage.setItem(
+		`pr_activity_unseen:v1:${projectId}`,
+		JSON.stringify({
+			7: [
+				["comment:1", later],
+				["bad", "invalid"],
+			],
+		}),
+	);
+	localStorage.setItem(`pr_activity_inbox:v1:${projectId}`, "malformed");
+	const options = reviewStateQueryOptions(projectId);
+	const state = await new QueryClient().fetchQuery(options);
+	expect(state).toEqual({
+		marks: { 7: earlier },
+		unseen: { 7: [["comment:1", later]] },
+		inbox: [],
+	});
+	expect(await idb.get(`pr_activity:v1:${projectId}`)).toEqual(state);
+	for (const part of ["seen", "unseen", "inbox"])
+		expect(localStorage.getItem(`pr_activity_${part}:v1:${projectId}`)).toBeNull();
+	expect(await new QueryClient().fetchQuery(options)).toEqual(state);
+});
+
+it("preserves concurrent migrations and updates from stale windows", async () => {
+	const projectId = project();
+	const first = new QueryClient();
+	const second = new QueryClient();
+	localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: earlier }));
+	const options = reviewStateQueryOptions(projectId);
+	await Promise.all([first.fetchQuery(options), second.fetchQuery(options)]);
+	await Promise.all([
+		updateReviewState(first, projectId, (state) => ({
+			...state,
+			marks: { ...state.marks, 8: later },
+		})),
+		updateReviewState(second, projectId, (state) => ({
+			...state,
+			marks: { ...state.marks, 9: later },
+		})),
+	]);
+	expect((await new QueryClient().fetchQuery(options)).marks).toEqual({
+		7: earlier,
+		8: later,
+		9: later,
+	});
+});
+
+it("invalidates another window and leaves unrelated row selectors unchanged", async () => {
+	const projectId = project();
+	const first = new QueryClient();
+	const second = new QueryClient();
+	const stops = [watchReviewState(first), watchReviewState(second)];
+	const options = reviewStateQueryOptions(projectId);
+	await second.fetchQuery(options);
+	const observer = new QueryObserver(second, {
+		...options,
+		select: (state) => state.marks[7] ?? null,
+		notifyOnChangeProps: ["data"],
+	});
+	const changed = vi.fn();
+	const unsubscribe = observer.subscribe(changed);
+	try {
+		await updateReviewState(first, projectId, (state) => ({ ...state, marks: { 8: earlier } }));
+		await vi.waitFor(() => expect(second.getQueryData(options.queryKey)?.marks[8]).toBe(earlier));
+		expect(changed).not.toHaveBeenCalled();
+		await updateReviewState(first, projectId, (state) => ({
+			...state,
+			marks: { ...state.marks, 7: later },
+		}));
+		await vi.waitFor(() => expect(observer.getCurrentResult().data).toBe(later));
+	} finally {
+		unsubscribe();
+		stops.forEach((stop) => stop());
+		first.clear();
+		second.clear();
+	}
+});
+
+it("keeps legacy data and session updates if IndexedDB is unavailable", async () => {
+	const projectId = project();
+	const client = new QueryClient();
+	const options = reviewStateQueryOptions(projectId);
+	localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: earlier }));
+	vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(() => {
+		throw new Error("unavailable");
+	});
+	expect((await client.fetchQuery(options)).marks[7]).toBe(earlier);
+	await updateReviewState(client, projectId, (state) => ({ ...state, marks: { 7: later } }));
+	await client.invalidateQueries({ queryKey: options.queryKey });
+	expect((await client.fetchQuery(options)).marks[7]).toBe(later);
+	expect(localStorage.getItem(`pr_activity_seen:v1:${projectId}`)).not.toBeNull();
+});
+
+it("waits for hydration before capturing the arrival watermark, then holds that snapshot", async () => {
+	const projectId = project();
+	const client = new QueryClient({
+		defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+	});
+	client.setQueryData(guiSettingsQueryOptions.queryKey, { version: 1, ...defaultSettings });
+	client.setQueryData(currentForgeLoginQueryOptions(projectId).queryKey, "alice");
+	localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: earlier }));
+	const container = document.createElement("div");
+	const root = createRoot(container);
+	const Arrival = () => <span>{useSeenOnArrival(projectId, 7).sinceMs}</span>;
+	try {
+		await act(async () => {
+			root.render(
+				<QueryClientProvider client={client}>
+					<Suspense fallback="Loading">
+						<Arrival />
+					</Suspense>
+				</QueryClientProvider>,
+			);
+		});
+		await act(async () => {
+			await client.ensureQueryData(reviewStateQueryOptions(projectId));
+		});
+		expect(container.textContent).toBe(String(Date.parse(earlier)));
+		await act(async () => {
+			await updateReviewState(client, projectId, (state) => ({ ...state, marks: { 7: later } }));
+		});
+		expect(container.textContent).toBe(String(Date.parse(earlier)));
+	} finally {
+		await act(async () => root.unmount());
+		client.clear();
+	}
+});

--- a/apps/lite/ui/src/review-state.ts
+++ b/apps/lite/ui/src/review-state.ts
@@ -1,0 +1,258 @@
+import { queryOptions, type QueryClient } from "@tanstack/react-query";
+import * as idb from "idb-keyval";
+import { isAgent } from "#ui/review-users.ts";
+
+export type InboxEntry = {
+	id: string;
+	legacyId?: string;
+	kind: InboxKind;
+	review: number;
+	reviewTitle: string;
+	unitSymbol: string;
+	sourceBranch: string;
+	htmlUrl: string;
+	author: string | null;
+	authorIsBot?: boolean;
+	/** How many items this entry coalesces — "3 comments". */
+	count: number;
+	/** The comment a click should land on, when the entry is about comments. */
+	commentId?: number | null;
+	snippet: string | null;
+	at: string;
+	seen: boolean;
+};
+
+const inboxKinds = [
+	"comment",
+	"mention",
+	"approved",
+	"changesRequested",
+	"reviewRequested",
+	"committed",
+	"merged",
+	"closed",
+] as const;
+export type InboxKind = (typeof inboxKinds)[number];
+
+export type SeenMarks = Record<number, string>;
+// The complement stays bounded even when one skipped item pins an old watermark.
+export type UnseenEntries = Record<number, Array<[key: string, at: string]>>;
+export const unseenCap = 50;
+
+export type ReviewState = {
+	marks: SeenMarks;
+	unseen: UnseenEntries;
+	inbox: Array<InboxEntry>;
+};
+
+export const isBotEntry = (entry: InboxEntry): boolean =>
+	isAgent({ login: entry.author ?? "", isBot: entry.authorIsBot === true });
+
+/** Each tab keeps its own history so agent traffic cannot crowd out humans. */
+const inboxCapPerType = 100;
+
+export const capInboxEntries = (entries: Array<InboxEntry>): Array<InboxEntry> => {
+	let humans = 0;
+	let agents = 0;
+	return entries.filter((entry) =>
+		isBotEntry(entry) ? ++agents <= inboxCapPerType : ++humans <= inboxCapPerType,
+	);
+};
+
+const parseMarks = (raw: string | null): SeenMarks => {
+	if (raw === null) return {};
+	try {
+		const stored: unknown = JSON.parse(raw);
+		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
+		const marks: SeenMarks = {};
+		for (const [reviewNumberText, seenAt] of Object.entries(stored)) {
+			if (
+				typeof seenAt === "string" &&
+				/^\d+$/.test(reviewNumberText) &&
+				!Number.isNaN(Date.parse(seenAt))
+			)
+				marks[Number(reviewNumberText)] = seenAt;
+		}
+		return marks;
+	} catch {
+		return {};
+	}
+};
+
+const parseUnseen = (raw: string | null): UnseenEntries => {
+	if (raw === null) return {};
+	try {
+		const stored: unknown = JSON.parse(raw);
+		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
+		const entries: UnseenEntries = {};
+		for (const [reviewNumberText, unseenItems] of Object.entries(stored)) {
+			if (!/^\d+$/.test(reviewNumberText) || !Array.isArray(unseenItems)) continue;
+			const kept = unseenItems.filter(
+				(entry): entry is [string, string] =>
+					Array.isArray(entry) &&
+					typeof entry[0] === "string" &&
+					typeof entry[1] === "string" &&
+					!Number.isNaN(Date.parse(entry[1])),
+			);
+			if (kept.length > 0) entries[Number(reviewNumberText)] = kept.slice(-unseenCap);
+		}
+		return entries;
+	} catch {
+		return {};
+	}
+};
+
+const migrateEntries = (entries: Array<InboxEntry>): Array<InboxEntry> => {
+	const byId = new Map<string, InboxEntry>();
+	for (const stored of entries) {
+		const legacyAgent =
+			stored.authorIsBot === undefined &&
+			isBotEntry(stored) &&
+			stored.id === `${stored.review}:${stored.kind}:${stored.at}`;
+		const entry = legacyAgent ? { ...stored, id: `${stored.id}:bot`, legacyId: stored.id } : stored;
+		const previous = byId.get(entry.id);
+		byId.set(
+			entry.id,
+			previous
+				? {
+						...entry,
+						seen: previous.seen || entry.seen,
+						authorIsBot: entry.authorIsBot ?? previous.authorIsBot,
+						legacyId: entry.legacyId ?? previous.legacyId,
+					}
+				: entry,
+		);
+	}
+	return [...byId.values()].map((entry) =>
+		entry.legacyId !== undefined && byId.has(entry.legacyId)
+			? { ...entry, legacyId: undefined }
+			: entry,
+	);
+};
+
+const parseEntries = (raw: string | null): Array<InboxEntry> => {
+	if (raw === null) return [];
+	try {
+		const stored: unknown = JSON.parse(raw);
+		if (!Array.isArray(stored)) return [];
+		// Ordered here, not just at write time: a list stored by an older
+		// build keeps whatever order it had until something new files.
+		return capInboxEntries(
+			migrateEntries(
+				stored.filter((entry): entry is InboxEntry => {
+					if (typeof entry !== "object" || entry === null) return false;
+					const e = entry as Record<string, unknown>;
+					return (
+						typeof e.id === "string" &&
+						(e.legacyId === undefined || typeof e.legacyId === "string") &&
+						typeof e.kind === "string" &&
+						inboxKinds.some((kind) => kind === e.kind) &&
+						typeof e.review === "number" &&
+						typeof e.reviewTitle === "string" &&
+						typeof e.unitSymbol === "string" &&
+						typeof e.sourceBranch === "string" &&
+						typeof e.htmlUrl === "string" &&
+						(e.author === null || typeof e.author === "string") &&
+						(e.authorIsBot === undefined || typeof e.authorIsBot === "boolean") &&
+						typeof e.count === "number" &&
+						(e.commentId === undefined ||
+							e.commentId === null ||
+							typeof e.commentId === "number") &&
+						(e.snippet === null || typeof e.snippet === "string") &&
+						typeof e.at === "string" &&
+						!Number.isNaN(Date.parse(e.at)) &&
+						typeof e.seen === "boolean"
+					);
+				}),
+			).sort((a, b) => Date.parse(b.at) - Date.parse(a.at)),
+		);
+	} catch {
+		return [];
+	}
+};
+
+const storageKey = (projectId: string) => `pr_activity:v1:${projectId}`;
+const legacyKey = (projectId: string, part: string) => `pr_activity_${part}:v1:${projectId}`;
+const readLegacy = (projectId: string): ReviewState => {
+	const read = (part: string) => {
+		try {
+			return localStorage.getItem(legacyKey(projectId, part));
+		} catch {
+			return null;
+		}
+	};
+	return {
+		marks: parseMarks(read("seen")),
+		unseen: parseUnseen(read("unseen")),
+		inbox: parseEntries(read("inbox")),
+	};
+};
+
+export const reviewStateQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: [projectId, "reviewState"],
+		staleTime: Infinity,
+		queryFn: async ({ client }): Promise<ReviewState> => {
+			try {
+				const stored = await idb.get<ReviewState>(storageKey(projectId));
+				if (stored !== undefined) return stored;
+				let migrated!: ReviewState;
+				// Two windows may migrate together; only the first initializes the record.
+				await idb.update<ReviewState>(
+					storageKey(projectId),
+					(current) => (migrated = current ?? readLegacy(projectId)),
+				);
+				try {
+					for (const part of ["seen", "unseen", "inbox"])
+						localStorage.removeItem(legacyKey(projectId, part));
+				} catch {
+					/* The durable record takes precedence if legacy storage is unavailable. */
+				}
+				return migrated;
+			} catch {
+				// Tracking remains usable for this session when persistence is unavailable.
+				return (
+					client.getQueryData<ReviewState>([projectId, "reviewState"]) ?? readLegacy(projectId)
+				);
+			}
+		},
+	});
+
+export const updateReviewState = async (
+	client: QueryClient,
+	projectId: string,
+	update: (state: ReviewState) => ReviewState,
+): Promise<ReviewState> => {
+	const options = reviewStateQueryOptions(projectId);
+	const loaded = await client.ensureQueryData(options);
+	let next!: ReviewState;
+	try {
+		// Read and write in one transaction so concurrent windows retain each other's changes.
+		await idb.update<ReviewState>(
+			storageKey(projectId),
+			(stored) => (next = update(stored ?? loaded)),
+		);
+	} catch {
+		next = update(client.getQueryData(options.queryKey) ?? loaded);
+	}
+	await client.cancelQueries({ queryKey: options.queryKey });
+	client.setQueryData(options.queryKey, next);
+	return next;
+};
+
+export const watchReviewState = (client: QueryClient): (() => void) => {
+	const channel = new BroadcastChannel("pr_activity:v1");
+	channel.onmessage = ({ data }: MessageEvent<unknown>) => {
+		if (typeof data === "string")
+			void client.invalidateQueries({ queryKey: reviewStateQueryOptions(data).queryKey });
+	};
+	const unsubscribe = client.getQueryCache().subscribe((event) => {
+		if (event.type !== "updated" || event.action.type !== "success" || !event.action.manual) return;
+		const [projectId, name] = event.query.queryKey as ReadonlyArray<unknown>;
+		if (name === "reviewState" && typeof projectId === "string") channel.postMessage(projectId);
+	});
+	return () => {
+		unsubscribe();
+		channel.close();
+	};
+};

--- a/apps/lite/ui/src/review-state.ts
+++ b/apps/lite/ui/src/review-state.ts
@@ -171,6 +171,7 @@ const parseEntries = (raw: string | null): Array<InboxEntry> => {
 	}
 };
 
+const reviewStore = idb.createStore("keyval-store", "keyval");
 const storageKey = (projectId: string) => `pr_activity:v1:${projectId}`;
 const legacyKey = (projectId: string, part: string) => `pr_activity_${part}:v1:${projectId}`;
 const readLegacy = (projectId: string): ReviewState => {
@@ -226,15 +227,24 @@ export const updateReviewState = async (
 	const options = reviewStateQueryOptions(projectId);
 	const loaded = await client.ensureQueryData(options);
 	let next!: ReviewState;
+	let changed = false;
 	try {
-		// Read and write in one transaction so concurrent windows retain each other's changes.
-		await idb.update<ReviewState>(
-			storageKey(projectId),
-			(stored) => (next = update(stored ?? loaded)),
-		);
+		// Compare and write in one transaction so stale windows cannot lose real updates.
+		await reviewStore("readwrite", async (store) => {
+			const current =
+				(await idb.promisifyRequest<ReviewState | undefined>(store.get(storageKey(projectId)))) ??
+				loaded;
+			next = update(current);
+			changed = next !== current;
+			if (changed) store.put(next, storageKey(projectId));
+			return idb.promisifyRequest(store.transaction);
+		});
 	} catch {
-		next = update(client.getQueryData(options.queryKey) ?? loaded);
+		const current = client.getQueryData(options.queryKey) ?? loaded;
+		next = update(current);
+		changed = next !== current;
 	}
+	if (!changed) return next;
 	await client.cancelQueries({ queryKey: options.queryKey });
 	client.setQueryData(options.queryKey, next);
 	return next;

--- a/apps/lite/ui/src/review-users.ts
+++ b/apps/lite/ui/src/review-users.ts
@@ -13,7 +13,8 @@ export const isAgent = (user: Pick<ForgeReviewUser, "isBot" | "login">): boolean
  * case-insensitive, and a bot's carries the `[bot]` suffix in REST but not
  * in GraphQL; both spellings reach the app.
  */
-export const sameLogin = (a: string, b: string): boolean => loginKey(a) === loginKey(b);
+export const sameLogin = (a: string | null | undefined, b: string | null | undefined): boolean =>
+	a != null && b != null && loginKey(a) === loginKey(b);
 
 /** The form of a login to key by, so both spellings of a bot land together. */
 export const loginKey = (login: string): string => login.toLowerCase().replace(/\[bot\]$/, "");

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.module.css
@@ -1,36 +1,6 @@
-.backdrop {
-	position: fixed;
-	inset: 0;
-	background-color: var(--bg-overlay);
-}
-
-.viewport {
-	display: flex;
-	position: fixed;
-	inset: 0;
-	padding: 4.5rem 1rem;
-}
-
 .popup {
-	display: flex;
-	flex-direction: column;
 	width: min(680px, 100%);
 	max-height: min(76vh, 900px);
-	margin: auto;
-	overflow: hidden;
-	border: 1px solid var(--border-2);
-	border-radius: var(--radius-lg);
-	/* The dialog receives initial focus; the ring belongs on its controls. */
-	outline: none;
-	background-color: var(--bg-1);
-	box-shadow:
-		0 0.5px 1px rgb(0 0 0 / 0.12),
-		0 1px 3px -1px rgb(0 0 0 / 0.04),
-		0 2px 4px -1px rgb(0 0 0 / 0.04),
-		0 4px 8px -2px rgb(0 0 0 / 0.04),
-		0 12px 14px -4px rgb(0 0 0 / 0.04),
-		0 24px 64px -8px rgb(0 0 0 / 0.04),
-		0 40px 48px -32px rgb(0 0 0 / 0.04);
 }
 
 .dialogHeader {

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.tsx
@@ -19,12 +19,13 @@ import { classes } from "#ui/components/classes.ts";
 import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
+import { Modal } from "#ui/components/Popup.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { authorTooltip, commitIsDiverged, commitTitle, shortCommitId } from "#ui/commit.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import type { BranchIntegrationStrategy, FullRefName } from "@gitbutler/but-sdk";
-import { Dialog, Toggle, ToggleGroup } from "@base-ui/react";
+import { Toggle, ToggleGroup } from "@base-ui/react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { type FC, useState } from "react";
 import { Row, RowCheckbox, RowLabel, RowLabelContainer } from "./Row.tsx";
@@ -268,7 +269,7 @@ const BranchUpdatePanel: FC<{
 		/** What landed: an integration still to publish, a push, or a replace. */
 		kind: "integrated" | "pushed" | "replaced";
 		force: boolean;
-		remoteName: string;
+		upstreamBranchLabel: string;
 	} | null>(null);
 
 	if (isPlanError) {
@@ -286,7 +287,7 @@ const BranchUpdatePanel: FC<{
 	const keptCount = previewRows?.filter((row) => row.origin === "local").length ?? null;
 	const conflictCount = previewRows?.filter((row) => row.commit.hasConflicts).length ?? 0;
 	const branchLabel = shortRefName(plan.divergence.branchRefName);
-	const remoteName = shortRefName(plan.divergence.upstreamRefName);
+	const upstreamBranchLabel = shortRefName(plan.divergence.upstreamRefName);
 
 	const allDivergenceCommits = [
 		...plan.divergence.localOnly,
@@ -335,7 +336,7 @@ const BranchUpdatePanel: FC<{
 					runHooks: true,
 					pushOpts: [],
 				},
-				{ onSuccess: () => setApplied({ kind: "pushed", force: true, remoteName }) },
+				{ onSuccess: () => setApplied({ kind: "pushed", force: true, upstreamBranchLabel }) },
 			);
 			return;
 		}
@@ -347,8 +348,8 @@ const BranchUpdatePanel: FC<{
 				onSuccess: () =>
 					setApplied(
 						choice === "theirs"
-							? { kind: "replaced", force: false, remoteName }
-							: { kind: "integrated", force: needsForce, remoteName },
+							? { kind: "replaced", force: false, upstreamBranchLabel }
+							: { kind: "integrated", force: needsForce, upstreamBranchLabel },
 					),
 			},
 		);
@@ -382,11 +383,11 @@ const BranchUpdatePanel: FC<{
 					<p className={classes("text-13", rowStyles.fadedText)}>
 						{applied.kind === "integrated"
 							? applied.force
-								? `${applied.remoteName} still holds the previous versions of your commits; force push to publish the result.`
-								: `${applied.remoteName} is behind; push to publish the result.`
+								? `${applied.upstreamBranchLabel} still holds the previous versions of your commits; force push to publish the result.`
+								: `${applied.upstreamBranchLabel} is behind; push to publish the result.`
 							: applied.kind === "pushed"
-								? `${applied.remoteName} now matches this branch.`
-								: `This branch now matches ${applied.remoteName}.`}
+								? `${applied.upstreamBranchLabel} now matches this branch.`
+								: `This branch now matches ${applied.upstreamBranchLabel}.`}
 					</p>
 				</div>
 				<div className={styles.footer}>
@@ -427,12 +428,12 @@ const BranchUpdatePanel: FC<{
 				<div className={styles.strategyRow}>
 					<p className={classes("text-13", styles.diagnosis)}>
 						{additions > 0 && rewritten > 0
-							? `${remoteName} has ${count(additions, "new commit")}, and a different version of ${rewritten === 1 ? "one" : rewritten} of yours.`
+							? `${upstreamBranchLabel} has ${count(additions, "new commit")}, and a different version of ${rewritten === 1 ? "one" : rewritten} of yours.`
 							: additions > 0
-								? `${remoteName} has ${count(additions, "new commit")}.`
+								? `${upstreamBranchLabel} has ${count(additions, "new commit")}.`
 								: rewritten > 0
-									? `${remoteName} holds a different version of ${rewritten === 1 ? "one" : rewritten} of your commits.`
-									: `${remoteName} and this branch have diverged.`}
+									? `${upstreamBranchLabel} holds a different version of ${rewritten === 1 ? "one" : rewritten} of your commits.`
+									: `${upstreamBranchLabel} and this branch have diverged.`}
 					</p>
 				</div>
 
@@ -556,24 +557,22 @@ export const BranchUpdateDialog: FC<{
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }> = ({ projectId, branchRef, open, onOpenChange }) => (
-	<Dialog.Root open={open} onOpenChange={onOpenChange}>
-		<Dialog.Portal>
-			<Dialog.Backdrop className={styles.backdrop} />
-			<Dialog.Viewport className={styles.viewport}>
-				<Dialog.Popup aria-labelledby="branch-update-heading" className={styles.popup}>
-					<div className={styles.dialogHeader}>
-						<Icon name="branch" />
-						<h1 id="branch-update-heading" className={classes("text-14", "text-bold")}>
-							Update {shortRefName({ full: branchRef })} from remote
-						</h1>
-					</div>
-					<BranchUpdatePanel
-						projectId={projectId}
-						branch={branchRef}
-						onApplied={() => onOpenChange(false)}
-					/>
-				</Dialog.Popup>
-			</Dialog.Viewport>
-		</Dialog.Portal>
-	</Dialog.Root>
+	<Modal
+		open={open}
+		onOpenChange={onOpenChange}
+		aria-labelledby="branch-update-heading"
+		className={styles.popup}
+	>
+		<div className={styles.dialogHeader}>
+			<Icon name="branch" />
+			<h1 id="branch-update-heading" className={classes("text-14", "text-bold")}>
+				Update {shortRefName({ full: branchRef })} from remote
+			</h1>
+		</div>
+		<BranchUpdatePanel
+			projectId={projectId}
+			branch={branchRef}
+			onApplied={() => onOpenChange(false)}
+		/>
+	</Modal>
 );

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -3376,6 +3376,7 @@ const ReviewLayout: FC<{
  */
 const ReviewView: FC<ComponentProps<typeof ReviewLayout>> = (p) => {
 	const seenOnArrival = useSeenOnArrival(p.projectId, p.review.number);
+	if (seenOnArrival === null) return null;
 	return (
 		<SeenOnArrivalContext.Provider value={seenOnArrival}>
 			<ReviewLayout {...p} />

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPlaceholder.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPlaceholder.tsx
@@ -2,19 +2,6 @@ import styles from "./DetailsPlaceholder.module.css";
 import { EmptyState } from "#ui/components/EmptyState.tsx";
 import type { FC, ReactNode } from "react";
 
-/**
- * The details pane with nothing to detail.
- *
- * The pane only ever empties because the list driving it is empty, and that
- * list is already carrying its own empty state a few hundred pixels to the
- * left. So this says the one thing the sidebar cannot: what the pane itself is
- * for. Present tense — an instruction would be unfollowable, since there is
- * nothing in the list to act on.
- *
- * No actions, matching the component in ⚛️ Lite Core, which hides its actions
- * slot here: every action belonging to this state belongs to the section that
- * owns it, and would be out of context in the pane.
- */
 export const DetailsPlaceholder: FC<{ title: string; description: ReactNode }> = ({
 	title,
 	description,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
@@ -47,7 +47,7 @@ export const usePlan = (projectId: string) => {
 				query.state.data.pages.some((page) => page.commits.some((commit) => commit.inWorkspace)) ||
 				query.state.data.pages.at(-1)?.hasMore === true),
 	});
-	const olderPages = useMemo(
+	const olderCommits = useMemo(
 		() => olderData?.pages.flatMap((page) => page.commits) ?? [],
 		[olderData],
 	);
@@ -57,13 +57,13 @@ export const usePlan = (projectId: string) => {
 		() =>
 			baseListing?.hasMore && olderData !== undefined
 				? {
-						commits: [...baseListing.commits, ...olderPages],
+						commits: [...baseListing.commits, ...olderCommits],
 						hasMore: olderData.pages.at(-1)?.hasMore ?? false,
 					}
 				: baseListing,
-		[baseListing, olderData, olderPages],
+		[baseListing, olderData, olderCommits],
 	);
-	const historyPages = baseListing?.hasMore ? noCommits : olderPages;
+	const historyPages = baseListing?.hasMore ? noCommits : olderCommits;
 	const structure = useMemo(
 		() => layoutStructure(listOrder, listing, worktrees),
 		[listOrder, listing, worktrees],

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -1,3 +1,4 @@
+import { useEditorMenuItem } from "./usePathMenuItems.ts";
 import {
 	useSetReviewThreadResolved,
 	useAddCommentReaction,
@@ -6,7 +7,6 @@ import {
 	useDeleteReviewComment,
 	useRemoveCommentReaction,
 	useRemoveSubmissionReaction,
-	useOpenInProgram,
 	useUpdateReviewComment,
 } from "#ui/api/mutations.ts";
 import {
@@ -20,7 +20,6 @@ import {
 	listReviewTimelineEventsQueryOptions,
 	guiSettingsQueryOptions,
 	headInfoQueryOptions,
-	listEditorsQueryOptions,
 	workspaceFileQueryOptions,
 	reviewerCandidatesQueryOptions,
 	userProfileQueryOptions,
@@ -66,7 +65,7 @@ import { ReviewThreadReply } from "#ui/routes/project/$id/workspace/ReviewThread
 import { encodeBytes } from "#ui/api/bytes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { forgeHunkDiff, threadStillAnchoredInFile } from "#ui/review-threads.ts";
-import { isAgent } from "#ui/review-users.ts";
+import { isAgent, sameLogin } from "#ui/review-users.ts";
 import { defaultSettings } from "#ui/settings.ts";
 import { pullRequestHotkeys } from "#ui/hotkeys.ts";
 import { FreshBadge, RegisterFreshItems } from "#ui/review-arrival.tsx";
@@ -237,7 +236,7 @@ const Comment: FC<{
 	onReply: (comment: Quotable) => void;
 }> = ({ projectId, reviewId, comment, currentLogin, onReply }) => {
 	const createdAtMs = comment.createdAt === null ? null : Date.parse(comment.createdAt);
-	const isOwn = currentLogin != null && comment.author?.login === currentLogin;
+	const isOwn = sameLogin(comment.author?.login, currentLogin);
 	// An optimistic comment awaiting its forge id; nothing can act on it yet.
 	const isSending = comment.id < 0;
 
@@ -433,12 +432,7 @@ const ThreadHunk: FC<{
 	lineNr: number | null;
 	diffHunk: string;
 }> = ({ projectId, path, lineNr, diffHunk }) => {
-	const { data: editors } = useQuery(listEditorsQueryOptions);
-	const { data: preferredEditor } = useQuery({
-		...guiSettingsQueryOptions,
-		select: (cfg) => editors?.find((editor) => editor.id === cfg.editorId),
-	});
-	const { isPending: isOpenInProgramPending, mutate: openInProgram } = useOpenInProgram();
+	const editorMenuItem = useEditorMenuItem({ projectId, path, lineNr });
 	const { data: settings } = useQuery({
 		...guiSettingsQueryOptions,
 		select: (cfg) => ({
@@ -449,8 +443,6 @@ const ThreadHunk: FC<{
 			diffLigatures: cfg.diffLigatures,
 		}),
 	});
-
-	const openAt = (programId: string) => openInProgram({ projectId, programId, path, lineNr });
 
 	/* The app's own menu replaces the window's, so it carries the copy the
 	   window would have offered — quoted code is here to be taken away. */
@@ -474,24 +466,7 @@ const ThreadHunk: FC<{
 						onSelect: () => void navigator.clipboard.writeText(selection),
 					}),
 				],
-				[
-					preferredEditor
-						? nativeMenuItem({
-								label: `Open in ${preferredEditor.name}`,
-								enabled: !isOpenInProgramPending,
-								onSelect: () => openAt(preferredEditor.id),
-							})
-						: nativeMenuItem({
-								label: "Open In Editor",
-								submenu: (editors ?? []).map((editor) =>
-									nativeMenuItem({
-										label: editor.name,
-										enabled: !isOpenInProgramPending,
-										onSelect: () => openAt(editor.id),
-									}),
-								),
-							}),
-				],
+				[editorMenuItem],
 			]),
 		);
 	};
@@ -955,7 +930,8 @@ const ownForgeAvatar = (
 				: item.kind === "submission"
 					? item.submission.author
 					: null;
-		if (author?.login === currentLogin && author.avatarUrl !== null) return author.avatarUrl;
+		if (author != null && sameLogin(author.login, currentLogin) && author.avatarUrl !== null)
+			return author.avatarUrl;
 	}
 	return null;
 };
@@ -1197,12 +1173,10 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 		// this endpoint's capability gate has to hold here instead.
 		enabled: forgeInfo?.capabilities.reviewComments === true,
 	});
-	// The people and agent feeds are split on the forge's own bot flag; a
-	// thread goes with whoever started it. Everything downstream — the fresh
-	// registration included — sees only what the feed shows, so a hidden
-	// comment is never counted as looked at.
+	// Threads follow their first author. Register only visible activity so
+	// hidden comments cannot be marked as read.
 	const inFeed = (author: ForgeReviewUser | null) =>
-		feed === "timeline" || (author?.isBot ?? false) === (feed === "agents");
+		feed === "timeline" || (author != null && isAgent(author)) === (feed === "agents");
 	const comments = allComments?.filter((comment) => inFeed(comment.author));
 	const submissions = allSubmissions?.filter((submission) => inFeed(submission.author));
 	const threads = allThreads?.filter((thread) => inFeed(thread.comments[0]?.author ?? null));
@@ -1224,8 +1198,7 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 
 	// What the dwell may record as skipped: the conversation's own unread-
 	// eligible items.
-	const own = (login: string | null | undefined) =>
-		currentLogin != null && login != null && login.toLowerCase() === currentLogin.toLowerCase();
+	const own = (login: string | null | undefined) => sameLogin(login, currentLogin);
 	const freshItems = [
 		...(comments ?? [])
 			.filter(

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -378,3 +378,17 @@
 .created {
 	color: var(--text-2);
 }
+
+.withdrawIcon {
+	display: none;
+}
+
+.reviewerRow:hover,
+.reviewerRow:has(button:focus) {
+	.withdrawIcon {
+		display: inline-flex;
+	}
+	.pendingIcon {
+		display: none;
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -88,11 +88,6 @@ const Section: FC<{
 const orEmptyNotice = (items: Array<NativeMenuItem>, notice: string): Array<NativeMenuItem> =>
 	items.length > 0 ? items : [nativeMenuItem({ label: notice, enabled: false })];
 
-/**
- * The header control for a pickable section. While the section is empty it
- * spells out what the picker adds so the section doesn't read as a bare
- * heading; once something is picked, a plus is enough.
- */
 /** Quiet until its row is hovered, like the comment kebab. */
 const RemoveButton: FC<{ label: string; onClick: () => void }> = ({ label, onClick }) => (
 	<button
@@ -119,15 +114,8 @@ const ReviewerRow: FC<{
 	onWithdraw: (() => void) | null;
 }> = ({ user, verdict, onWithdraw }) => {
 	const [icon, color, label] = verdictBits(verdict);
-	const [hovered, setHovered] = useState(false);
-	const [focused, setFocused] = useState(false);
 	return (
-		<div
-			className={styles.reviewerRow}
-			onPointerEnter={() => setHovered(true)}
-			onPointerLeave={() => setHovered(false)}
-			title={label}
-		>
+		<div className={styles.reviewerRow} title={label}>
 			<ReviewUser user={user} />
 			{onWithdraw === null ? (
 				<span className={styles.verdictSlot}>
@@ -137,19 +125,14 @@ const ReviewerRow: FC<{
 				<button
 					aria-label="Withdraw review request"
 					className={getButtonClassName({ variant: "ghost", size: "small", iconOnly: true })}
-					onBlur={() => setFocused(false)}
 					onClick={onWithdraw}
-					onFocus={() => setFocused(true)}
 					title="Withdraw review request"
 					type="button"
 				>
 					{/* The cross has no ring, so it sits a touch smaller than the
 					    verdicts to read as light. */}
-					{hovered || focused ? (
-						<Icon name="cross" size={13} />
-					) : (
-						<Icon name={icon} style={{ color }} size={15} />
-					)}
+					<Icon name="cross" size={13} className={styles.withdrawIcon} />
+					<Icon name={icon} style={{ color }} size={15} className={styles.pendingIcon} />
 				</button>
 			)}
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -129,9 +129,7 @@ const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 DryRunWorkspaceContext.displayName = "DryRunWorkspaceContext";
 
 /**
- * An element's height, kept current as it resizes: give the element the ref.
- * Keyed on the element, not a ref object, so a replaced node (a hot reload
- * swaps them) is measured afresh rather than watched after it is gone.
+ * Reuse the empty lane list so graph inputs keep their identity.
  */
 const noLanes: ReadonlyArray<Worktree> = [];
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
@@ -309,13 +309,14 @@ const WorktreeBranchRow: FC<
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	// Only this branch's number: the listing refetches on a timer, and a row
 	// should re-render only when its own pull request changes.
-	const { data: pullRequest = null } = useQuery({
+	const { data: pullRequestNumber = null } = useQuery({
 		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
 		enabled: !!forgeInfo?.capabilities.prService,
 		select: (reviews) =>
 			reviews.find((review) => review.sourceBranch === refName.displayName)?.number ?? null,
 	});
-	const forgeUrl = pullRequest !== null && forgeInfo ? prForgeUrl(pullRequest, forgeInfo) : null;
+	const forgeUrl =
+		pullRequestNumber !== null && forgeInfo ? prForgeUrl(pullRequestNumber, forgeInfo) : null;
 
 	const pushBranch = () => {
 		workspaceBranchAndAncestorsPush({

--- a/apps/lite/ui/src/routes/project/$id/workspace/usePathMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/usePathMenuItems.ts
@@ -27,11 +27,6 @@ export const usePathMenuItems = ({
 	worktree?: string;
 }): Array<NativeMenuItem> => {
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
-	const { data: editors } = useQuery(listEditorsQueryOptions);
-	const { data: preferredEditor } = useQuery({
-		...guiSettingsQueryOptions,
-		select: (cfg) => editors?.find((editor) => editor.id === cfg.editorId),
-	});
 	const { data: worktreePath } = useQuery({
 		...worktreesListQueryOptions(projectId),
 		enabled: worktree !== undefined,
@@ -45,34 +40,16 @@ export const usePathMenuItems = ({
 	const basePath = worktree === undefined ? selectedProject.path : worktreePath;
 	const absolutePath = () => window.lite.pathJoin(basePath ?? "", path);
 
-	const { isPending: isOpenInProgramPending, mutate: openInProgram } = useOpenInProgram();
-	// The backend resolves the path against the project's checkout, so a linked
-	// worktree's file is handed over absolute, which joining leaves untouched.
-	const openPath = async (programId: string) => {
-		const target = worktree === undefined ? path : await absolutePath();
-		openInProgram({ projectId, programId, path: target, lineNr: null });
-	};
-	const canOpen = !isOpenInProgramPending && basePath !== undefined;
+	const editorMenuItem = useEditorMenuItem({
+		projectId,
+		// Linked worktree paths must be absolute; the backend resolves relative paths in the main checkout.
+		path: worktree === undefined ? path : absolutePath,
+		enabled: basePath !== undefined,
+		accelerator: toElectronAccelerator(changesFileHotkeys.openInEditor.hotkey),
+	});
 
 	return [
-		preferredEditor
-			? nativeMenuItem({
-					label: `Open in ${preferredEditor.name}`,
-					enabled: canOpen,
-					accelerator: toElectronAccelerator(changesFileHotkeys.openInEditor.hotkey),
-					onSelect: () => void openPath(preferredEditor.id),
-				})
-			: nativeMenuItem({
-					label: "Open In Editor",
-					submenu:
-						editors?.map((editor) =>
-							nativeMenuItem({
-								label: editor.name,
-								enabled: canOpen,
-								onSelect: () => void openPath(editor.id),
-							}),
-						) ?? [],
-				}),
+		editorMenuItem,
 		nativeMenuItem({
 			label: revealInFolderLabel,
 			enabled: basePath !== undefined,
@@ -94,4 +71,49 @@ export const usePathMenuItems = ({
 			],
 		}),
 	];
+};
+
+export const useEditorMenuItem = ({
+	projectId,
+	path,
+	lineNr = null,
+	enabled = true,
+	accelerator,
+}: {
+	projectId: string;
+	path: string | (() => Promise<string>);
+	lineNr?: number | null;
+	enabled?: boolean;
+	accelerator?: string;
+}): NativeMenuItem => {
+	const { data: editors } = useQuery(listEditorsQueryOptions);
+	const { data: preferredEditor } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => editors?.find((editor) => editor.id === cfg.editorId),
+	});
+
+	const { isPending, mutate: openInProgram } = useOpenInProgram();
+	const openPath = async (programId: string) => {
+		const target = typeof path === "string" ? path : await path();
+		openInProgram({ projectId, programId, path: target, lineNr });
+	};
+	const canOpen = enabled && !isPending;
+	return preferredEditor
+		? nativeMenuItem({
+				label: `Open in ${preferredEditor.name}`,
+				enabled: canOpen,
+				accelerator,
+				onSelect: () => void openPath(preferredEditor.id),
+			})
+		: nativeMenuItem({
+				label: "Open In Editor",
+				submenu:
+					editors?.map((editor) =>
+						nativeMenuItem({
+							label: editor.name,
+							enabled: canOpen,
+							onSelect: () => void openPath(editor.id),
+						}),
+					) ?? [],
+			});
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: ^1.0.0
         version: 1.0.0(eslint@9.39.5(jiti@2.7.0))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       fast-check:
         specifier: ^4.9.0
         version: 4.9.0
@@ -6757,6 +6760,10 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -16448,6 +16455,8 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fake-indexeddb@6.2.5: {}
 
   fast-check@3.23.2:
     dependencies:


### PR DESCRIPTION
## 🧢 Changes

- Reuse shared modals, popup sections, and editor menus.
- Clarify variable names and remove obvious or misleading comments.
- Share login matching and bot detection across review views.
- Move notifications and read/unread state into one IndexedDB store.
- Migrate existing data and preserve updates from multiple windows.
- Fix missed review activity while stored state loads at startup.
- Read fresh state when opening reviews or notifications.
- Skip unchanged writes and keep arrival snapshots stable.

## ☕️ Reasoning

- Reduce duplicate code and custom state subscriptions.
- Keep persisted review state in IndexedDB, as required by Lite's storage convention.

## Validation

- Typechecking, 590 unit/harness tests, lint, Knip, and formatting pass.
- Full E2E suite: 40 passed, 9 skipped.
