### PR TITLE
Group workspace branch push controls

### DIFF
--- a/apps/lite/e2e/tests/workspace-reviews.spec.ts
+++ b/apps/lite/e2e/tests/workspace-reviews.spec.ts
@@ -65,7 +65,23 @@ test("shows PR titles and labels on workspace branches without hover shifts", as
 	await expect(branch.getByText(review.title, { exact: true })).toBeVisible();
 	await expect(branch.getByText("accessibility", { exact: true })).toBeVisible();
 	await expect(branch.getByText("@gitbutler/lite", { exact: true })).toBeVisible();
-	await expect(branch.getByText("PR #1", { exact: true })).toBeVisible();
+	await expect(branch.getByText("PR #1", { exact: true })).toHaveCount(0);
+	const name = branch.getByTitle("C", { exact: true });
+	const status = branch.getByText("Unpushed branch", { exact: true });
+	const push = branch.getByRole("button", {
+		name: "Push this and all branches below",
+		exact: true,
+	});
+	const [nameBox, statusBox, pushBox] = await Promise.all([
+		name.boundingBox(),
+		status.boundingBox(),
+		push.boundingBox(),
+	]);
+	if (!nameBox || !statusBox || !pushBox) throw new Error("Branch push row has no bounds");
+	const centers = [nameBox, statusBox, pushBox].map((box) => box.y + box.height / 2);
+	expect(Math.max(...centers) - Math.min(...centers)).toBeLessThanOrEqual(1);
+	expect(nameBox.x + nameBox.width).toBeLessThan(statusBox.x);
+	expect(statusBox.x + statusBox.width).toBeLessThan(pushBox.x);
 	const labelBounds = await branch
 		.getByText("@gitbutler/lite", { exact: true })
 		.evaluate((element) => {

--- a/apps/lite/harness/tests/panel.test.tsx
+++ b/apps/lite/harness/tests/panel.test.tsx
@@ -183,9 +183,9 @@ test("someone else's review activity files one coalesced inbox entry and the unr
 		listReviewTimelineEvents: () => [],
 	});
 
-	// The PR chip proves the baseline listing landed; nothing is filed yet —
+	// The review title proves the baseline listing landed; nothing is filed yet —
 	// history must never replay as notifications.
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await vi.waitFor(() => expect(panel.container.textContent).toContain(review.title), settle);
 	expect(inboxEntries()).toHaveLength(0);
 
 	// Someone comments; the forge bumps the review and a fetch notices.
@@ -233,7 +233,7 @@ test("a mention left on a diff line is filed like any other", async () => {
 		listReviewTimelineEvents: () => [],
 	});
 
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await vi.waitFor(() => expect(panel.container.textContent).toContain(review.title), settle);
 
 	review = { ...review, modifiedAt: "2026-01-01T11:00:00Z" };
 	threads = [
@@ -297,7 +297,7 @@ test("a mention toasts even when the review's branch is not in the workspace", a
 		listReviewTimelineEvents: () => [],
 	});
 
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await vi.waitFor(() => expect(panel.container.textContent).toContain(mine.title), settle);
 
 	outside = { ...outside, modifiedAt: "2026-01-01T11:00:00Z" };
 	comments = [
@@ -347,7 +347,7 @@ test("loud activity is offered to the desktop, and its click lands on the entry"
 			shown.push(notice);
 		},
 	});
-	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	await vi.waitFor(() => expect(panel.container.textContent).toContain(review.title), settle);
 
 	review = { ...review, modifiedAt: "2026-01-01T12:00:00Z" };
 	// Its own minute: entry ids carry the time, and the inbox module keeps an

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -536,66 +536,36 @@ export const BranchRow: FC<
 				/>
 			) : (
 				<RowLabelGroup id={descriptionId}>
-					{openReview !== undefined && (
+					{openReview !== undefined ? (
 						<BranchRowHeadline title={openReview.title} labels={openReview.labels} />
+					) : (
+						<RowLabelContainer>
+							<RowLabel heading singleLine title={optimisticBranchDisplayName}>
+								{optimisticBranchDisplayName}
+							</RowLabel>
+						</RowLabelContainer>
 					)}
-					<RowLabelContainer style={{ columnGap: 4 }}>
-						{pullRequest !== null && (
-							<Icon name="branch" size={12} className={rowStyles.fadedText} />
-						)}
-						<RowLabel
-							className={openReview !== undefined ? rowStyles.fadedText : undefined}
-							heading={openReview === undefined}
-							singleLine
-							title={optimisticBranchDisplayName}
-						>
-							{optimisticBranchDisplayName}
-						</RowLabel>
-					</RowLabelContainer>
 
 					<RowMeta>
-						{/* The remote's news in the row itself; the chip opens the commits. */}
-						{remote !== null && incoming > 0 && (
+						{openReview !== undefined && (
 							<>
-								<button
-									type="button"
-									aria-expanded={incomingExpanded}
-									aria-label={`${incomingExpanded ? "Hide" : "Show"} ${String(incoming)} incoming ${incoming === 1 ? "commit" : "commits"} from ${remote.remoteName}/${remote.displayName}`}
+								<span
 									className={classes(
-										getRowButtonClassName({ variant: "ghost" }),
+										rowStyles.fadedText,
 										rowStyles.metaItem,
 										rowStyles.metaItemShrinkable,
 									)}
-									onClick={toggleIncoming}
 								>
-									<Icon size={12} name={incomingExpanded ? "chevron-down" : "chevron-right"} />
-									<span className={rowStyles.metaItemText}>{incomingLabel}</span>
-									{/* Its own flex item: the chip's gap, not a space, parts it from the label. */}
-									<span>+{incoming}</span>
-								</button>
-								<RowMetaSeparator />
-							</>
-						)}
-
-						{/* Only while folded: the count stands in for the commits it hides,
-						    so showing it alongside them would just be noise. */}
-						{isFolded && commitCount > 0 && (
-							<>
-								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
-									<Icon size={14} name="commit" />
-									{commitCount}
+									<Icon name="branch" size={12} />
+									<span className={rowStyles.metaItemText} title={optimisticBranchDisplayName}>
+										{optimisticBranchDisplayName}
+									</span>
 								</span>
 								<RowMetaSeparator />
 							</>
 						)}
 
-						<span
-							className={classes(
-								rowStyles.fadedText,
-								rowStyles.metaItem,
-								rowStyles.metaItemShrinkable,
-							)}
-						>
+						<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
 							<span className={rowStyles.metaItemText} title={pushStatusTooltip}>
 								{Match.value(pushStatus).pipe(
 									Match.when("nothingToPush", () => "Nothing to push"),
@@ -610,28 +580,6 @@ export const BranchRow: FC<
 								)}
 							</span>
 						</span>
-
-						{/* The checks belong to the PR, so they ride alongside its label
-						    rather than standing as their own meta item. */}
-						{pullRequest !== null && (
-							<>
-								<RowMetaSeparator />
-								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
-									<Icon size={14} name="pr" />
-									{forgeInfo?.unit.abbr ?? "PR"} {forgeInfo?.unit.symbol ?? "#"}
-									{pullRequest}
-								</span>
-
-								{ciChecks?.aggregate &&
-									(ciURL != null ? (
-										<a href={ciURL} onClick={(evt) => void openCIChecksInBrowser(evt)}>
-											<CIBubble checks={ciChecks.aggregate} />
-										</a>
-									) : (
-										<CIBubble checks={ciChecks.aggregate} />
-									))}
-							</>
-						)}
 
 						{downstackPushStatus.anyRequiresPush &&
 							(() => {
@@ -698,6 +646,54 @@ export const BranchRow: FC<
 									</Tooltip.Root>
 								);
 							})()}
+
+						{ciChecks?.aggregate && (
+							<>
+								<RowMetaSeparator />
+								{ciURL != null ? (
+									<a href={ciURL} onClick={(evt) => void openCIChecksInBrowser(evt)}>
+										<CIBubble checks={ciChecks.aggregate} />
+									</a>
+								) : (
+									<CIBubble checks={ciChecks.aggregate} />
+								)}
+							</>
+						)}
+
+						{/* The remote's news in the row itself; the chip opens the commits. */}
+						{remote !== null && incoming > 0 && (
+							<>
+								<RowMetaSeparator />
+								<button
+									type="button"
+									aria-expanded={incomingExpanded}
+									aria-label={`${incomingExpanded ? "Hide" : "Show"} ${String(incoming)} incoming ${incoming === 1 ? "commit" : "commits"} from ${remote.remoteName}/${remote.displayName}`}
+									className={classes(
+										getRowButtonClassName({ variant: "ghost" }),
+										rowStyles.metaItem,
+										rowStyles.metaItemShrinkable,
+									)}
+									onClick={toggleIncoming}
+								>
+									<Icon size={12} name={incomingExpanded ? "chevron-down" : "chevron-right"} />
+									<span className={rowStyles.metaItemText}>{incomingLabel}</span>
+									{/* Its own flex item: the chip's gap, not a space, parts it from the label. */}
+									<span>+{incoming}</span>
+								</button>
+							</>
+						)}
+
+						{/* Only while folded: the count stands in for the commits it hides,
+						    so showing it alongside them would just be noise. */}
+						{isFolded && commitCount > 0 && (
+							<>
+								<RowMetaSeparator />
+								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
+									<Icon size={14} name="commit" />
+									{commitCount}
+								</span>
+							</>
+						)}
 
 						{/* Beside Push rather than in its place: a plain push cannot land
 						    while the remote is ahead, and forcing would drop theirs. */}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -1228,7 +1228,7 @@ const Stacks: FC<{
 					const review = reviews?.find(
 						(review) => review.sourceBranch === segment.refName?.displayName,
 					);
-					if (review !== undefined) contentHeight += 34 + (review.labels.length > 0 ? 22 : 0);
+					if (review !== undefined) contentHeight += 6 + (review.labels.length > 0 ? 22 : 0);
 				}
 
 				const isFolded = branchRef !== null && foldedSegments[branchRef] === true;


### PR DESCRIPTION
Keep the branch name, push status, and Push button together, and remove the PR number.