### PR TITLE
Reveal check job link arrows on hover

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -331,6 +331,13 @@
 .checkLinkIcon {
 	flex-shrink: 0;
 	color: var(--text-3);
+	opacity: 0;
+	transition: opacity var(--transition-fast);
+
+	.checkRow:hover &,
+	.checkRow:focus-visible & {
+		opacity: 1;
+	}
 }
 
 /* Long branch names truncate instead of shattering mid-word; the arrow and


### PR DESCRIPTION
Hide external-link arrows in PR check rows until the row is hovered or keyboard-focused. Preserve the icon space so job names and timing stay aligned, and use the shared fade duration.

Validation: Lite typecheck, 583 unit/harness tests, 40 E2E tests (9 skipped), lint, both Knip checks, and formatting passed. Browser checks verified hidden, hover, keyboard-focus, and no-layout-shift behavior. One-off screenshots cover the resting and hovered states.