### PR TITLE
An experiment

### DIFF
--- a/apps/lite/e2e/pr-readability-fixture.ts
+++ b/apps/lite/e2e/pr-readability-fixture.ts
@@ -1,3 +1,4 @@
+import type { LiteElectronApi } from "#electron/ipc.ts";
 import type {
 	ForgeReview,
 	ForgeInfo,
@@ -12,7 +13,7 @@ export const review: ForgeReview = {
 	sourceBranch: "C",
 	targetBranch: "master",
 	htmlUrl: "https://github.com/example/repo/pull/1",
-	body: "This change makes pull request reviews easier to read.\n\nIt keeps the description visible and makes outstanding review work explicit.",
+	body: "This change makes pull request reviews easier to read.\n\nIt keeps the description visible and makes outstanding review work explicit.\n\nReviewers can scan the changed files alongside the conversation.\n\nThe keyboard shortcuts remain available throughout the review.",
 	author: null,
 	labels: [
 		{ name: "accessibility", color: "0e8a16", description: "Keyboard and screen reader support" },
@@ -115,9 +116,24 @@ const checks: Array<CiCheck> = [
 
 export const openReadabilityReview = async (appWindow: Page, electronApp: ElectronApplication) => {
 	await appWindow.setViewportSize({ width: 1440, height: 900 });
+	const sample = await appWindow.evaluate(() =>
+		(window as unknown as { lite: LiteElectronApi }).lite.branchDiff({
+			projectId: location.pathname.split("/")[2] ?? "",
+			branch: "refs/heads/C",
+		}),
+	);
+	const first = sample.changes[0];
+	if (!first) throw new Error("Expected a changed file");
+	const changes = Array.from({ length: 12 }, (_, index) => ({
+		...first,
+		path: `src/file-${index}.ts`,
+		pathBytes: Array.from(Buffer.from(`src/file-${index}.ts`)),
+	}));
+
 	await electronApp.evaluate(
 		({ ipcMain }, data) => {
 			const responses = {
+				branchDiff: { ...data.sample, changes: data.changes },
 				forgeInfo: data.forge,
 				listReviews: [data.review],
 				getReview: data.review,
@@ -136,7 +152,7 @@ export const openReadabilityReview = async (appWindow: Page, electronApp: Electr
 				ipcMain.handle(key, () => value);
 			}
 		},
-		{ review, forge, checks, submissions, comments },
+		{ review, forge, checks, submissions, comments, sample, changes },
 	);
 	await appWindow.reload();
 	await appWindow

--- a/apps/lite/e2e/pr-readability-fixture.ts
+++ b/apps/lite/e2e/pr-readability-fixture.ts
@@ -1,0 +1,146 @@
+import type {
+	ForgeReview,
+	ForgeInfo,
+	ForgeReviewSubmission,
+	ForgeReviewComment,
+	CiCheck,
+} from "@gitbutler/but-sdk";
+import type { ElectronApplication, Page } from "@playwright/test";
+export const review: ForgeReview = {
+	number: 1,
+	title: "Improve keyboard navigation in large repositories",
+	sourceBranch: "C",
+	targetBranch: "master",
+	htmlUrl: "https://github.com/example/repo/pull/1",
+	body: "This change makes pull request reviews easier to read.\n\nIt keeps the description visible and makes outstanding review work explicit.",
+	author: null,
+	labels: [
+		{ name: "accessibility", color: "0e8a16", description: "Keyboard and screen reader support" },
+		{ name: "@gitbutler/lite", color: "5319e7", description: null },
+	],
+	draft: false,
+	sha: "0000000000000000000000000000000000000001",
+	integrationCommitShas: [],
+	createdAt: "2026-08-01T00:00:00Z",
+	modifiedAt: "2026-08-02T00:00:00Z",
+	mergedAt: null,
+	closedAt: null,
+	repositorySshUrl: null,
+	repositoryHttpsUrl: null,
+	repoOwner: null,
+	headRepoIsFork: false,
+	reviewers: [1, 2, 3, 4].map((id) => ({
+		id,
+		login: `reviewer${id}`,
+		name: null,
+		email: null,
+		avatarUrl: null,
+		isBot: false,
+	})),
+	autoMergeEnabled: false,
+	unitSymbol: "#",
+	lastSyncAt: "2026-08-02T00:00:00Z",
+};
+const forge: ForgeInfo = {
+	name: "github",
+	baseUrl: "https://github.com/example/repo",
+	commitUrlPath: "/commit/",
+	prUrlPath: "/pull/",
+	unit: { symbol: "#", name: "pull request", abbr: "PR" },
+	posthogLabel: "",
+	capabilities: {
+		prService: true,
+		checks: true,
+		repoInfo: false,
+		listService: false,
+		reviewComments: true,
+		reviewManagement: false,
+	},
+};
+const author = {
+	id: 5,
+	login: "review-agent",
+	name: null,
+	email: null,
+	avatarUrl: null,
+	isBot: true,
+};
+const submissions: Array<ForgeReviewSubmission> = [
+	{
+		id: 10,
+		author,
+		state: "commented",
+		body: "Please add coverage for pending reviews.",
+		submittedAt: "2026-09-01T00:00:00Z",
+		htmlUrl: review.htmlUrl,
+		reactions: [],
+	},
+];
+const comments: Array<ForgeReviewComment> = [
+	{
+		id: 20,
+		author: { ...author, login: "alice", isBot: false },
+		body: "## 🔵 Needs a closer look\n\nThe keyboard flow needs another pass.",
+		createdAt: "2026-09-02T00:00:00Z",
+		modifiedAt: null,
+		htmlUrl: review.htmlUrl,
+		reactions: [],
+	},
+	{
+		id: 21,
+		author,
+		body: "## 🟡 Changes recommended\n\nPlease review the remaining edge cases.",
+		createdAt: "2026-09-03T00:00:00Z",
+		modifiedAt: null,
+		htmlUrl: review.htmlUrl,
+		reactions: [],
+	},
+];
+const checks: Array<CiCheck> = [
+	{
+		id: 1,
+		name: "Unit tests",
+		output: { summary: "", text: "", title: "" },
+		startedAt: "2026-09-01T00:00:00Z",
+		status: { complete: { conclusion: "success", completed_at: "2026-09-01T00:01:00Z" } },
+		headSha: review.sha,
+		url: review.htmlUrl,
+		htmlUrl: review.htmlUrl,
+		detailsUrl: review.htmlUrl,
+		pullRequests: [],
+		reference: "C",
+		lastSyncAt: "2026-09-01T00:01:00Z",
+	},
+];
+
+export const openReadabilityReview = async (appWindow: Page, electronApp: ElectronApplication) => {
+	await appWindow.setViewportSize({ width: 1440, height: 900 });
+	await electronApp.evaluate(
+		({ ipcMain }, data) => {
+			const responses = {
+				forgeInfo: data.forge,
+				listReviews: [data.review],
+				getReview: data.review,
+				listKnownGithubAccounts: [{ type: "patUsername", info: { username: "test" } }],
+				getReviewMergeStatus: { isMergeable: false, mergeableState: "blocked", commentsCount: 1 },
+				listCiChecks: data.checks,
+				listReviewSubmissions: data.submissions,
+				listReviewComments: data.comments,
+				listReviewThreads: [],
+				listReviewTimelineEvents: [],
+				listReviewReactions: [],
+				currentForgeLogin: "test",
+			};
+			for (const [key, value] of Object.entries(responses)) {
+				ipcMain.removeHandler(key);
+				ipcMain.handle(key, () => value);
+			}
+		},
+		{ review, forge, checks, submissions, comments },
+	);
+	await appWindow.reload();
+	await appWindow
+		.getByRole("treeitem", { name: "C", exact: true })
+		.getByTitle("C", { exact: true })
+		.click();
+};

--- a/apps/lite/e2e/tests/branches-list.spec.ts
+++ b/apps/lite/e2e/tests/branches-list.spec.ts
@@ -1,3 +1,4 @@
+import { enabled, shoot } from "../screenshot-helpers.ts";
 import type { LiteElectronApi } from "../../electron/src/ipc.ts";
 import type { ListedStack } from "@gitbutler/but-sdk";
 import { expect, test } from "../test.ts";
@@ -173,12 +174,10 @@ test.describe("recent branch reviews", () => {
 			"background-color",
 			"rgba(0, 0, 0, 0)",
 		);
-		await expect(branch.getByText(/by octocat/)).toBeVisible();
+		await expect(branch.getByText("octocat", { exact: true })).toBeVisible();
 		await expect(branch.getByText("2 commits", { exact: true })).toBeVisible();
 		await expect(
-			appWindow
-				.getByRole("treeitem", { name: "branch2", exact: true })
-				.getByText("Draft", { exact: true }),
+			appWindow.getByRole("treeitem", { name: "Draft group", exact: true }),
 		).toBeVisible();
 		await expect(
 			appWindow
@@ -240,5 +239,80 @@ test.describe("recent branch reviews", () => {
 		await expect(appWindow.getByText("No branches match", { exact: true })).toBeVisible();
 		await filter.press("Escape");
 		await expect(branch).toBeVisible();
+	});
+});
+
+test.describe("branch state groups", () => {
+	test.use({ scenario: "project-with-remote-branches.sh" });
+	test("keeps open and draft work visible above 27 collapsed merged branches", async ({
+		appWindow,
+		electronApp,
+	}) => {
+		await appWindow.setViewportSize({ width: 1440, height: 900 });
+		const source = await appWindow.evaluate(async () =>
+			(window as unknown as { lite: LiteElectronApi }).lite.branchList(
+				location.pathname.split("/")[2] ?? "",
+			),
+		);
+		const template = source.flatMap((stack) => stack.branches)[0];
+		if (!template) throw new Error("Expected a seeded branch");
+		const stacks: Array<ListedStack> = Array.from({ length: 34 }, (_, index) => {
+			const state = index < 27 ? "merged" : index < 31 ? "open" : index < 33 ? "draft" : null;
+			return {
+				status: "standalone",
+				updatedAtMs: null,
+				branches: [
+					{
+						...template,
+						displayName: `review-pass-${index}`,
+						refName: { full: `refs/heads/review-pass-${index}` },
+						commitCount: 1,
+						reviewStatus: state,
+						review:
+							state === null
+								? null
+								: {
+										title: `Review ${index}`,
+										number: index + 1,
+										htmlUrl: `https://example.com/pull/${index + 1}`,
+										unitSymbol: "#",
+										createdAt: null,
+										author: { login: "octocat", name: null },
+										labels: [],
+									},
+					},
+				],
+			};
+		});
+		await electronApp.evaluate(({ ipcMain }, stacks) => {
+			ipcMain.removeHandler("branchList");
+			ipcMain.handle("branchList", () => stacks);
+		}, stacks);
+		await appWindow.reload();
+		await appWindow
+			.getByRole("group", { name: "Pages" })
+			.getByRole("button", { name: "Branches", exact: true })
+			.click();
+		for (let index = 27; index < 33; index++) {
+			await expect(
+				appWindow.getByRole("treeitem", { name: `review-pass-${index}`, exact: true }),
+			).toBeInViewport();
+		}
+		const merged = appWindow.getByRole("treeitem", { name: "Merged group", exact: true });
+		await expect(merged).toHaveAttribute("aria-expanded", "false");
+		await expect(merged.getByText("27", { exact: true })).toBeVisible();
+		await expect(
+			appWindow.getByRole("treeitem", { name: "review-pass-0", exact: true }),
+		).toHaveCount(0);
+		if (enabled) await shoot(appWindow, "branch-state-groups", "#sidebar-panel");
+		await merged.getByRole("button").click();
+		await expect(merged).toHaveAttribute("aria-expanded", "true");
+		await expect(
+			appWindow.getByRole("treeitem", { name: "review-pass-0", exact: true }),
+		).toBeVisible();
+		await appWindow.getByRole("button", { name: "Author", exact: true }).click();
+		await expect(
+			appWindow.getByRole("treeitem", { name: "octocat group", exact: true }),
+		).toBeVisible();
 	});
 });

--- a/apps/lite/e2e/tests/branches-list.spec.ts
+++ b/apps/lite/e2e/tests/branches-list.spec.ts
@@ -164,13 +164,13 @@ test.describe("recent branch reviews", () => {
 			.click();
 		const branch = appWindow.getByRole("treeitem", { name: "branch1", exact: true });
 		await expect(branch).toHaveAccessibleDescription(
-			/Speed up branch listing in large repositories.*performance.*octocat/,
+			/Speed up branch listing in large repositories.*octocat.*performance/,
 		);
 		await expect(
 			branch.getByText("Speed up branch listing in large repositories", { exact: true }),
 		).toBeVisible();
 		await expect(branch.getByText("performance", { exact: true })).toBeVisible();
-		await expect(branch.getByTitle("needs review", { exact: true })).not.toHaveCSS(
+		await expect(branch.getByText("needs review", { exact: true })).toHaveCSS(
 			"background-color",
 			"rgba(0, 0, 0, 0)",
 		);
@@ -218,6 +218,24 @@ test.describe("recent branch reviews", () => {
 		).toBe("https://example.com/pull/42");
 		await branch.getByTitle("branch1", { exact: true }).click();
 		await expect(branch).toHaveAttribute("aria-selected", "true");
+		await expect
+			.poll(() =>
+				branch.evaluate((element) => {
+					const row = element.matches('[class*="containerSelected"]')
+						? element
+						: element.querySelector('[class*="containerSelected"]');
+					if (!row) return false;
+					const probe = document.createElement("span");
+					probe.style.backgroundColor = "color-mix(in srgb, var(--fill-pop-bg) 10%, transparent)";
+					row.append(probe);
+					const matches =
+						getComputedStyle(row).backgroundColor === getComputedStyle(probe).backgroundColor;
+					probe.remove();
+					return matches;
+				}),
+			)
+			.toBe(true);
+
 		await branch.getByRole("button", { name: "Unfold commits" }).click();
 		await expect(branch).toHaveAttribute("aria-expanded", "true");
 		await expect(branch.getByRole("treeitem", { name: "branch1: second commit" })).toBeVisible();

--- a/apps/lite/e2e/tests/branches-list.spec.ts
+++ b/apps/lite/e2e/tests/branches-list.spec.ts
@@ -170,12 +170,18 @@ test.describe("recent branch reviews", () => {
 			branch.getByText("Speed up branch listing in large repositories", { exact: true }),
 		).toBeVisible();
 		await expect(branch.getByText("performance", { exact: true })).toBeVisible();
-		await expect(branch.getByText("needs review", { exact: true })).toHaveCSS(
+		await expect(branch.getByTitle("needs review", { exact: true })).not.toHaveCSS(
 			"background-color",
 			"rgba(0, 0, 0, 0)",
 		);
 		await expect(branch.getByText("octocat", { exact: true })).toBeVisible();
 		await expect(branch.getByText("2 commits", { exact: true })).toBeVisible();
+		await expect(branch.getByText("Open", { exact: true })).toBeVisible();
+		await expect(
+			appWindow
+				.getByRole("treeitem", { name: "branch2", exact: true })
+				.getByText("Draft", { exact: true }),
+		).toBeVisible();
 		await expect(
 			appWindow.getByRole("treeitem", { name: "Draft group", exact: true }),
 		).toBeVisible();
@@ -296,7 +302,10 @@ test.describe("branch state groups", () => {
 										unitSymbol: "#",
 										createdAt: null,
 										author: { login: "octocat", name: null },
-										labels: [],
+										labels: [
+											{ name: "rust", color: "dea584", description: null },
+											{ name: "@gitbutler/lite", color: "5319e7", description: null },
+										],
 									},
 					},
 				],
@@ -327,6 +336,11 @@ test.describe("branch state groups", () => {
 		await expect(merged).toHaveAttribute("aria-expanded", "true");
 		await expect(
 			appWindow.getByRole("treeitem", { name: "review-pass-0", exact: true }),
+		).toBeVisible();
+		await expect(
+			appWindow
+				.getByRole("treeitem", { name: "review-pass-0", exact: true })
+				.getByText("Merged", { exact: true }),
 		).toBeVisible();
 		await appWindow.getByRole("button", { name: "Author", exact: true }).click();
 		await expect(

--- a/apps/lite/e2e/tests/changes-rail.spec.ts
+++ b/apps/lite/e2e/tests/changes-rail.spec.ts
@@ -1,0 +1,107 @@
+import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import type { LiteElectronApi } from "#electron/ipc.ts";
+import { enabled, openProject, shoot } from "../screenshot-helpers.ts";
+import { expect, test } from "../test.ts";
+
+test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+test("shows change volume in flat and tree lists and folds reviewed folders", async ({
+	appWindow,
+	electronApp,
+}) => {
+	await openProject(appWindow);
+	const sample = await appWindow.evaluate(async () => {
+		const projectId = location.pathname.split("/")[2] ?? "";
+		return (window as unknown as { lite: LiteElectronApi }).lite.branchDiff({
+			projectId,
+			branch: "refs/heads/C",
+		});
+	});
+	const first = sample.changes[0];
+	if (first?.status.type !== "Addition") throw new Error("expected seeded added file");
+	const state = first.status.subject.state;
+	const changes: Array<TreeChange> = Array.from({ length: 34 }, (_, index) => {
+		const name =
+			index === 0
+				? "Graph/usePlan.ts"
+				: index === 1
+					? "src/large.ts"
+					: `src/group-${index % 4}/file-${index}.ts`;
+		return {
+			path: name,
+			pathBytes: Array.from(Buffer.from(name)),
+			status:
+				index < 30
+					? { type: "Modification", subject: { previousState: state, state, flags: null } }
+					: index < 33
+						? { type: "Addition", subject: { state, isUntracked: false } }
+						: { type: "Deletion", subject: { previousState: state } },
+		};
+	});
+	const patches: Record<string, UnifiedPatch> = Object.fromEntries<UnifiedPatch>(
+		changes.map((change, index): [string, UnifiedPatch] => {
+			if (index === 2) return [change.path, { type: "Binary" }];
+			const added = index === 1 ? 120 : index === 33 ? 0 : 1;
+			const removed = index < 30 || index === 33 ? 1 : 0;
+			return [
+				change.path,
+				{
+					type: "Patch",
+					subject: {
+						isResultOfBinaryToTextConversion: false,
+						linesAdded: added,
+						linesRemoved: removed,
+						hunks: [
+							{
+								oldStart: removed > 0 ? 1 : 0,
+								oldLines: removed,
+								newStart: added > 0 ? 1 : 0,
+								newLines: added,
+								diff: `@@ -${removed > 0 ? 1 : 0},${removed} +${added > 0 ? 1 : 0},${added} @@\n${removed > 0 ? "-before\n" : ""}${"+after\n".repeat(added)}`,
+							},
+						],
+					},
+				},
+			];
+		}),
+	);
+	await electronApp.evaluate(
+		({ ipcMain }, { sample, changes, patches }) => {
+			ipcMain.removeHandler("branchDiff");
+			ipcMain.handle("branchDiff", () => ({ ...sample, changes }));
+			ipcMain.removeHandler("treeChangeDiffs");
+			ipcMain.handle(
+				"treeChangeDiffs",
+				(_event, { change }: { change: TreeChange }) => patches[change.path],
+			);
+		},
+		{ sample, changes, patches },
+	);
+	await appWindow.reload();
+	const details = appWindow.locator("#details-panel");
+	await expect(details.getByText("34 files", { exact: true })).toBeVisible();
+	await details.getByRole("button", { name: "Flat", exact: true }).click();
+	await details
+		.getByRole("tree")
+		.evaluate((tree) => tree.parentElement?.scrollTo({ top: tree.parentElement.scrollHeight }));
+	const largest = details.getByRole("treeitem", { name: "Modification src/large.ts", exact: true });
+	await expect(largest.getByText("+120", { exact: true })).toBeVisible();
+	await expect(largest.getByLabel("Modification", { exact: true })).toHaveCount(0);
+	await details.getByRole("button", { name: "Tree", exact: true }).click();
+	await details.getByRole("tree").evaluate((tree) => tree.parentElement?.scrollTo({ top: 0 }));
+	await expect(details.getByText("Graph/usePlan.ts", { exact: true })).toBeVisible();
+	const folder = details.getByRole("treeitem", { name: "Directory src", exact: true });
+	await expect(folder.getByText("33", { exact: true })).toBeVisible();
+	await expect(folder.getByText("+150", { exact: true })).toBeVisible();
+	await details.getByRole("button", { name: "Mark all reviewed", exact: true }).click();
+	await expect(folder).toHaveAttribute("aria-expanded", "false");
+	if (enabled) await shoot(appWindow, "changes-rail", "#details-panel");
+	await folder.getByRole("button", { name: "Expand directory src", exact: true }).click();
+	await expect(folder).toHaveAttribute("aria-expanded", "true");
+	await appWindow.reload();
+	await expect(details.getByRole("button", { name: "Tree", exact: true })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await expect(folder).toHaveAttribute("aria-expanded", "false");
+});

--- a/apps/lite/e2e/tests/diff-readability.spec.ts
+++ b/apps/lite/e2e/tests/diff-readability.spec.ts
@@ -1,0 +1,67 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { enabled, openProject, shoot } from "../screenshot-helpers.ts";
+import { expect, test } from "../test.ts";
+
+test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+test("reads both sides of a replacement, wraps and scrolls long lines, and tracks review progress", async ({
+	appWindow,
+	testEnvironment,
+}) => {
+	await openProject(appWindow);
+	const longLine = `const value = "${"long-token-".repeat(100)}";`;
+	writeFileSync(
+		path.join(testEnvironment.workdir, "local-clone", "base.txt"),
+		`${longLine}\nsecond line\n`,
+	);
+	await appWindow.reload();
+	await appWindow
+		.locator("#sidebar-panel")
+		.getByRole("treeitem", { name: "Modification base.txt", exact: true })
+		.click();
+	const details = appWindow.locator("#details-panel");
+	await details.getByRole("button", { name: "Unified", exact: true }).click();
+	const oldNumbers = details.locator('[data-gitbutler-line-number="old"]');
+	const newNumbers = details.locator('[data-gitbutler-line-number="new"]');
+	await expect(oldNumbers).toHaveText(["1", "·", "·"]);
+	await expect(newNumbers).toHaveText(["·", "1", "2"]);
+	const line = details.locator('[data-line-type="change-addition"][data-line]').first();
+	await expect(line).toHaveText(longLine);
+	await expect(line).toHaveCSS("white-space", "pre-wrap");
+	await expect
+		.poll(() => line.evaluate((el) => el.getBoundingClientRect().height))
+		.toBeGreaterThan(40);
+	await expect(line).toHaveCSS("overflow-wrap", "anywhere");
+	await details.getByRole("button", { name: "Scroll", exact: true }).click();
+	await expect(line).toHaveCSS("white-space", "pre");
+	expect(
+		await line.evaluate((el) => {
+			let ancestor = el.parentElement;
+			while (ancestor && ancestor.scrollWidth <= ancestor.clientWidth)
+				ancestor = ancestor.parentElement;
+			if (!ancestor) return false;
+			ancestor.scrollLeft = ancestor.scrollWidth;
+			return ancestor.scrollLeft > 0;
+		}),
+	).toBe(true);
+	await appWindow.reload();
+	await expect(details.getByRole("button", { name: "Scroll", exact: true })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	const progress = details.getByRole("progressbar", { name: "Files reviewed" });
+	await expect(progress).toHaveAttribute("aria-valuenow", "0");
+	await details.getByRole("button", { name: "Mark all reviewed", exact: true }).click();
+	await expect(progress).toHaveAttribute("aria-valuenow", "1");
+	await details.getByRole("button", { name: "Reviewed", exact: true }).click();
+	await expect(progress).toHaveAttribute("aria-valuenow", "0");
+	if (enabled) {
+		await details.getByRole("button", { name: "Wrap", exact: true }).click();
+		const grayscale = await appWindow.addStyleTag({
+			content: "#details-panel { filter: grayscale(1); }",
+		});
+		await shoot(appWindow, "replacement-grayscale", "#details-panel");
+		await grayscale.evaluate((element) => element.parentNode?.removeChild(element));
+	}
+});

--- a/apps/lite/e2e/tests/pr-readability.spec.ts
+++ b/apps/lite/e2e/tests/pr-readability.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "../test.ts";
+import { openReadabilityReview } from "../pr-readability-fixture.ts";
+
+test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+test("makes merge blockers visible and moves verdict headings to bylines", async ({
+	appWindow,
+	electronApp,
+}) => {
+	await openReadabilityReview(appWindow, electronApp);
+	const merge = appWindow.getByRole("button", { name: "Merge", exact: true });
+	await expect(merge).toBeDisabled();
+	await expect(
+		appWindow.getByText("Changes recommended · 4 reviews pending", { exact: true }),
+	).toBeInViewport();
+	const readiness = appWindow.getByRole("region", { name: "Merge readiness" });
+	await expect(readiness.getByText("Blocked on review", { exact: true })).toBeInViewport();
+	await expect(readiness.getByText("Checks passed", { exact: true })).toBeVisible();
+	await expect(
+		appWindow.getByText("The keyboard flow needs another pass.", { exact: true }),
+	).toBeVisible();
+	await expect(
+		appWindow.getByRole("heading", { name: /Needs a closer look|Changes recommended/ }),
+	).toHaveCount(0);
+	await expect(
+		appWindow.locator('[data-verdict="pop"]').getByText("Needs a closer look", { exact: true }),
+	).toBeVisible();
+	await electronApp.evaluate(({ ipcMain }) => {
+		ipcMain.removeHandler("getReviewMergeStatus");
+		ipcMain.handle("getReviewMergeStatus", () => ({
+			isMergeable: true,
+			mergeableState: "clean",
+			commentsCount: 1,
+		}));
+	});
+	await appWindow.reload();
+	await expect(merge).toBeEnabled();
+	await expect(readiness.getByText("Ready to merge", { exact: true })).toBeVisible();
+	await expect(
+		appWindow.getByText("Changes recommended · 4 reviews pending", { exact: true }),
+	).toHaveCount(0);
+});

--- a/apps/lite/e2e/tests/pr-readability.spec.ts
+++ b/apps/lite/e2e/tests/pr-readability.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "../test.ts";
-import { openReadabilityReview } from "../pr-readability-fixture.ts";
+import { openReadabilityReview, review } from "../pr-readability-fixture.ts";
 
 test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
 test("makes merge blockers visible and moves verdict headings to bylines", async ({
@@ -38,4 +38,71 @@ test("makes merge blockers visible and moves verdict headings to bylines", async
 	await expect(
 		appWindow.getByText("Changes recommended · 4 reviews pending", { exact: true }),
 	).toHaveCount(0);
+});
+
+test("keeps the description readable, fills the rail, and separates audience from density", async ({
+	appWindow,
+	electronApp,
+}) => {
+	await openReadabilityReview(appWindow, electronApp);
+	const description = appWindow
+		.getByRole("heading", { name: review.title, exact: true })
+		.locator("..");
+	await expect(description.getByRole("button", { name: "Show more", exact: true })).toHaveCount(0);
+	const prose = description
+		.getByText("This change makes pull request reviews easier to read.", { exact: true })
+		.locator("..");
+	await expect(prose).toHaveCSS("font-size", "14px");
+	await expect(prose).toHaveCSS("line-height", "22.4px");
+	const files = appWindow.getByRole("region", { name: "Files changed", exact: true });
+	await expect(files.getByTitle("src/file-0.ts", { exact: true })).toBeVisible();
+	await expect(files.getByRole("button", { name: "4 more", exact: true })).toBeVisible();
+	await files.getByRole("button", { name: "4 more", exact: true }).click();
+	await expect(files.getByTitle("src/file-11.ts", { exact: true })).toHaveCount(1);
+	const panel = files.locator("..");
+	const scroll = appWindow.locator('[class*="prTabScroll"]');
+	const panelBox = await panel.boundingBox();
+	const scrollBox = await scroll.boundingBox();
+	if (!panelBox || !scrollBox) throw new Error("Expected PR panel bounds");
+	expect(
+		Math.abs(panelBox.y + panelBox.height - (scrollBox.y + scrollBox.height - 24)),
+	).toBeLessThan(3);
+	await expect(panel.getByRole("heading", { name: "Owners", exact: true })).toBeVisible();
+	await expect(panel.getByText("@gitbutler/lite", { exact: true })).toHaveCSS(
+		"font-family",
+		'"Geist Mono", monospace',
+	);
+	await expect(panel.getByRole("heading", { name: "Topics", exact: true })).toBeVisible();
+	const audience = appWindow.getByRole("group", { name: "Activity audience" });
+	await expect(audience.getByRole("button", { name: "All", exact: true })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await audience.getByRole("button", { name: "Humans", exact: true }).click();
+	await expect(
+		appWindow.getByText("The keyboard flow needs another pass.", { exact: true }),
+	).toBeVisible();
+	await expect(
+		appWindow.getByText("Please add coverage for pending reviews.", { exact: true }),
+	).toHaveCount(0);
+	const compact = appWindow.getByRole("button", { name: "Compact", exact: true });
+	await compact.click();
+	await expect(compact).toHaveAttribute("aria-pressed", "true");
+	await audience.getByRole("button", { name: "Agents", exact: true }).click();
+	await expect(
+		appWindow.getByText("Please add coverage for pending reviews.", { exact: true }),
+	).toBeVisible();
+	await expect(
+		appWindow.getByText("The keyboard flow needs another pass.", { exact: true }),
+	).toHaveCount(0);
+	await expect(compact).toHaveAttribute("aria-pressed", "true");
+	await electronApp.evaluate(({ ipcMain }, review) => {
+		ipcMain.removeHandler("listReviews");
+		ipcMain.handle("listReviews", () => [
+			{ ...review, body: `${"A paragraph of review context.\n\n".repeat(20)}Final paragraph.` },
+		]);
+	}, review);
+	await appWindow.reload();
+	await description.getByRole("button", { name: "Show more", exact: true }).click();
+	await expect(description.getByText("Final paragraph.", { exact: true })).toBeVisible();
 });

--- a/apps/lite/e2e/tests/workspace-focus.spec.ts
+++ b/apps/lite/e2e/tests/workspace-focus.spec.ts
@@ -73,7 +73,9 @@ test.describe("workspace focus", () => {
 			.toBe("uncommitted-files");
 	});
 
-	test("only the focused details child uses focused selection styling", async ({ appWindow }) => {
+	test("moves focus between details children without changing selection styling", async ({
+		appWindow,
+	}) => {
 		await appWindow.getByRole("treeitem", { name: "C: first commit" }).click();
 
 		const toggleFiles = appWindow.getByRole("button", { name: "Toggle files" });
@@ -97,8 +99,12 @@ test.describe("workspace focus", () => {
 			.poll(async () => (blurredBackground = await selectedFileBackground()))
 			.not.toBe("");
 		await files.focus();
-		await expect.poll(selectedFileBackground).not.toBe(blurredBackground);
+		await expect(files).toBeFocused();
+		await expect(files).toHaveAttribute("data-selection-focused", "true");
+		await expect.poll(selectedFileBackground).toBe(blurredBackground);
 		await diff.focus();
+		await expect(diff).toBeFocused();
+		await expect(files).not.toHaveAttribute("data-selection-focused", "true");
 		await expect.poll(selectedFileBackground).toBe(blurredBackground);
 	});
 
@@ -143,7 +149,7 @@ test.describe("workspace focus", () => {
 		await appWindow.keyboard.press("ControlOrMeta+K");
 		await expect(appWindow.getByRole("dialog", { name: "Command palette" })).toBeVisible();
 		await expect(appWindow.locator("[data-selection-focused]")).toHaveCount(0);
-		await expect.poll(commitBackground).not.toBe(focusedBackground);
+		await expect.poll(commitBackground).toBe(focusedBackground);
 
 		await appWindow.keyboard.press("Escape");
 		await expect(appWindow.getByRole("dialog", { name: "Command palette" })).not.toBeVisible();

--- a/apps/lite/e2e/tests/workspace-reviews.spec.ts
+++ b/apps/lite/e2e/tests/workspace-reviews.spec.ts
@@ -107,6 +107,24 @@ test("shows PR titles and labels on workspace branches without hover shifts", as
 	await expect(branch.getByRole("button", { name: "Branch menu", exact: true })).toBeVisible();
 	expect(await headline.boundingBox()).toEqual(before);
 	await branch.getByTitle("C", { exact: true }).click();
+	await expect
+		.poll(() =>
+			branch.evaluate((element) => {
+				const row = element.matches('[class*="containerSelected"]')
+					? element
+					: element.querySelector('[class*="containerSelected"]');
+				if (!row) return false;
+				const probe = document.createElement("span");
+				probe.style.backgroundColor = "color-mix(in srgb, var(--fill-pop-bg) 10%, transparent)";
+				row.append(probe);
+				const matches =
+					getComputedStyle(row).backgroundColor === getComputedStyle(probe).backgroundColor;
+				probe.remove();
+				return matches;
+			}),
+		)
+		.toBe(true);
+
 	await appWindow.keyboard.press("F2");
 	const editor = branch.getByRole("textbox", { name: "Branch name" });
 	await expect(editor).toHaveValue("C");

--- a/apps/lite/e2e/tests/workspace-reviews.spec.ts
+++ b/apps/lite/e2e/tests/workspace-reviews.spec.ts
@@ -97,6 +97,10 @@ test("shows PR titles and labels on workspace branches without hover shifts", as
 	await expect(branch).toHaveAccessibleDescription(
 		/Improve keyboard navigation.*accessibility.*@gitbutler\/lite/,
 	);
+	await expect(branch.getByTitle("@gitbutler/lite", { exact: true })).not.toHaveCSS(
+		"background-color",
+		"rgba(0, 0, 0, 0)",
+	);
 	await expect(
 		branch.getByTitle("C", { exact: true }).locator("..").locator("[data-icon]"),
 	).toBeVisible();

--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -22,6 +22,7 @@ const guiSettingsV1 = type({
 	"diffFontFamily?": "string",
 	"diffFontSize?": "number",
 	"diffLigatures?": "boolean",
+	"branchGrouping?": "'state' | 'author' | 'recent'",
 	"diffOverflow?": "'scroll' | 'wrap'",
 	"diffStyle?": '"unified" | "split"',
 	"diffTabSize?": "number",

--- a/apps/lite/ui/src/branch.test.ts
+++ b/apps/lite/ui/src/branch.test.ts
@@ -1,3 +1,4 @@
+import { branchReviewPresentation } from "./branch.ts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -287,5 +288,37 @@ describe("branch list sections", () => {
 				.map((section) => section.group?.label),
 		).toEqual(["alice", "Unknown author"]);
 		expect(branchListSections(input, "recent", {})).toHaveLength(1);
+	});
+});
+
+describe("branch review presentation", () => {
+	it("extracts only known initial bracketed prefixes and limits actions to one", () => {
+		expect(
+			branchReviewPresentation("[DO NOT REVIEW] Jt/lifetime", [
+				{ name: "screenshots needed" },
+				{ name: "rust" },
+			]),
+		).toEqual({ title: "Jt/lifetime", action: "Do not review", topics: [{ name: "rust" }] });
+		expect(branchReviewPresentation("Title [do not review]", [])).toMatchObject({
+			title: "Title [do not review]",
+			action: undefined,
+		});
+		expect(branchReviewPresentation("[unknown] Title", [])).toMatchObject({
+			title: "[unknown] Title",
+			action: undefined,
+		});
+	});
+	it("normalizes actionable labels while preserving topic text", () => {
+		expect(
+			branchReviewPresentation("Title", [
+				{ name: "Screenshots Needed" },
+				{ name: "CLI" },
+				{ name: "@gitbutler/lite" },
+			]),
+		).toEqual({
+			title: "Title",
+			action: "Screenshots needed",
+			topics: [{ name: "CLI" }, { name: "@gitbutler/lite" }],
+		});
 	});
 });

--- a/apps/lite/ui/src/branch.test.ts
+++ b/apps/lite/ui/src/branch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	activeBranchFilterCount,
+	branchListSections,
 	branchDetailsParams,
 	branchIsEmpty,
 	branchOwnCommits,
@@ -236,5 +237,55 @@ describe("branchDetailsParams", () => {
 			branchName: "feature/login",
 			remote: null,
 		});
+	});
+});
+
+describe("branch list sections", () => {
+	const withReview = (name: string, state: "open" | "draft" | "merged") =>
+		branch({
+			displayName: name,
+			reviewStatus: state,
+			review: {
+				title: name,
+				number: 1,
+				htmlUrl: "https://example.com/1",
+				unitSymbol: "#",
+				createdAt: null,
+				author: { login: "alice", name: null },
+				labels: [],
+			},
+		});
+	it("orders states and keeps merged work behind its collapsed header", () => {
+		const result = branchListSections(
+			[
+				stack([
+					withReview("merged", "merged"),
+					branch({ displayName: "bare" }),
+					withReview("draft", "draft"),
+					withReview("open", "open"),
+				]),
+			],
+			"state",
+			{},
+		);
+		expect(
+			result.map((section) => section.group?.label ?? section.branches[0]?.branch.displayName),
+		).toEqual(["Open", "open", "Draft", "draft", "No pull request", "bare", "Merged"]);
+		expect(result.at(-1)?.group).toMatchObject({ count: 1, collapsed: true });
+		const open = result.find((section) => section.branches[0]?.branch.displayName === "open");
+		expect(open?.branches[0]).toMatchObject({ isStacked: true, isTopBranch: false });
+	});
+	it("can expand merged work and group by author without losing bare branches", () => {
+		const input = [stack([withReview("merged", "merged"), branch({ displayName: "bare" })])];
+		expect(
+			branchListSections(input, "state", { "state:merged": false }).at(-1)?.branches[0]?.branch
+				.displayName,
+		).toBe("merged");
+		expect(
+			branchListSections(input, "author", {})
+				.filter((section) => section.group)
+				.map((section) => section.group?.label),
+		).toEqual(["alice", "Unknown author"]);
+		expect(branchListSections(input, "recent", {})).toHaveLength(1);
 	});
 });

--- a/apps/lite/ui/src/branch.ts
+++ b/apps/lite/ui/src/branch.ts
@@ -128,3 +128,85 @@ export const branchDetailsParams = (
 		? { branchName, remote }
 		: { branchName: refName.replace(/^refs\/heads\//, ""), remote: null };
 };
+
+export type BranchGrouping = "state" | "author" | "recent";
+export type BranchListGroup = { key: string; label: string; count: number; collapsed: boolean };
+type GroupedBranch = { branch: ListedBranch; isTopBranch: boolean; isStacked: boolean };
+type BranchListSection = {
+	key: string;
+	group?: BranchListGroup;
+	branches: Array<GroupedBranch>;
+	grouped: boolean;
+};
+
+export const branchListSections = (
+	stacks: Array<ListedStack>,
+	grouping: BranchGrouping,
+	collapsedGroups: Record<string, boolean>,
+): Array<BranchListSection> => {
+	const entries = stacks.map((stack) =>
+		stack.branches.map((branch, index) => ({
+			branch,
+			isTopBranch: index === 0,
+			isStacked: stack.branches.length > 1,
+		})),
+	);
+	if (grouping === "recent") {
+		return entries.flatMap((branches) => {
+			const first = branches[0];
+			return first ? [{ key: first.branch.refName.full, branches, grouped: false }] : [];
+		});
+	}
+	const labels: Record<string, string> = {
+		open: "Open",
+		draft: "Draft",
+		none: "No pull request",
+		merged: "Merged",
+		closed: "Closed",
+	};
+	const groups = new Map<string, Array<GroupedBranch>>();
+	for (const stack of entries) {
+		for (const entry of stack) {
+			const value =
+				grouping === "state"
+					? (entry.branch.reviewStatus ?? "none")
+					: (entry.branch.review?.author?.login ??
+						entry.branch.lastAuthor?.name ??
+						"Unknown author");
+			const members = groups.get(value);
+			if (members) members.push(entry);
+			else groups.set(value, [entry]);
+		}
+	}
+	const keys =
+		grouping === "state"
+			? Object.keys(labels).filter((key) => groups.has(key))
+			: Array.from(groups.keys()).sort((a, b) => a.localeCompare(b));
+	return keys.flatMap((value): Array<BranchListSection> => {
+		const branches = groups.get(value);
+		if (!branches) return [];
+		const key = `${grouping}:${value}`;
+		const collapsed =
+			collapsedGroups[key] ?? (grouping === "state" && (value === "merged" || value === "closed"));
+		return [
+			{
+				key,
+				group: {
+					key,
+					label: grouping === "state" ? (labels[value] ?? value) : value,
+					count: branches.length,
+					collapsed,
+				},
+				branches: [],
+				grouped: true,
+			},
+			...(collapsed
+				? []
+				: branches.map((entry) => ({
+						key: entry.branch.refName.full,
+						branches: [entry],
+						grouped: true,
+					}))),
+		];
+	});
+};

--- a/apps/lite/ui/src/branch.ts
+++ b/apps/lite/ui/src/branch.ts
@@ -210,3 +210,30 @@ export const branchListSections = (
 		];
 	});
 };
+
+type BranchAction = "Screenshots needed" | "Do not review";
+const branchAction = (value: string): BranchAction | undefined => {
+	switch (value.toLowerCase()) {
+		case "screenshots needed":
+			return "Screenshots needed";
+		case "do not review":
+			return "Do not review";
+		default:
+			return undefined;
+	}
+};
+
+export const branchReviewPresentation = <T extends { name: string }>(
+	title: string,
+	labels: ReadonlyArray<T> = [],
+) => {
+	const prefix = /^\[(do not review|screenshots needed)\]\s*/i.exec(title);
+	const action = prefix
+		? branchAction(prefix[1] ?? "")
+		: labels.map((label) => branchAction(label.name)).find(Boolean);
+	return {
+		title: prefix ? title.slice(prefix[0].length) : title,
+		action,
+		topics: labels.filter((label) => branchAction(label.name) === undefined),
+	};
+};

--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -5,19 +5,6 @@
 	min-width: 16px;
 	border-radius: 30px;
 	--badge-bg-opacity: 20%;
-
-	/* Selected rows set --selection-inverted; flipping to the opposite color
-	   scheme makes every light-dark() token inside the badge resolve to its
-	   inverted value, matching the row's inverted selection background. */
-	@container style(--selection-inverted: true) {
-		--badge-bg-opacity: 40%;
-		color-scheme: dark;
-
-		@media (prefers-color-scheme: dark) {
-			color-scheme: light;
-			--badge-bg-opacity: 20%;
-		}
-	}
 }
 
 .regular {

--- a/apps/lite/ui/src/components/DiffStats.tsx
+++ b/apps/lite/ui/src/components/DiffStats.tsx
@@ -17,7 +17,7 @@ export const DiffStats: FC<Props> = ({ added, removed, ...props }) => {
 	return (
 		<span {...props} className={classes(props.className, styles.container)}>
 			{added > 0 && <span className={styles.added}>+{added}</span>}
-			{removed > 0 && <span className={styles.removed}>-{removed}</span>}
+			{removed > 0 && <span className={styles.removed}>−{removed}</span>}
 		</span>
 	);
 };

--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -2,17 +2,6 @@
 	display: flex;
 
 	color: var(--commit-status-color);
-
-	/* Selected rows set --selection-inverted; flipping to the opposite color
-	   scheme resolves the line tokens to their inverted values, so the rail
-	   stays legible against the row's inverted selection background. */
-	@container style(--selection-inverted: true) {
-		color-scheme: dark;
-
-		@media (prefers-color-scheme: dark) {
-			color-scheme: light;
-		}
-	}
 }
 
 /* A stretch of the rail in another status's colour; without one, the glyph's. */

--- a/apps/lite/ui/src/components/Markdown.tsx
+++ b/apps/lite/ui/src/components/Markdown.tsx
@@ -189,8 +189,8 @@ const remarkLiteralTags = () => {
  *   request logs to authors, so they can't track viewers); any other host
  *   renders as a link and is never fetched. See {@link isGitHubHostedImage}.
  */
-export const Markdown: FC<{ children: string }> = ({ children }) => (
-	<div className={classes("text-13", "text-body", styles.markdown)}>
+export const Markdown: FC<{ children: string; className?: string }> = ({ children, className }) => (
+	<div className={classes("text-13", "text-body", styles.markdown, className)}>
 		<ReactMarkdown
 			remarkPlugins={[remarkGfm, remarkGemoji, remarkLiteralTags]}
 			rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}

--- a/apps/lite/ui/src/components/ToggleGroup.module.css
+++ b/apps/lite/ui/src/components/ToggleGroup.module.css
@@ -38,3 +38,24 @@
 		border-end-start-radius: 0;
 	}
 }
+
+.segmented {
+	padding: 2px;
+	border-radius: 4px;
+	background: var(--bg-mute);
+
+	.item {
+		border: 0;
+		border-radius: 3px;
+		background: transparent;
+		color: var(--text-2);
+		white-space: nowrap;
+
+		&[data-pressed] {
+			background: var(--bg-1);
+			box-shadow: var(--shadow-card);
+			color: var(--text-1);
+			font-weight: 600;
+		}
+	}
+}

--- a/apps/lite/ui/src/components/ToggleGroup.stories.tsx
+++ b/apps/lite/ui/src/components/ToggleGroup.stories.tsx
@@ -152,3 +152,20 @@ export const MultipleSelectionIconOnly = meta.story({
 		</ToggleGroup>
 	),
 });
+
+export const Segmented = meta.story({
+	render: () => (
+		<ToggleGroup
+			render={<ToggleGroupStyles segmented />}
+			defaultValue={["wrap"]}
+			aria-label="Line wrapping"
+		>
+			<Toggle render={<ToggleStyles />} value="wrap">
+				Wrap
+			</Toggle>
+			<Toggle render={<ToggleStyles />} value="scroll">
+				Scroll
+			</Toggle>
+		</ToggleGroup>
+	),
+});

--- a/apps/lite/ui/src/components/ToggleGroup.tsx
+++ b/apps/lite/ui/src/components/ToggleGroup.tsx
@@ -4,8 +4,14 @@ import styles from "./ToggleGroup.module.css";
 import type { ComponentProps, FC } from "react";
 
 /** @public */
-export const ToggleGroupStyles: FC<ComponentProps<"div">> = (props) => (
-	<div {...props} className={classes(props.className, styles.group)} />
+export const ToggleGroupStyles: FC<ComponentProps<"div"> & { segmented?: boolean }> = ({
+	segmented,
+	...props
+}) => (
+	<div
+		{...props}
+		className={classes(props.className, styles.group, segmented && styles.segmented)}
+	/>
 );
 
 /** @public */

--- a/apps/lite/ui/src/pr.test.ts
+++ b/apps/lite/ui/src/pr.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { mergeReadiness, reviewVerdictBody, reviewReadinessVerdicts } from "./pr.ts";
+
+describe("review verdict headings", () => {
+	it("moves a known leading heading into metadata while preserving prose", () => {
+		expect(reviewVerdictBody("## 🟡 Changes recommended\n\nKeep this prose.")).toEqual({
+			body: "Keep this prose.",
+			badge: { label: "Changes recommended", variant: "warn" },
+		});
+		expect(reviewVerdictBody("🔵 Needs a closer look\nDetails").badge?.variant).toBe("pop");
+		expect(reviewVerdictBody("### ✅ Approved\nLooks good").badge?.variant).toBe("safe");
+	});
+	it("preserves unrecognized and non-leading headings", () => {
+		const body = "Intro\n## 🟡 Changes recommended\nDetails";
+		expect(reviewVerdictBody(body)).toEqual({ body, badge: undefined });
+		expect(reviewVerdictBody("## Other verdict\nDetails").body).toBe("## Other verdict\nDetails");
+	});
+});
+
+describe("merge readiness", () => {
+	const review = { draft: false, mergedAt: null, closedAt: null, reviewers: [] };
+	it("leaves merge authorization with the forge even with requested reviewers", () => {
+		const ready = mergeReadiness(
+			{ ...review, reviewers: [{}] },
+			{ isMergeable: true, mergeableState: "clean" },
+			"success",
+			["approved"],
+		);
+		expect(ready.ready).toBe(true);
+		expect(ready.blocker).toBeNull();
+		expect(ready.rows.map((row) => row.label)).toContain("1 review pending");
+	});
+	it("names review blockers and does not infer clean conflicts from blocked status", () => {
+		const result = mergeReadiness(
+			{ ...review, reviewers: [{}, {}, {}, {}] },
+			{ isMergeable: false, mergeableState: "blocked" },
+			"success",
+			["changesRequested"],
+		);
+		expect(result.headline).toBe("Blocked on review");
+		expect(result.blocker).toBe("Changes recommended · 4 reviews pending");
+		expect(result.rows.at(-1)).toEqual({ label: "Conflicts not reported", tone: "pending" });
+	});
+	it("reports unknown, conflicts, draft, and additional backend restrictions truthfully", () => {
+		expect(mergeReadiness(review, undefined, undefined, []).ready).toBe(false);
+		expect(mergeReadiness(review, undefined, undefined, []).blocker).toBe("Checking mergeability…");
+		expect(
+			mergeReadiness(review, { isMergeable: false, mergeableState: "dirty" }, "success", [])
+				.blocker,
+		).toBe("Merge conflicts with the base branch");
+		expect(mergeReadiness({ ...review, draft: true }, undefined, undefined, []).blocker).toBe(
+			"Draft pull requests cannot be merged",
+		);
+		expect(
+			mergeReadiness(review, { isMergeable: false, mergeableState: "behind" }, "success", [])
+				.blocker,
+		).toBe("Behind the base branch; update the branch first");
+	});
+});
+
+describe("readiness from review activity", () => {
+	const author = { id: 1, login: "agent", name: null, email: null, avatarUrl: null, isBot: true };
+	it("includes ordinary comment verdicts and lets a later formal approval supersede them", () => {
+		const comments = [
+			{
+				id: 1,
+				author,
+				body: "## 🟡 Changes recommended\nFix this.",
+				createdAt: "2026-09-01T00:00:00Z",
+				modifiedAt: null,
+			},
+		];
+		expect(reviewReadinessVerdicts([], comments)).toEqual(["changesRequested"]);
+		expect(
+			reviewReadinessVerdicts(
+				[{ id: 2, author, state: "approved", body: null, submittedAt: "2026-09-02T00:00:00Z" }],
+				comments,
+			),
+		).toEqual(["approved"]);
+	});
+	it("keeps only the latest heading per author and ignores ordinary prose", () => {
+		expect(
+			reviewReadinessVerdicts(
+				[],
+				[
+					{
+						id: 2,
+						author,
+						body: "🔵 Needs a closer look\nDetails",
+						createdAt: "2026-09-02T00:00:00Z",
+						modifiedAt: null,
+					},
+					{
+						id: 1,
+						author,
+						body: "🟡 Changes recommended\nDetails",
+						createdAt: "2026-09-01T00:00:00Z",
+						modifiedAt: null,
+					},
+					{
+						id: 3,
+						author,
+						body: "Thanks for the update.",
+						createdAt: "2026-09-03T00:00:00Z",
+						modifiedAt: null,
+					},
+				],
+			),
+		).toEqual(["needsCloserLook"]);
+	});
+});

--- a/apps/lite/ui/src/pr.ts
+++ b/apps/lite/ui/src/pr.ts
@@ -1,5 +1,23 @@
-import { forgeInfoOptions, getReviewQueryOptions } from "#ui/api/queries.ts";
-import type { ForgeInfo, ReviewMergeMethod } from "@gitbutler/but-sdk";
+import type { AggregateCIStatus } from "./ci.ts";
+import { loginKey } from "./review-users.ts";
+import { Match } from "effect";
+import {
+	forgeInfoOptions,
+	getReviewQueryOptions,
+	getReviewMergeStatusQueryOptions,
+	listCIChecksQueryOptions,
+	listReviewCommentsQueryOptions,
+	listReviewSubmissionsQueryOptions,
+} from "#ui/api/queries.ts";
+import type {
+	ForgeInfo,
+	ForgeReview,
+	ForgeReviewSubmission,
+	ForgeReviewComment,
+	ForgeReviewUser,
+	ReviewMergeStatus,
+	ReviewMergeMethod,
+} from "@gitbutler/but-sdk";
 import { type QueryClient, queryOptions, useMutation, useQuery } from "@tanstack/react-query";
 import * as idb from "idb-keyval";
 
@@ -143,3 +161,259 @@ export const useDeleteDraftPR = () =>
 				null,
 			),
 	});
+
+/** Dismissals collapse to "commented", so they never appear as a verdict. */
+export type ReviewerVerdict = "approved" | "changesRequested" | "commented" | "awaiting";
+
+export type ReviewerRow = { user: ForgeReviewUser; verdict: ReviewerVerdict };
+
+/**
+ * One row per reviewer: everyone still requested (awaiting) plus everyone
+ * who submitted a review, carrying their effective verdict. A comment-only
+ * submission never overrides an earlier approval or change request, and a
+ * dismissal drops the verdict back to commented.
+ */
+export const reviewerRows = (
+	requested: Array<ForgeReviewUser>,
+	submissions: Array<ForgeReviewSubmission>,
+): Array<ReviewerRow> => {
+	const byLogin = new Map<string, ReviewerRow>();
+	for (const submission of submissions) {
+		if (submission.author === null) continue;
+		const existing = byLogin.get(loginKey(submission.author.login));
+		const verdict = Match.value(submission.state).pipe(
+			Match.withReturnType<ReviewerVerdict>(),
+			Match.when("approved", () => "approved"),
+			Match.when("changesRequested", () => "changesRequested"),
+			Match.when("commented", () => existing?.verdict ?? "commented"),
+			Match.when("dismissed", () => "commented"),
+			Match.exhaustive,
+		);
+		byLogin.set(loginKey(submission.author.login), { user: submission.author, verdict });
+	}
+	for (const user of requested) {
+		const key = loginKey(user.login);
+		if (!byLogin.has(key)) byLogin.set(key, { user, verdict: "awaiting" });
+	}
+	return [...byLogin.values()];
+};
+
+/** Why the Merge button is disabled, or null when merging is possible. */
+const mergeBlockedReason = (
+	mergeStatus: Pick<ReviewMergeStatus, "isMergeable" | "mergeableState"> | undefined,
+): string | null => {
+	if (mergeStatus === undefined) return "Checking mergeability…";
+	if (mergeStatus.isMergeable) return null;
+
+	switch (mergeStatus.mergeableState) {
+		case "blocked":
+			return "Blocked: required approvals or checks are not satisfied";
+		case "behind":
+			return "Behind the base branch; update the branch first";
+		case "dirty":
+			return "Merge conflicts with the base branch";
+		case "draft":
+			return "Draft pull requests cannot be merged";
+		case "unknown":
+		case "checking":
+		case null:
+			return "Mergeability not yet determined by the forge";
+		default:
+			return `Not mergeable (state: ${mergeStatus.mergeableState})`;
+	}
+};
+
+type ReadinessRow = { label: string; tone: "safe" | "danger" | "warn" | "pending" };
+/** @public */
+export const mergeReadiness = (
+	review: Pick<ForgeReview, "draft" | "mergedAt" | "closedAt"> & {
+		reviewers: ReadonlyArray<unknown>;
+	},
+	mergeStatus: Pick<ReviewMergeStatus, "isMergeable" | "mergeableState"> | undefined,
+	checks: AggregateCIStatus | null | undefined,
+	verdicts: ReadonlyArray<ReviewerVerdict | "needsCloserLook">,
+) => {
+	const ready =
+		mergeStatus?.isMergeable === true &&
+		!review.draft &&
+		review.mergedAt === null &&
+		review.closedAt === null;
+	const changes = verdicts.includes("changesRequested");
+	const closerLook = verdicts.includes("needsCloserLook");
+	const approved = verdicts.includes("approved");
+	const pending = review.reviewers.length;
+	const state = mergeStatus?.mergeableState;
+	const conflict = state === "dirty";
+	const clean = state === "clean" || state === "can_be_merged";
+	const checkRow: ReadinessRow =
+		checks === "success"
+			? { label: "Checks passed", tone: "safe" }
+			: checks === "failure" || checks === "cancelled"
+				? { label: "Checks failed", tone: "danger" }
+				: checks === "action_required"
+					? { label: "Checks need attention", tone: "warn" }
+					: checks === "in_progress"
+						? { label: "Checks running", tone: "warn" }
+						: { label: "Checks not reported", tone: "pending" };
+	const pendingLabel = `${pending} review${pending === 1 ? "" : "s"} pending`;
+	const inputs = [
+		changes ? "Changes recommended" : closerLook ? "Needs a closer look" : false,
+		pending > 0 && pendingLabel,
+		checkRow.tone !== "safe" && checkRow.tone !== "pending" && checkRow.label,
+	]
+		.filter(Boolean)
+		.join(" · ");
+	const blocker = ready
+		? null
+		: review.mergedAt !== null
+			? "Already merged"
+			: review.closedAt !== null
+				? "Pull request is closed"
+				: review.draft
+					? "Draft pull requests cannot be merged"
+					: (state === "blocked" || state === "unstable") && inputs !== ""
+						? inputs
+						: mergeBlockedReason(mergeStatus);
+	const headline = ready
+		? "Ready to merge"
+		: review.mergedAt !== null
+			? "Merged"
+			: review.closedAt !== null
+				? "Closed"
+				: review.draft
+					? "Draft"
+					: conflict
+						? "Blocked on conflicts"
+						: state === "blocked" && (changes || closerLook || pending > 0)
+							? "Blocked on review"
+							: checkRow.tone === "danger" || checkRow.tone === "warn"
+								? "Blocked on checks"
+								: mergeStatus === undefined
+									? "Checking mergeability"
+									: "Merge blocked";
+	const rows: Array<ReadinessRow> = [
+		checkRow,
+		{
+			label: changes
+				? "Changes recommended"
+				: closerLook
+					? "Needs a closer look"
+					: approved
+						? "Approved"
+						: "No review verdict",
+			tone: changes || closerLook ? "warn" : approved ? "safe" : "pending",
+		},
+		{ label: pendingLabel, tone: "pending" },
+		{
+			label: conflict ? "Merge conflicts" : clean ? "No conflicts" : "Conflicts not reported",
+			tone: conflict ? "danger" : clean ? "safe" : "pending",
+		},
+	];
+	return { ready, blocker, headline, rows };
+};
+
+export const useMergeReadiness = (projectId: string, review: ForgeReview) => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const { data: mergeStatus, isError } = useQuery({
+		...getReviewMergeStatusQueryOptions({ projectId, reviewId: review.number }),
+		enabled: !review.draft && review.mergedAt === null && review.closedAt === null,
+	});
+	const { data: checks } = useQuery({
+		...listCIChecksQueryOptions({ projectId, reference: review.sourceBranch, polling: "priority" }),
+		enabled: forgeInfo?.capabilities.checks === true,
+		select: (data) => data.aggregate?.status ?? null,
+	});
+	const { data: submissions } = useQuery({
+		...listReviewSubmissionsQueryOptions({ projectId, reviewId: review.number }),
+		enabled: forgeInfo?.capabilities.reviewComments === true,
+	});
+	const { data: comments } = useQuery({
+		...listReviewCommentsQueryOptions({ projectId, reviewId: review.number }),
+		enabled: forgeInfo?.capabilities.reviewComments === true,
+	});
+	const verdicts = reviewReadinessVerdicts(submissions ?? [], comments ?? []);
+	const result = mergeReadiness(review, mergeStatus, checks, verdicts);
+	return isError
+		? {
+				...result,
+				ready: false,
+				blocker: "Could not check mergeability",
+				headline: "Mergeability unavailable",
+			}
+		: result;
+};
+
+export const reviewVerdictBody = (body: string) => {
+	const heading =
+		/^(?:#{1,6}[ \t]+)?(?:[🟡🔵🟢✅]\uFE0F?[ \t]+)?(?:\*\*)?(Changes recommended|Needs a closer look|Approved)(?:\*\*)?[ \t]*(?:\r?\n|$)/iu.exec(
+			body,
+		);
+	if (!heading) return { body, badge: undefined };
+	const key = (heading[1] ?? "").toLowerCase();
+	const badge =
+		key === "changes recommended"
+			? { label: "Changes recommended", variant: "warn" as const }
+			: key === "needs a closer look"
+				? { label: "Needs a closer look", variant: "pop" as const }
+				: { label: "Approved", variant: "safe" as const };
+	return { body: body.slice(heading[0].length).replace(/^(?:\r?\n)+/, ""), badge };
+};
+
+/** @public */
+export const reviewReadinessVerdicts = (
+	submissions: ReadonlyArray<
+		Pick<ForgeReviewSubmission, "id" | "author" | "body" | "state" | "submittedAt">
+	>,
+	comments: ReadonlyArray<
+		Pick<ForgeReviewComment, "id" | "author" | "body" | "createdAt" | "modifiedAt">
+	>,
+): Array<ReviewerVerdict | "needsCloserLook"> => {
+	type Verdict = ReviewerVerdict | "needsCloserLook";
+	type Event = { key: string; at: number; state: Verdict | "dismissed" };
+	const bodyVerdict = (body: string): Verdict | undefined => {
+		const badge = reviewVerdictBody(body).badge;
+		return badge?.variant === "warn"
+			? "changesRequested"
+			: badge?.variant === "pop"
+				? "needsCloserLook"
+				: badge?.variant === "safe"
+					? "approved"
+					: undefined;
+	};
+	const timestamp = (value: string | null) => {
+		const at = Date.parse(value ?? "");
+		return Number.isNaN(at) ? 0 : at;
+	};
+	const events: Array<Event> = [
+		...comments.flatMap((comment): Array<Event> => {
+			const state = bodyVerdict(comment.body);
+			return state === undefined
+				? []
+				: [
+						{
+							key: comment.author?.login.toLowerCase() ?? `comment:${String(comment.id)}`,
+							at: timestamp(comment.modifiedAt ?? comment.createdAt),
+							state,
+						},
+					];
+		}),
+		...submissions.map(
+			(submission): Event => ({
+				key: submission.author?.login.toLowerCase() ?? `submission:${String(submission.id)}`,
+				at: timestamp(submission.submittedAt),
+				state:
+					submission.state === "commented"
+						? (bodyVerdict(submission.body ?? "") ?? "commented")
+						: submission.state,
+			}),
+		),
+	];
+	events.sort((a, b) => a.at - b.at);
+	const verdicts = new Map<string, Verdict>();
+	for (const event of events) {
+		if (event.state === "dismissed") verdicts.set(event.key, "commented");
+		else if (event.state !== "commented" || !verdicts.has(event.key))
+			verdicts.set(event.key, event.state);
+	}
+	return Array.from(verdicts.values());
+};

--- a/apps/lite/ui/src/projects/branches.ts
+++ b/apps/lite/ui/src/projects/branches.ts
@@ -8,6 +8,7 @@ export type BranchFilter = keyof BranchFilters;
  * cursor table (`cursors.branches`), with every other list's.
  */
 export type BranchesState = {
+	collapsedGroups?: Record<string, boolean>;
 	filters: BranchFilters;
 	/**
 	 * The filter query, or `null` while the filter is closed — the list's header
@@ -83,6 +84,8 @@ export const writeStoredBranchFilters = (projectId: string, filters: BranchFilte
 	}
 };
 
+const EMPTY_GROUPS: Record<string, boolean> = {};
+
 const branchesSlice = createSlice({
 	name: "branches",
 	initialState,
@@ -117,6 +120,7 @@ const branchesSlice = createSlice({
 		},
 	},
 	selectors: {
+		selectCollapsedBranchGroups: (state) => state.collapsedGroups ?? EMPTY_GROUPS,
 		selectBranchFilters: (state) => state.filters,
 		selectBranchSearch: (state) => state.search,
 		selectUnfoldedBranches: (state) => state.unfolded,

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -552,6 +552,12 @@ export const projectReducers = {
 		const collapsed = state.workspace.filesCollapsedDirectories;
 		collapsed[path] = !(isCollapsed ?? collapsed[path] ?? false);
 	},
+	toggleBranchGroup: (
+		state: ProjectState,
+		{ key, collapsed }: { key: string; collapsed: boolean },
+	) => {
+		(state.branches.collapsedGroups ??= {})[key] = !collapsed;
+	},
 	setBranchSearch: (state: ProjectState, { search }: { search: string | null }) => {
 		branchesReducers.setSearch(state.branches, { search });
 	},

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -126,7 +126,7 @@ type WorkspaceState = {
 	 * and each is somewhere the user is looking separately.
 	 */
 	uncommittedFilesCollapsedDirectories: Record<string, true>;
-	filesCollapsedDirectories: Record<string, true>;
+	filesCollapsedDirectories: Record<string, boolean>;
 };
 
 const createInitialWorkspaceState = (): WorkspaceState => ({
@@ -545,10 +545,12 @@ export const projectReducers = {
 		if (collapsed[path]) delete collapsed[path];
 		else collapsed[path] = true;
 	},
-	toggleFilesDirectoryCollapsed: (state: ProjectState, { path }: { path: string }) => {
+	toggleFilesDirectoryCollapsed: (
+		state: ProjectState,
+		{ path, isCollapsed }: { path: string; isCollapsed?: boolean },
+	) => {
 		const collapsed = state.workspace.filesCollapsedDirectories;
-		if (collapsed[path]) delete collapsed[path];
-		else collapsed[path] = true;
+		collapsed[path] = !(isCollapsed ?? collapsed[path] ?? false);
 	},
 	setBranchSearch: (state: ProjectState, { search }: { search: string | null }) => {
 		branchesReducers.setSearch(state.branches, { search });

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.module.css
@@ -19,5 +19,11 @@
 	color: var(--fill-warn-fg);
 }
 .topics {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	min-width: 0;
+	max-width: 100%;
+	gap: 4px;
 	color: var(--text-2);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.module.css
@@ -4,8 +4,20 @@
 	line-height: 22px;
 	overflow-wrap: anywhere;
 }
-
 .headline .title {
 	display: inline;
+	font-weight: 600;
+	font-size: 13px;
 	line-height: inherit;
+	font-family: Inter, sans-serif;
+}
+.actionLine {
+	padding-block: 2px;
+}
+.actionLine .screenshots {
+	background: var(--fill-warn-bg);
+	color: var(--fill-warn-fg);
+}
+.topics {
+	color: var(--text-2);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.tsx
@@ -1,22 +1,54 @@
-import { ForgeLabel } from "#ui/components/ForgeLabel.tsx";
+import { Badge } from "#ui/components/Badge.tsx";
+import { branchReviewPresentation } from "#ui/branch.ts";
 import type { ForgeReviewLabel } from "@gitbutler/but-sdk";
 import { type FC, Fragment } from "react";
 import { RowLabel, RowLabelContainer } from "./Row.tsx";
 import styles from "./BranchRowHeadline.module.css";
 
-export const BranchRowHeadline: FC<{
-	title: string;
+type ReviewProps = { title: string; labels?: ReadonlyArray<ForgeReviewLabel> };
+export const BranchRowHeadline: FC<ReviewProps> = ({ title, labels }) => {
+	const presentation = branchReviewPresentation(title, labels);
+	return (
+		<RowLabelContainer className={styles.headline}>
+			<RowLabel heading className={styles.title} title={presentation.title}>
+				{presentation.title}
+			</RowLabel>
+		</RowLabelContainer>
+	);
+};
+
+export const BranchReviewTag: FC<ReviewProps> = ({ title, labels }) => {
+	const { action } = branchReviewPresentation(title, labels);
+	return (
+		action !== undefined && (
+			<div className={styles.actionLine}>
+				<Badge
+					variant={action === "Screenshots needed" ? "warn" : "fillGray"}
+					className={action === "Screenshots needed" ? styles.screenshots : undefined}
+				>
+					{action}
+				</Badge>
+			</div>
+		)
+	);
+};
+
+export const BranchTopics: FC<{
 	labels?: ReadonlyArray<ForgeReviewLabel>;
-}> = ({ title, labels }) => (
-	<RowLabelContainer className={styles.headline}>
-		<RowLabel heading className={styles.title} title={title}>
-			{title}
-		</RowLabel>
-		{labels?.map((label) => (
-			<Fragment key={label.name}>
-				{" "}
-				<ForgeLabel label={label} size="regular" />
-			</Fragment>
-		))}
-	</RowLabelContainer>
-);
+	separator?: boolean;
+}> = ({ labels, separator = false }) => {
+	const { topics } = branchReviewPresentation("", labels);
+	return (
+		topics.length > 0 && (
+			<span className={styles.topics}>
+				{separator && "· "}
+				{topics.map((label, index) => (
+					<Fragment key={label.name}>
+						{index > 0 && ", "}
+						<span title={label.description ?? undefined}>{label.name}</span>
+					</Fragment>
+				))}
+			</span>
+		)
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchRowHeadline.tsx
@@ -1,7 +1,8 @@
 import { Badge } from "#ui/components/Badge.tsx";
+import { ForgeLabel } from "#ui/components/ForgeLabel.tsx";
 import { branchReviewPresentation } from "#ui/branch.ts";
 import type { ForgeReviewLabel } from "@gitbutler/but-sdk";
-import { type FC, Fragment } from "react";
+import type { FC } from "react";
 import { RowLabel, RowLabelContainer } from "./Row.tsx";
 import styles from "./BranchRowHeadline.module.css";
 
@@ -41,12 +42,9 @@ export const BranchTopics: FC<{
 	return (
 		topics.length > 0 && (
 			<span className={styles.topics}>
-				{separator && "· "}
-				{topics.map((label, index) => (
-					<Fragment key={label.name}>
-						{index > 0 && ", "}
-						<span title={label.description ?? undefined}>{label.name}</span>
-					</Fragment>
+				{separator && <span aria-hidden="true">·</span>}
+				{topics.map((label) => (
+					<ForgeLabel key={label.name} label={label} size="regular" />
 				))}
 			</span>
 		)

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -109,3 +109,86 @@
 .branchRow .branchMeta {
 	font-size: 12px;
 }
+
+.groupControls {
+	display: flex;
+	align-items: center;
+	padding: 0 12px 8px;
+	gap: 8px;
+	color: var(--text-2);
+	font-size: 11px;
+}
+.groupHeader {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	height: 28px;
+	padding: 0 12px;
+	gap: 6px;
+	border: 0;
+	background: var(--bg-2);
+	color: var(--text-2);
+	font-size: 10px;
+	font-family: "Geist Mono", monospace;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	> span {
+		margin-left: auto;
+		color: var(--text-3);
+	}
+}
+.groupedCard > div {
+	padding-block: 0;
+}
+.branchRef {
+	font-weight: 600;
+	font-size: 12px;
+	font-family: "Geist Mono", monospace;
+}
+.bareBranchMeta {
+	flex-shrink: 0;
+	align-self: center;
+	margin-left: auto;
+	color: var(--text-2);
+	font-size: 11px;
+	white-space: nowrap;
+}
+.prHeadline {
+	display: flex;
+	align-items: baseline;
+	min-width: 0;
+	padding-top: 6px;
+	gap: 6px;
+}
+.reviewLink {
+	align-self: baseline;
+	margin-left: auto;
+	border: 0;
+	background: none;
+	color: var(--text-2);
+	font-size: 11px;
+	font-family: "Geist Mono", monospace;
+}
+.stateDot {
+	flex-shrink: 0;
+	align-self: start;
+	width: 6px;
+	height: 6px;
+	margin-top: 8px;
+	border-radius: 50%;
+	background: var(--fill-safe-bg);
+	&[data-state="draft"] {
+		border: 1px solid var(--border-1);
+		background: transparent;
+	}
+	&[data-state="merged"] {
+		background: var(--commit-integrated);
+	}
+	&[data-state="closed"] {
+		background: var(--fill-danger-bg);
+	}
+}
+.branchRow .reviewMeta {
+	color: var(--text-2);
+	font-size: 11px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -169,25 +169,6 @@
 	font-size: 11px;
 	font-family: "Geist Mono", monospace;
 }
-.stateDot {
-	flex-shrink: 0;
-	align-self: start;
-	width: 6px;
-	height: 6px;
-	margin-top: 8px;
-	border-radius: 50%;
-	background: var(--fill-safe-bg);
-	&[data-state="draft"] {
-		border: 1px solid var(--border-1);
-		background: transparent;
-	}
-	&[data-state="merged"] {
-		background: var(--commit-integrated);
-	}
-	&[data-state="closed"] {
-		background: var(--fill-danger-bg);
-	}
-}
 .branchRow .reviewMeta {
 	color: var(--text-2);
 	font-size: 11px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -10,7 +10,8 @@ import { useBranchRemove } from "#ui/api/mutations.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { activeBranchFilterCount, branchIsEmpty, type BranchFilters } from "#ui/branch.ts";
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
-import { Badge } from "#ui/components/Badge.tsx";
+import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
+import type { IconName } from "#ui/components/iconNames.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { BranchRowHeadline, BranchReviewTag, BranchTopics } from "./BranchRowHeadline.tsx";
 import { classes } from "#ui/components/classes.ts";
@@ -35,7 +36,7 @@ import { useAutofocusScope, useAddressSpaceHotkeys, type FocusScope } from "#ui/
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import { getRangeExtractorWithIndices } from "#ui/virtual.ts";
-import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
+import type { BranchReviewStatus, Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { Toolbar, Toggle, ToggleGroup } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -319,51 +320,63 @@ const BareBranchRow: FC<BranchRowProps> = ({ branch, rowProps, leading, actions,
 	</Row>
 );
 
+const reviewStates: Record<
+	BranchReviewStatus,
+	{ label: string; variant: BadgeVariant; icon: IconName }
+> = {
+	open: { label: "Open", variant: "safe", icon: "pr" },
+	draft: { label: "Draft", variant: "lightGray", icon: "pr-draft" },
+	merged: { label: "Merged", variant: "purple", icon: "branch-merge" },
+	closed: { label: "Closed", variant: "danger", icon: "pr-close" },
+};
+
 const PullRequestBranchRow: FC<
 	BranchRowProps & {
 		review: NonNullable<ListedBranch["review"]>;
 		descriptionId: string;
 		openReview: () => Promise<void>;
 	}
-> = ({ branch, rowProps, leading, actions, now, review, descriptionId, openReview }) => (
-	<Row {...rowProps} className={styles.branchRow}>
-		{leading}
-		<RowLabelGroup id={descriptionId}>
-			<div className={styles.prHeadline}>
-				<span
-					className={styles.stateDot}
-					data-state={branch.reviewStatus}
-					aria-label={branch.reviewStatus ?? "open"}
-				/>
-				<BranchRowHeadline title={review.title} labels={review.labels} />
-				<button
-					type="button"
-					className={styles.reviewLink}
-					aria-label={`Open ${review.unitSymbol}${review.number} in browser`}
-					onClick={() => void openReview()}
-				>
-					{review.unitSymbol}
-					{review.number}
-				</button>
-			</div>
-			<BranchReviewTag title={review.title} labels={review.labels} />
-			<RowMeta className={styles.branchRef} title={branch.displayName}>
-				{branch.displayName}
-			</RowMeta>
-			<RowMeta className={styles.reviewMeta}>
-				{review.author && (
-					<>
-						<span>{review.author.login}</span>
-						<span aria-hidden="true">·</span>
-					</>
-				)}
-				<BranchAge branch={branch} now={now} />
-				<BranchTopics labels={review.labels} separator />
-			</RowMeta>
-		</RowLabelGroup>
-		{actions}
-	</Row>
-);
+> = ({ branch, rowProps, leading, actions, now, review, descriptionId, openReview }) => {
+	const reviewState = reviewStates[branch.reviewStatus ?? "open"];
+	return (
+		<Row {...rowProps} className={styles.branchRow}>
+			{leading}
+			<RowLabelGroup id={descriptionId}>
+				<div className={styles.prHeadline}>
+					<BranchRowHeadline title={review.title} labels={review.labels} />
+					<button
+						type="button"
+						className={styles.reviewLink}
+						aria-label={`Open ${review.unitSymbol}${review.number} in browser`}
+						onClick={() => void openReview()}
+					>
+						<Badge variant={reviewState.variant}>
+							<Icon name={reviewState.icon} size={12} />
+							{reviewState.label}
+						</Badge>
+						{review.unitSymbol}
+						{review.number}
+					</button>
+				</div>
+				<BranchReviewTag title={review.title} labels={review.labels} />
+				<RowMeta className={styles.branchRef} title={branch.displayName}>
+					{branch.displayName}
+				</RowMeta>
+				<RowMeta className={styles.reviewMeta}>
+					{review.author && (
+						<>
+							<span>{review.author.login}</span>
+							<span aria-hidden="true">·</span>
+						</>
+					)}
+					<BranchAge branch={branch} now={now} />
+					<BranchTopics labels={review.labels} separator />
+				</RowMeta>
+			</RowLabelGroup>
+			{actions}
+		</Row>
+	);
+};
 
 const BranchItem: FC<{
 	projectId: string;

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -1,14 +1,18 @@
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
+import { useSaveGUISettings } from "#ui/api/mutations.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import { useQuery } from "@tanstack/react-query";
+import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
+import type { BranchGrouping } from "#ui/branch.ts";
 import rowStyles from "./Row.module.css";
 import uiStyles from "#ui/components/ui.module.css";
 import { useBranchRemove } from "#ui/api/mutations.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
-import { assert } from "#ui/assert.ts";
 import { activeBranchFilterCount, branchIsEmpty, type BranchFilters } from "#ui/branch.ts";
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
-import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
+import { Badge } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { BranchRowHeadline } from "./BranchRowHeadline.tsx";
-import type { IconName } from "#ui/components/iconNames.ts";
 import { classes } from "#ui/components/classes.ts";
 import { EmptyState } from "#ui/components/EmptyState.tsx";
 import {
@@ -31,8 +35,8 @@ import { useAutofocusScope, useAddressSpaceHotkeys, type FocusScope } from "#ui/
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import { getRangeExtractorWithIndices } from "#ui/virtual.ts";
-import type { BranchReviewStatus, Commit, ListedBranch } from "@gitbutler/but-sdk";
-import { Toolbar } from "@base-ui/react";
+import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
+import { Toolbar, Toggle, ToggleGroup } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { type Range, useVirtualizer } from "@tanstack/react-virtual";
@@ -41,6 +45,7 @@ import {
 	type FC,
 	Fragment,
 	type RefObject,
+	type ReactNode,
 	useCallback,
 	useId,
 	useLayoutEffect,
@@ -54,7 +59,6 @@ import {
 	RowLabelContainer,
 	RowLabelGroup,
 	RowMeta,
-	RowMetaSeparator,
 	RowToolbar,
 	SectionHeaderRow,
 } from "./Row.tsx";
@@ -86,16 +90,6 @@ const filterMenuLabels: Array<[keyof BranchFilters, string]> = [
 	["onlyLocal", "Show Only Local Branches"],
 	["onlyStacks", "Show Only Stacks"],
 ];
-
-const reviewStates: Record<
-	BranchReviewStatus,
-	{ label: string; variant: BadgeVariant; icon: IconName }
-> = {
-	open: { label: "Open", variant: "safe", icon: "pr" },
-	draft: { label: "Draft", variant: "lightGray", icon: "pr-draft" },
-	merged: { label: "Merged", variant: "purple", icon: "branch-merge" },
-	closed: { label: "Closed", variant: "danger", icon: "pr-close" },
-};
 
 /**
  * The graph has no remote-only state, so a branch that exists only on a remote
@@ -286,6 +280,89 @@ const BranchCommits: FC<{
 	);
 };
 
+type BranchRowProps = {
+	branch: ListedBranch;
+	rowProps: ComponentProps<typeof Row>;
+	leading: ReactNode;
+	actions: ReactNode;
+	now: number;
+};
+
+const BranchAge: FC<{ branch: ListedBranch; now: number }> = ({ branch, now }) => (
+	<>
+		{branch.commitCount !== null && (
+			<span>
+				{branch.commitCount} {branch.commitCount === 1 ? "commit" : "commits"}
+			</span>
+		)}
+		{branch.updatedAtMs !== null && (
+			<>
+				<span aria-hidden="true"> · </span>
+				<RelativeTime timestamp={branch.updatedAtMs} now={now} compact />
+			</>
+		)}
+	</>
+);
+
+const BareBranchRow: FC<BranchRowProps> = ({ branch, rowProps, leading, actions, now }) => (
+	<Row {...rowProps} className={styles.bareBranchRow}>
+		{leading}
+		<RowLabelContainer>
+			<RowLabel singleLine className={styles.branchRef} title={branch.displayName}>
+				{branch.displayName}
+			</RowLabel>
+		</RowLabelContainer>
+		<span className={styles.bareBranchMeta}>
+			<BranchAge branch={branch} now={now} />
+		</span>
+		{actions}
+	</Row>
+);
+
+const PullRequestBranchRow: FC<
+	BranchRowProps & {
+		review: NonNullable<ListedBranch["review"]>;
+		descriptionId: string;
+		openReview: () => Promise<void>;
+	}
+> = ({ branch, rowProps, leading, actions, now, review, descriptionId, openReview }) => (
+	<Row {...rowProps} className={styles.branchRow}>
+		{leading}
+		<RowLabelGroup id={descriptionId}>
+			<div className={styles.prHeadline}>
+				<span
+					className={styles.stateDot}
+					data-state={branch.reviewStatus}
+					aria-label={branch.reviewStatus ?? "open"}
+				/>
+				<BranchRowHeadline title={review.title} labels={review.labels} />
+				<button
+					type="button"
+					className={styles.reviewLink}
+					aria-label={`Open ${review.unitSymbol}${review.number} in browser`}
+					onClick={() => void openReview()}
+				>
+					{review.unitSymbol}
+					{review.number}
+				</button>
+			</div>
+			<RowMeta className={styles.branchRef} title={branch.displayName}>
+				{branch.displayName}
+			</RowMeta>
+			<RowMeta className={styles.reviewMeta}>
+				{review.author && (
+					<>
+						<span>{review.author.login}</span>
+						<span aria-hidden="true">·</span>
+					</>
+				)}
+				<BranchAge branch={branch} now={now} />
+			</RowMeta>
+		</RowLabelGroup>
+		{actions}
+	</Row>
+);
+
 const BranchItem: FC<{
 	projectId: string;
 	branch: ListedBranch;
@@ -334,8 +411,6 @@ const BranchItem: FC<{
 	const railGlyph: GraphSegmentGlyph = isTopBranch ? "forkRight" : "joinRight";
 
 	const review = branch.review;
-	const reviewState = branch.reviewStatus === null ? null : reviewStates[branch.reviewStatus];
-	const createdAt = review?.createdAt != null ? Date.parse(review.createdAt) : Number.NaN;
 
 	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
 	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
@@ -371,15 +446,37 @@ const BranchItem: FC<{
 		}),
 	];
 
-	const lastAuthorName = branch.lastAuthor?.name;
-
-	const showsAuthorMeta = lastAuthorName !== undefined || branch.updatedAtMs !== null;
-	/* The branch's own commits, matching what unfolding reveals.
-	   commitsAheadOfTarget would also count the branches below it in a stack, so
-	   every row above the bottom would overstate. Only while folded: the count
-	   stands in for the commits it hides, so showing it alongside them would just
-	   be noise. */
-	const showsCommitCount = !unfolded && branch.commitCount !== null && branch.commitCount > 0;
+	const rowProps: ComponentProps<typeof Row> = {
+		isSelected,
+		onSelect: () => setCursor("unapplied", address),
+		onContextMenu: (event) => {
+			void showNativeContextMenu(event, menuItems);
+		},
+	};
+	const leading = canUnfold ? (
+		<RowFoldToggle
+			folded={!unfolded}
+			aria-label={unfolded ? "Fold commits" : "Unfold commits"}
+			onClick={toggleUnfolded}
+			glyph={<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />}
+		/>
+	) : (
+		<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />
+	);
+	const actions = (
+		<Toolbar.Root aria-label="Branch actions" render={<RowToolbar reserveSpace />}>
+			{isApplyPending && <Icon name="spinner" />}
+			<Toolbar.Button
+				aria-label="Branch menu"
+				onClick={(event) => {
+					void showNativeMenuFromTrigger(event.currentTarget, menuItems);
+				}}
+				className={getRowButtonClassName({ iconOnly: true })}
+			>
+				<Icon name="kebab" />
+			</Toolbar.Button>
+		</Toolbar.Root>
+	);
 
 	return (
 		<div
@@ -395,126 +492,26 @@ const BranchItem: FC<{
 			// entirely rather than reporting it as collapsed.
 			aria-expanded={canUnfold ? unfolded : undefined}
 		>
-			<Row
-				className={styles.branchRow}
-				isSelected={isSelected}
-				onSelect={() => setCursor("unapplied", address)}
-				onContextMenu={(event) => {
-					void showNativeContextMenu(event, menuItems);
-				}}
-			>
-				{canUnfold ? (
-					<RowFoldToggle
-						folded={!unfolded}
-						aria-label={unfolded ? "Fold commits" : "Unfold commits"}
-						onClick={toggleUnfolded}
-						glyph={<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />}
-						foldedIndicator={<GraphSegment glyph="group" status={branchGraphStatus(branch)} />}
-					/>
-				) : (
-					<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />
-				)}
-
-				<RowLabelGroup id={descriptionId}>
-					<BranchRowHeadline title={review?.title ?? branch.displayName} labels={review?.labels} />
-
-					{review !== null && (
-						<RowMeta className={styles.reviewMeta}>
-							<button
-								type="button"
-								className={classes(getRowButtonClassName({ variant: "ghost" }), styles.reviewLink)}
-								aria-label={`Open ${review.unitSymbol}${String(review.number)} in browser`}
-								onClick={() => void openReviewInBrowser()}
-							>
-								{reviewState !== null && (
-									<Badge variant={reviewState.variant}>
-										<Icon name={reviewState.icon} size={12} />
-										{reviewState.label}
-									</Badge>
-								)}
-								<span>
-									{review.unitSymbol}
-									{review.number}
-								</span>
-								<Icon name="arrow-up-right" size={12} />
-							</button>
-							<span className={classes(rowStyles.fadedText, styles.reviewAuthor)}>
-								{Number.isFinite(createdAt) && (
-									<>
-										opened <RelativeTime timestamp={createdAt} now={now} compact /> ago{" "}
-									</>
-								)}
-								{review.author && <>by {review.author.login}</>}
-							</span>
-						</RowMeta>
-					)}
-
-					<RowMeta className={styles.branchMeta}>
-						{review !== null ? (
-							<span
-								className={classes(
-									rowStyles.fadedText,
-									rowStyles.metaItem,
-									rowStyles.metaItemShrinkable,
-								)}
-								title={branch.displayName}
-							>
-								<Icon size={12} name="branch" />
-								<span className={rowStyles.metaItemText}>{branch.displayName}</span>
-							</span>
-						) : (
-							showsAuthorMeta && (
-								<span
-									className={classes(
-										rowStyles.fadedText,
-										rowStyles.metaItem,
-										rowStyles.metaItemShrinkable,
-									)}
-									title={branch.lastAuthor?.email}
-								>
-									<span className={rowStyles.metaItemText}>
-										{lastAuthorName !== undefined && (
-											<>
-												{lastAuthorName}
-												{branch.updatedAtMs !== null && " · "}
-											</>
-										)}
-										{branch.updatedAtMs !== null && (
-											<>
-												updated <RelativeTime timestamp={branch.updatedAtMs} now={now} compact />{" "}
-												ago
-											</>
-										)}
-									</span>
-								</span>
-							)
-						)}
-
-						{showsCommitCount && (
-							<>
-								{(review !== null || showsAuthorMeta) && <RowMetaSeparator />}
-								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
-									{branch.commitCount} {branch.commitCount === 1 ? "commit" : "commits"}
-								</span>
-							</>
-						)}
-
-						{isApplyPending && <Icon name="spinner" />}
-					</RowMeta>
-				</RowLabelGroup>
-
-				<Toolbar.Root aria-label="Branch actions" render={<RowToolbar reserveSpace />}>
-					<Toolbar.Button
-						aria-label="Branch menu"
-						onClick={(event) => {
-							void showNativeMenuFromTrigger(event.currentTarget, menuItems);
-						}}
-						className={getRowButtonClassName({ iconOnly: true })}
-					>
-						<Icon name="kebab" />
-					</Toolbar.Button>
-				</Toolbar.Root>
-			</Row>
+			{review === null ? (
+				<BareBranchRow
+					branch={branch}
+					rowProps={rowProps}
+					leading={leading}
+					actions={actions}
+					now={now}
+				/>
+			) : (
+				<PullRequestBranchRow
+					branch={branch}
+					review={review}
+					rowProps={rowProps}
+					leading={leading}
+					actions={actions}
+					now={now}
+					descriptionId={descriptionId}
+					openReview={openReviewInBrowser}
+				/>
+			)}
 
 			{unfolded && (
 				<BranchCommits
@@ -549,6 +546,11 @@ export const BranchesList: FC<
 	// WorkspacePage resolves selection from this query data and passes the same data down, so
 	// selection and rendering consume the same snapshot.
 	const { stacks, stackIndexByAddressIndex, addressSpace } = branches ?? emptyBranchesListContent;
+	const { data: grouping = defaultSettings.branchGrouping } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => cfg.branchGrouping ?? defaultSettings.branchGrouping,
+	});
+	const { mutate: saveGUISettings } = useSaveGUISettings();
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),
 	);
@@ -593,10 +595,7 @@ export const BranchesList: FC<
 	// The virtualiser treats getItemKey identity as part of its measurement model. Keep it stable
 	// across selection renders, but refresh estimates when either stack identity or commit counts
 	// change.
-	const getStackKey = useCallback(
-		(index: number) => stacks[index]?.branches[0]?.branch.refName.full ?? index,
-		[stacks],
-	);
+	const getStackKey = useCallback((index: number) => stacks[index]?.key ?? index, [stacks]);
 	const selectedAddressKey = selection === null ? undefined : addressIdentityKey(selection);
 	const selectedAddressIndex =
 		selectedAddressKey === undefined ? undefined : addressSpace.indexByKey.get(selectedAddressKey);
@@ -618,6 +617,10 @@ export const BranchesList: FC<
 		count: stacks.length,
 		getScrollElement: () => scrollElementRef.current,
 		estimateSize: (index) => {
+			const stack = stacks[index];
+			if (stack?.group) return 28;
+			if (stack?.grouped)
+				return 1 + (stack.reviewCount > 0 ? 78 : 28) + stack.commitCount * COMMIT_ROW_HEIGHT;
 			// Estimate unwrapped titles; measured cards account for titles and labels that wrap.
 			const branchTitleHeight = 34;
 			const reviewMetaHeight = 22;
@@ -716,7 +719,7 @@ export const BranchesList: FC<
 		},
 	);
 
-	const firstBranch = stacks[0]?.branches[0]?.branch;
+	const firstBranch = stacks.find((stack) => stack.branches.length > 0)?.branches[0]?.branch;
 	const branchFilter = useListFilter({
 		filter: search,
 		setFilter: (search) => dispatch(projectSlice.actions.setBranchSearch({ projectId, search })),
@@ -807,6 +810,27 @@ export const BranchesList: FC<
 				<ListFilterRow {...branchFilter.rowProps} />
 			)}
 
+			<div className={styles.groupControls}>
+				<span>Group by</span>
+				<ToggleGroup
+					render={<ToggleGroupStyles segmented />}
+					aria-label="Group branches by"
+					value={[grouping]}
+					onValueChange={(values: Array<BranchGrouping>) => {
+						if (values[0] !== undefined) saveGUISettings({ branchGrouping: values[0] });
+					}}
+				>
+					<Toggle render={<ToggleStyles size="small" />} value="state">
+						State
+					</Toggle>
+					<Toggle render={<ToggleStyles size="small" />} value="author">
+						Author
+					</Toggle>
+					<Toggle render={<ToggleStyles size="small" />} value="recent">
+						Recent
+					</Toggle>
+				</ToggleGroup>
+			</div>
 			<div
 				ref={retainScrollElement}
 				className={classes(uiStyles.scroller, styles.list)}
@@ -865,10 +889,51 @@ export const BranchesList: FC<
 					{rowVirtualizer.getVirtualItems().map((virtualRow) => {
 						const stack = stacks[virtualRow.index];
 						if (stack === undefined) return null;
+						if (stack.group) {
+							const group = stack.group;
+							return (
+								<div
+									key={stack.key}
+									data-index={virtualRow.index}
+									ref={rowVirtualizer.measureElement}
+									role="treeitem"
+									aria-level={1}
+									aria-expanded={!group.collapsed}
+									aria-label={`${group.label} group`}
+									style={{
+										position: "absolute",
+										top: 0,
+										left: 0,
+										width: "100%",
+										transform: `translateY(${virtualRow.start}px)`,
+									}}
+								>
+									<button
+										type="button"
+										className={styles.groupHeader}
+										aria-expanded={!group.collapsed}
+										onClick={() =>
+											dispatch(
+												projectSlice.actions.toggleBranchGroup({
+													projectId,
+													key: group.key,
+													collapsed: group.collapsed,
+												}),
+											)
+										}
+									>
+										<Icon size={12} name={group.collapsed ? "chevron-right" : "chevron-down"} />
+										{group.label}
+										<span>{group.count}</span>
+									</button>
+								</div>
+							);
+						}
 
 						return (
 							<StackCard
-								key={assert(stack.branches[0]).branch.refName.full}
+								key={stack.key}
+								className={stack.grouped ? styles.groupedCard : undefined}
 								data-index={virtualRow.index}
 								ref={rowVirtualizer.measureElement}
 								style={{
@@ -882,40 +947,44 @@ export const BranchesList: FC<
 								role="group"
 								aria-label="Stack"
 							>
-								{stack.branches.map(({ branch, addressIndex, commits }, index) => {
-									const selectedCommitIndex =
-										selectedAddressIndex !== undefined &&
-										selectedAddressIndex > addressIndex &&
-										selectedAddressIndex <= addressIndex + (commits?.length ?? 0)
-											? selectedAddressIndex - addressIndex - 1
-											: undefined;
+								{stack.branches.map(
+									({ branch, addressIndex, commits, isTopBranch, isStacked }, index) => {
+										const selectedCommitIndex =
+											selectedAddressIndex !== undefined &&
+											selectedAddressIndex > addressIndex &&
+											selectedAddressIndex <= addressIndex + (commits?.length ?? 0)
+												? selectedAddressIndex - addressIndex - 1
+												: undefined;
 
-									return (
-										<Fragment key={branch.refName.full}>
-											<BranchItem
-												projectId={projectId}
-												branch={branch}
-												isTopBranch={index === 0}
-												isStacked={stack.branches.length > 1}
-												commits={commits}
-												scrollElementRef={scrollElementRef}
-												stackScrollStart={virtualRow.start}
-												stackSize={virtualRow.size}
-												branchAddressIndex={addressIndex}
-												selectedCommitIndex={selectedCommitIndex}
-												positionInSet={index + 1}
-												setSize={stack.branches.length}
-											/>
+										return (
+											<Fragment key={branch.refName.full}>
+												<BranchItem
+													projectId={projectId}
+													branch={branch}
+													isTopBranch={isTopBranch}
+													isStacked={isStacked}
+													commits={commits}
+													scrollElementRef={scrollElementRef}
+													stackScrollStart={virtualRow.start}
+													stackSize={virtualRow.size}
+													branchAddressIndex={addressIndex}
+													selectedCommitIndex={selectedCommitIndex}
+													positionInSet={index + 1}
+													setSize={stack.branches.length}
+												/>
 
-											{/* Carries the rail down to the next branch, and past the
+												{/* Carries the rail down to the next branch, and past the
 											    last one as the card's floor — as the workspace card's
 											    segment connectors do. */}
-											<Row interactive={false} className={stackCardStyles.railConnector}>
-												<GraphSegment glyph="parent" status={branchGraphStatus(branch)} />
-											</Row>
-										</Fragment>
-									);
-								})}
+												{!stack.grouped && (
+													<Row interactive={false} className={stackCardStyles.railConnector}>
+														<GraphSegment glyph="parent" status={branchGraphStatus(branch)} />
+													</Row>
+												)}
+											</Fragment>
+										);
+									},
+								)}
 							</StackCard>
 						);
 					})}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -12,7 +12,7 @@ import { activeBranchFilterCount, branchIsEmpty, type BranchFilters } from "#ui/
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import { Badge } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
-import { BranchRowHeadline } from "./BranchRowHeadline.tsx";
+import { BranchRowHeadline, BranchReviewTag, BranchTopics } from "./BranchRowHeadline.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { EmptyState } from "#ui/components/EmptyState.tsx";
 import {
@@ -346,6 +346,7 @@ const PullRequestBranchRow: FC<
 					{review.number}
 				</button>
 			</div>
+			<BranchReviewTag title={review.title} labels={review.labels} />
 			<RowMeta className={styles.branchRef} title={branch.displayName}>
 				{branch.displayName}
 			</RowMeta>
@@ -357,6 +358,7 @@ const PullRequestBranchRow: FC<
 					</>
 				)}
 				<BranchAge branch={branch} now={now} />
+				<BranchTopics labels={review.labels} separator />
 			</RowMeta>
 		</RowLabelGroup>
 		{actions}

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.module.css
@@ -1,0 +1,33 @@
+.summary {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	padding: 0 12px 8px;
+	gap: 6px;
+	color: var(--text-2);
+	font-size: 11px;
+	font-family: "Geist Mono", monospace;
+}
+.count {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	&[data-status="Modification"] > span {
+		color: var(--text-2);
+	}
+	> span {
+		font-family: inherit;
+	}
+	> span[aria-hidden] {
+		color: var(--text-2);
+	}
+	&[data-status="Addition"] {
+		color: var(--change-status-addition);
+	}
+	&[data-status="Deletion"] {
+		color: var(--change-status-deletion);
+	}
+	&[data-status="Rename"] {
+		color: var(--change-status-rename);
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.module.css
@@ -31,3 +31,8 @@
 		color: var(--change-status-rename);
 	}
 }
+
+.mode {
+	margin: 0 12px 6px 6px;
+	float: right;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
@@ -17,8 +17,8 @@ import { Toolbar } from "@base-ui/react";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import { Match } from "effect";
 import type { FC } from "react";
-import { ChangeStats } from "./ChangeStats.tsx";
-import type { LineStats } from "./lineStats.ts";
+import { FileStatusBadge, type FileStatusType } from "#ui/components/FileStatusBadge.tsx";
+import styles from "./ChangesHeaderRow.module.css";
 import { getRowButtonClassName } from "./Row-utils.ts";
 import { RowToolbar, SectionHeaderRow } from "./Row.tsx";
 import { useFileDisplayModeMenuItems } from "./useFileDisplayModeMenuItems.ts";
@@ -27,16 +27,18 @@ export const ChangesHeaderRow: FC<{
 	projectId: string;
 	fileParent: FileParent;
 	changes: Array<TreeChange>;
-	lineStats: LineStats;
 	className?: string;
 	onOpenFilter: () => void;
-}> = ({ projectId, fileParent, changes, lineStats, className, onOpenFilter }) => {
+}> = ({ projectId, fileParent, changes, className, onOpenFilter }) => {
 	const { isPending: isCommitUncommitChangesPending, mutate: commitUncommitChanges } =
 		useCommitUncommitChanges();
 	const { isPending: isCommitDiscardChangesPending, mutate: commitDiscardChanges } =
 		useCommitDiscardChanges();
 	const { isPending: isDiscardWorktreeChangesPending, mutate: discardWorktreeChanges } =
 		useDiscardWorktreeChanges();
+
+	const counts: Partial<Record<FileStatusType, number>> = {};
+	for (const change of changes) counts[change.status.type] = (counts[change.status.type] ?? 0) + 1;
 
 	const diffSpecs = () => changes.map((change) => createDiffSpec(change, []));
 	const fileDisplayModeMenuItems = useFileDisplayModeMenuItems();
@@ -97,37 +99,48 @@ export const ChangesHeaderRow: FC<{
 	]);
 
 	return (
-		<SectionHeaderRow
-			label="Changes"
-			className={className}
-			onContextMenu={(event) => {
-				void showNativeContextMenu(event, menuItems);
-			}}
-			actions={
-				<Toolbar.Root aria-label="Changes actions" render={<RowToolbar forceVisible />}>
-					{changes.length > 0 && (
+		<div className={className}>
+			<SectionHeaderRow
+				label="Changes"
+				onContextMenu={(event) => {
+					void showNativeContextMenu(event, menuItems);
+				}}
+				actions={
+					<Toolbar.Root aria-label="Changes actions" render={<RowToolbar forceVisible />}>
+						{changes.length > 0 && (
+							<Toolbar.Button
+								aria-label="Filter files"
+								onClick={onOpenFilter}
+								className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+							>
+								<Icon name="search" />
+							</Toolbar.Button>
+						)}
+
 						<Toolbar.Button
-							aria-label="Filter files"
-							onClick={onOpenFilter}
+							aria-label="Changes menu"
+							onClick={(event) => {
+								void showNativeMenuFromTrigger(event.currentTarget, menuItems);
+							}}
 							className={getRowButtonClassName({ size: "regular", iconOnly: true })}
 						>
-							<Icon name="search" />
+							<Icon name="kebab" />
 						</Toolbar.Button>
-					)}
-
-					<Toolbar.Button
-						aria-label="Changes menu"
-						onClick={(event) => {
-							void showNativeMenuFromTrigger(event.currentTarget, menuItems);
-						}}
-						className={getRowButtonClassName({ size: "regular", iconOnly: true })}
-					>
-						<Icon name="kebab" />
-					</Toolbar.Button>
-				</Toolbar.Root>
-			}
-		>
-			<ChangeStats fileCount={changes.length} lineStats={lineStats} />
-		</SectionHeaderRow>
+					</Toolbar.Root>
+				}
+			/>
+			<div className={styles.summary}>
+				<span>{changes.length} files</span>
+				{(["Modification", "Addition", "Deletion", "Rename"] satisfies Array<FileStatusType>).map(
+					(status) =>
+						(counts[status] ?? 0) > 0 ? (
+							<span key={status} className={styles.count} data-status={status}>
+								<span aria-hidden="true">·</span> {counts[status]}{" "}
+								<FileStatusBadge status={status} fontSize={11} />
+							</span>
+						) : null,
+				)}
+			</div>
+		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
@@ -1,3 +1,7 @@
+import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
+import { useSaveGUISettings } from "#ui/api/mutations.ts";
+import { useFileDisplayMode } from "./useFileDisplayMode.ts";
+import type { FileDisplayMode } from "./file-tree.ts";
 import {
 	useCommitDiscardChanges,
 	useCommitUncommitChanges,
@@ -13,7 +17,7 @@ import {
 } from "#ui/native-menu.ts";
 import type { FileParent } from "#ui/addresses.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
-import { Toolbar } from "@base-ui/react";
+import { Toolbar, Toggle, ToggleGroup } from "@base-ui/react";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import { Match } from "effect";
 import type { FC } from "react";
@@ -37,6 +41,8 @@ export const ChangesHeaderRow: FC<{
 	const { isPending: isDiscardWorktreeChangesPending, mutate: discardWorktreeChanges } =
 		useDiscardWorktreeChanges();
 
+	const mode = useFileDisplayMode();
+	const { mutate: saveGUISettings } = useSaveGUISettings();
 	const counts: Partial<Record<FileStatusType, number>> = {};
 	for (const change of changes) counts[change.status.type] = (counts[change.status.type] ?? 0) + 1;
 
@@ -129,6 +135,23 @@ export const ChangesHeaderRow: FC<{
 					</Toolbar.Root>
 				}
 			/>
+			<div className={styles.mode}>
+				<ToggleGroup
+					render={<ToggleGroupStyles segmented />}
+					aria-label="File display"
+					value={[mode]}
+					onValueChange={(values: Array<FileDisplayMode>) => {
+						if (values[0] !== undefined) saveGUISettings({ fileDisplayMode: values[0] });
+					}}
+				>
+					<Toggle render={<ToggleStyles size="small" />} value="tree">
+						Tree
+					</Toggle>
+					<Toggle render={<ToggleStyles size="small" />} value="list">
+						Flat
+					</Toggle>
+				</ToggleGroup>
+			</div>
 			<div className={styles.summary}>
 				<span>{changes.length} files</span>
 				{(["Modification", "Addition", "Deletion", "Rename"] satisfies Array<FileStatusType>).map(

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -277,7 +277,7 @@
    details header out of view with it. */
 .prTabScroll {
 	/* The tab's inset and column gap scale with this width (see .prTab). */
-	container-type: inline-size;
+	container-type: size;
 	overflow-y: auto;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -64,6 +64,7 @@
 
 .actions {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	/* With a separate header above (commit/branch views), use tighter padding. */
 	padding: 8px;
@@ -79,6 +80,8 @@
 
 .diffControls {
 	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
 	margin-inline-start: auto;
 	gap: 6px;
 }
@@ -516,4 +519,50 @@
    scrolling beneath a pinned ruler. */
 .diffArea > * {
 	min-height: 0;
+}
+
+.reviewProgress {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	color: var(--text-2);
+	font-size: 13px;
+	white-space: nowrap;
+
+	strong {
+		color: var(--text-1);
+		font-weight: 400;
+		font-family: "Geist Mono", monospace;
+	}
+}
+.reviewProgressTrack {
+	appearance: none;
+	width: 90px;
+	height: 4px;
+	overflow: hidden;
+	border: none;
+	border-radius: 2px;
+	background: var(--bg-mute);
+	&::-webkit-progress-bar {
+		border-radius: 2px;
+		background: var(--bg-mute);
+	}
+	&::-webkit-progress-value {
+		background: var(--fill-pop-bg);
+	}
+	&::-moz-progress-bar {
+		background: var(--fill-pop-bg);
+	}
+}
+.reviewAll {
+	padding: 0;
+	border: 0;
+	border-bottom: 1px dotted var(--text-3);
+	background: none;
+	color: var(--text-2);
+	font-size: 13px;
+	white-space: nowrap;
+	&:disabled {
+		opacity: 0.5;
+	}
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1849,6 +1849,11 @@ const DiffContents: FC<{
 						};
           }
 
+          [data-overflow="wrap"] [data-line] {
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+          }
+
           [data-diffs-header="custom"] {
             background-color: var(--bg-1);
           }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1822,6 +1822,7 @@ const DiffContents: FC<{
 				onSelectedLinesChange={handleLinesSelected}
 				options={{
 					diffStyle: effectiveDiffStyle,
+					diffIndicators: "classic",
 					loadDiffFiles,
 					disableBackground: !(diffBackgrounds ?? defaultSettings.diffBackground),
 					lineDiffType: settings?.lineDiffType ?? defaultSettings.lineDiffType,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2128,12 +2128,13 @@ const FilesToggle: FC<{ projectId: string }> = ({ projectId }) => {
 				render={
 					<button
 						type="button"
-						className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
+						className={getButtonClassName({ variant: "ghost" })}
 						aria-label={workspaceHotkeys.toggleFiles.meta.name}
 						aria-pressed={filesVisible}
 						onClick={() => dispatch(projectSlice.actions.toggleFiles({ projectId }))}
 					>
 						{filesVisible ? <Icon name="files-sidebar" /> : <Icon name="sidebar-narrow" />}
+						Files
 					</button>
 				}
 			/>
@@ -2148,116 +2149,7 @@ const FilesToggle: FC<{ projectId: string }> = ({ projectId }) => {
 	);
 };
 
-const DiffOverflowToggle: FC<
-	Omit<ComponentProps<typeof Toggle>, "aria-label" | "pressed" | "onPressedChange">
-> = (toggleProps) => {
-	const { data: diffOverflow } = useQuery({
-		...guiSettingsQueryOptions,
-		select: (cfg) => cfg.diffOverflow,
-	});
-	const { mutate: saveGUISettings } = useSaveGUISettings();
-
-	return (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				render={
-					<Toggle
-						{...toggleProps}
-						aria-label="Toggle line wrapping"
-						pressed={(diffOverflow ?? defaultSettings.diffOverflow) === "wrap"}
-						onPressedChange={(pressed) =>
-							saveGUISettings({ diffOverflow: pressed ? "wrap" : "scroll" })
-						}
-					/>
-				}
-			/>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup />}>Toggle line wrapping</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-};
-
-const DiffBackgroundsToggle: FC<
-	Omit<ComponentProps<typeof Toggle>, "aria-label" | "pressed" | "onPressedChange">
-> = (toggleProps) => {
-	const { data: diffBackgrounds } = useQuery({
-		...guiSettingsQueryOptions,
-		select: (cfg) => cfg.diffBackground,
-	});
-	const { mutate: saveGUISettings } = useSaveGUISettings();
-
-	return (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				render={
-					<Toggle
-						{...toggleProps}
-						aria-label="Toggle diff backgrounds"
-						pressed={diffBackgrounds ?? defaultSettings.diffBackground}
-						onPressedChange={(enabled) => saveGUISettings({ diffBackground: enabled })}
-					/>
-				}
-			/>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup />}>Toggle diff backgrounds</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-};
-
-const DiffStyleToggleGroup: FC<
-	Omit<
-		ToggleGroup.Props<NonNullable<GUISettings["diffStyle"]>>,
-		"aria-label" | "value" | "onValueChange"
-	>
-> = (toggleGroupProps) => {
-	const { data: diffStyle } = useQuery({
-		...guiSettingsQueryOptions,
-		select: (cfg) => cfg.diffStyle,
-	});
-	const { mutate: saveGUISettings } = useSaveGUISettings();
-
-	return (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				render={
-					<ToggleGroup
-						{...toggleGroupProps}
-						aria-label={diffHotkeys.toggleDiffStyle.meta.name}
-						value={[diffStyle ?? defaultSettings.diffStyle]}
-						onValueChange={(value: Array<NonNullable<GUISettings["diffStyle"]>>) => {
-							const head = value[0];
-							if (head === undefined) return;
-
-							saveGUISettings({ diffStyle: head });
-						}}
-					/>
-				}
-			/>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup kbd={diffHotkeys.toggleDiffStyle.hotkey} />}>
-						{diffHotkeys.toggleDiffStyle.meta.name}
-					</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-};
-
-/**
- * Kept whole and out of the component so the compiler can memoise the layout on
- * its inputs; derived in render, the rows — and the address space built from
- * them — take a fresh identity every time anything else about the pane changes.
- *
- * The filter narrows the file list only; the diff itself keeps every file, so
- * the list stays a way of reaching a file rather than a way of hiding one.
- */
+/** The filter narrows navigation only; the diff retains every file. */
 const buildFilesRows = ({
 	filesItems,
 	filter,
@@ -2798,9 +2690,56 @@ const Diff: FC<{
 							<ChangeStats fileCount={changes.length} lineStats={lineStats} />
 						)}
 
+						<div className={styles.reviewProgress}>
+							<span>
+								Reviewed <strong>{reviewedFilePaths.size}</strong> of{" "}
+								<strong>{changes.length}</strong>
+							</span>
+							<progress
+								aria-label="Files reviewed"
+								aria-valuenow={reviewedFilePaths.size}
+								max={Math.max(1, changes.length)}
+								value={reviewedFilePaths.size}
+								className={styles.reviewProgressTrack}
+							/>
+						</div>
 						<Toolbar.Root aria-label="Diff controls" className={styles.diffControls}>
+							<ToggleGroup
+								render={<ToggleGroupStyles segmented />}
+								aria-label="Diff layout"
+								value={[diffStyle]}
+								onValueChange={(values: Array<NonNullable<GUISettings["diffStyle"]>>) => {
+									if (values[0] !== undefined) saveGUISettings({ diffStyle: values[0] });
+								}}
+							>
+								<Toolbar.Button
+									render={<Toggle render={<ToggleStyles />} />}
+									value="split"
+									disabled={!canUseSplitDiff}
+								>
+									Split
+								</Toolbar.Button>
+								<Toolbar.Button render={<Toggle render={<ToggleStyles />} />} value="unified">
+									Unified
+								</Toolbar.Button>
+							</ToggleGroup>
+							<ToggleGroup
+								render={<ToggleGroupStyles segmented />}
+								aria-label="Line wrapping"
+								value={[diffSettings?.diffOverflow ?? defaultSettings.diffOverflow]}
+								onValueChange={(values: Array<NonNullable<GUISettings["diffOverflow"]>>) => {
+									if (values[0] !== undefined) saveGUISettings({ diffOverflow: values[0] });
+								}}
+							>
+								<Toolbar.Button render={<Toggle render={<ToggleStyles />} />} value="wrap">
+									Wrap
+								</Toolbar.Button>
+								<Toolbar.Button render={<Toggle render={<ToggleStyles />} />} value="scroll">
+									Scroll
+								</Toolbar.Button>
+							</ToggleGroup>
 							<Toolbar.Button
-								className={getButtonClassName({ variant: "outline" })}
+								className={styles.reviewAll}
 								disabled={
 									preparedDiffFiles.length === 0 || preparedDiffFiles.length !== changes.length
 								}
@@ -2808,38 +2747,6 @@ const Diff: FC<{
 							>
 								{allFilesReviewed ? "Mark all unreviewed" : "Mark all reviewed"}
 							</Toolbar.Button>
-							<ToggleGroupStyles>
-								<Toolbar.Button
-									render={
-										<DiffOverflowToggle render={<ToggleStyles iconOnly />}>
-											<Icon name="text-wrap" />
-										</DiffOverflowToggle>
-									}
-								/>
-								<Toolbar.Button
-									render={
-										<DiffBackgroundsToggle render={<ToggleStyles iconOnly />}>
-											<Icon name="text-block" />
-										</DiffBackgroundsToggle>
-									}
-								/>
-							</ToggleGroupStyles>
-							{canUseSplitDiff && (
-								<DiffStyleToggleGroup render={<ToggleGroupStyles />}>
-									<Toolbar.Button
-										render={<Toggle render={<ToggleStyles />} />}
-										value={"split" satisfies GUISettings["diffStyle"]}
-									>
-										Split
-									</Toolbar.Button>
-									<Toolbar.Button
-										render={<Toggle render={<ToggleStyles />} />}
-										value={"unified" satisfies GUISettings["diffStyle"]}
-									>
-										Unified
-									</Toolbar.Button>
-								</DiffStyleToggleGroup>
-							)}
 						</Toolbar.Root>
 					</div>
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2155,16 +2155,19 @@ const buildFilesRows = ({
 	filter,
 	mode,
 	collapsedDirectories,
+	reviewedPaths,
 }: {
 	filesItems: Array<FileRowItem>;
 	filter: string | null;
 	mode: FileDisplayMode;
-	collapsedDirectories: Record<string, true>;
+	collapsedDirectories: Record<string, boolean>;
+	reviewedPaths: ReadonlySet<string>;
 }): Array<FileTreeRow<FileRowItem>> =>
 	buildFileTreeRows({
 		items: filesItems.filter((item) => pathMatchesFilter(item.path, filter)),
 		mode,
 		collapsedDirectories,
+		reviewedPaths,
 	});
 
 const withLineStats = (treeChangeDiffs: Array<UnifiedPatch | null | undefined>) => ({
@@ -2259,21 +2262,6 @@ const Diff: FC<{
 	const filesCollapsedDirectories = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesCollapsedDirectories(state, projectId),
 	);
-	// As with `fileParent` below, the compiler leaves this derivation outside its
-	// memo blocks here, and the rows carry the identity the file list and its
-	// address space are keyed on — so it is memoised by hand.
-	const filesRows = useMemo(
-		() =>
-			buildFilesRows({
-				filesItems,
-				filter: filesFilter,
-				mode: fileDisplayMode,
-				collapsedDirectories: filesCollapsedDirectories,
-			}),
-		[filesItems, filesFilter, fileDisplayMode, filesCollapsedDirectories],
-	);
-	const filesAddressSpace = useMemo(() => fileTreeAddressSpace(filesRows), [filesRows]);
-	const filesSelection = useSelection("files", filesAddressSpace);
 
 	// At time of writing React Compiler cannot statically analyse that these are pure derivations of
 	// the sidebar selection, even with the helpers inlined, hence manual memoisation.
@@ -2381,11 +2369,6 @@ const Diff: FC<{
 		[threads, fileParent],
 	);
 
-	// A directory row stands for the first file below it, so the diff has
-	// something to show while the cursor rests on a folder.
-	const activeFilePath =
-		selection._tag === "File" ? selection.path : selectedFilePath(filesRows, filesSelection);
-
 	const preparedDiffFiles = useMemo(
 		() =>
 			prepareDiffFiles({ fileParent, changes: unsortedChanges, treeChangeDiffs }).sort((a, b) =>
@@ -2393,6 +2376,33 @@ const Diff: FC<{
 			),
 		[fileParent, unsortedChanges, treeChangeDiffs],
 	);
+	const reviewedFilePaths = useMemo(
+		() => reviewedPaths(preparedDiffFiles, reviewedFiles),
+		[preparedDiffFiles, reviewedFiles],
+	);
+
+	// As with `fileParent`, the compiler leaves this derivation outside its
+	// memo blocks here, and the rows carry the identity the file list and its
+	// address space are keyed on — so it is memoised by hand.
+	const filesRows = useMemo(
+		() =>
+			buildFilesRows({
+				filesItems,
+				filter: filesFilter,
+				mode: fileDisplayMode,
+				collapsedDirectories: filesCollapsedDirectories,
+				reviewedPaths: reviewedFilePaths,
+			}),
+		[filesItems, filesFilter, fileDisplayMode, filesCollapsedDirectories, reviewedFilePaths],
+	);
+	const filesAddressSpace = useMemo(() => fileTreeAddressSpace(filesRows), [filesRows]);
+	const filesSelection = useSelection("files", filesAddressSpace);
+
+	// A directory row stands for the first file below it, so the diff has
+	// something to show while the cursor rests on a folder.
+	const activeFilePath =
+		selection._tag === "File" ? selection.path : selectedFilePath(filesRows, filesSelection);
+
 	// Keyed on the file's index, not its path: scrolling moves the selection, so
 	// keying on path reparsed every file per boundary crossed. `null` is
 	// render-all, distinct from the -1 of a path matching no file.
@@ -2455,10 +2465,6 @@ const Diff: FC<{
 		preparedDiffFiles.length > 0 &&
 		preparedDiffFiles.length === changes.length &&
 		preparedDiffFiles.every(({ change, version }) => reviewedFiles.get(change.path)?.has(version));
-
-	// Resolved once for the whole list rather than per row: a row would have to
-	// find its own version to answer this.
-	const reviewedFilePaths = reviewedPaths(preparedDiffFiles, reviewedFiles);
 
 	const toggleAllFilesReviewed = (): void => {
 		setManualCollapseByItem(new Map());
@@ -2657,9 +2663,16 @@ const Diff: FC<{
 						projectId={projectId}
 						rows={filesRows}
 						lineStatsByPath={lineStatsByPath}
-						collapsedDirectories={filesCollapsedDirectories}
 						onToggleDirectoryCollapsed={(path) =>
-							dispatch(projectSlice.actions.toggleFilesDirectoryCollapsed({ projectId, path }))
+							dispatch(
+								projectSlice.actions.toggleFilesDirectoryCollapsed({
+									projectId,
+									path,
+									isCollapsed: filesRows.some(
+										(row) => row._tag === "Directory" && row.path === path && row.collapsed,
+									),
+								}),
+							)
 						}
 						selection={filesSelection}
 						addressSpace={filesAddressSpace}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2443,6 +2443,14 @@ const Diff: FC<{
 	const diffContextKey =
 		shownFileIndex === null ? reviewedFilesContextId : (activeFileItemId ?? reviewedFilesContextId);
 
+	const lineStatsByPath = useMemo(
+		() =>
+			new Map(
+				preparedDiffFiles.map((file) => [file.change.path, patchLineStats(file.treeChangeDiff)]),
+			),
+		[preparedDiffFiles],
+	);
+
 	const allFilesReviewed =
 		preparedDiffFiles.length > 0 &&
 		preparedDiffFiles.length === changes.length &&
@@ -2635,7 +2643,6 @@ const Diff: FC<{
 						projectId={projectId}
 						fileParent={fileParent}
 						changes={changes}
-						lineStats={lineStats}
 						onOpenFilter={fileFilter.open}
 					/>
 				) : (
@@ -2649,6 +2656,7 @@ const Diff: FC<{
 						onRowSelection={activateRow}
 						projectId={projectId}
 						rows={filesRows}
+						lineStatsByPath={lineStatsByPath}
 						collapsedDirectories={filesCollapsedDirectories}
 						onToggleDirectoryCollapsed={(path) =>
 							dispatch(projectSlice.actions.toggleFilesDirectoryCollapsed({ projectId, path }))

--- a/apps/lite/ui/src/routes/project/$id/workspace/DirectoryRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DirectoryRow.tsx
@@ -1,3 +1,5 @@
+import { DiffStats } from "#ui/components/DiffStats.tsx";
+import type { LineStats } from "./lineStats.ts";
 import { FolderIcon } from "#ui/components/FolderIcon.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
@@ -22,6 +24,7 @@ export const DirectoryRow: FC<
 		/** The trailing path segments this row stands for, e.g. `src/lib`. */
 		name: string;
 		fileCount: number;
+		lineStats?: LineStats;
 		depth: number;
 		isCollapsed: boolean;
 		onToggleCollapsed: () => void;
@@ -37,6 +40,7 @@ export const DirectoryRow: FC<
 	path,
 	name,
 	fileCount,
+	lineStats,
 	depth,
 	isCollapsed,
 	onToggleCollapsed,
@@ -99,14 +103,21 @@ export const DirectoryRow: FC<
 			</div>
 
 			<RowLabelContainer>
-				<RowLabel singleLine>{name}</RowLabel>
+				<RowLabel singleLine={lineStats === undefined}>{name}</RowLabel>
 			</RowLabelContainer>
 
 			{/* Collapsed, the count is the only sign of what the row is holding. */}
-			{isCollapsed && (
+			{(isCollapsed || lineStats !== undefined) && (
 				<span className={classes(styles.fileCount, rowStyles.fadedText, "text-11")}>
 					{fileCount}
 				</span>
+			)}
+			{lineStats !== undefined && (
+				<DiffStats
+					added={lineStats.linesAdded}
+					removed={lineStats.linesRemoved}
+					className={styles.lineStats}
+				/>
 			)}
 		</Row>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
@@ -58,3 +58,14 @@
 	color: var(--fill-pop-bg);
 	font-size: 11px;
 }
+
+.inlineStatus {
+	margin-inline-start: 5px;
+	font-weight: 700;
+	font-family: "Geist Mono", monospace;
+}
+.lineStats {
+	margin-inline-start: auto;
+	font-size: 10.5px;
+	font-family: "Geist Mono", monospace;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -34,6 +34,7 @@ const AGE_TOOLTIP_MIN_AGE_MS = 60 * 60_000;
 
 type FileRowProps = {
 	lineStats?: LineStats | null;
+	fileLabel?: string;
 	item: FileRowItem;
 	projectId: string;
 	fileParent: FileParent;
@@ -106,6 +107,7 @@ export const FileRow: FC<FileRowProps> = ({ canUncommit, uncommit, ...props }) =
 export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 	item,
 	lineStats,
+	fileLabel,
 	projectId,
 	fileParent,
 	branchNameByCommitId,
@@ -177,7 +179,7 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 
 			<div className={treeStyles.leading}>
 				<FileIcon
-					fileName={fileName}
+					fileName={pathDisplay === "hidden" ? (fileLabel ?? fileName) : fileName}
 					className={classes(treeStyles.leadingMark, isReviewed && styles.reviewedFade)}
 				/>
 				<RowCheckbox
@@ -227,11 +229,11 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 						aria-label="Conflicted"
 					/>
 				)}
-				<RowLabel singleLine>
+				<RowLabel singleLine={lineStats === undefined}>
 					{directoryPath !== null && pathDisplay === "lead" && (
 						<span className={classes(styles.pathLead, rowStyles.fadedText)}>{directoryPath}/</span>
 					)}
-					{fileName}
+					{pathDisplay === "hidden" ? (fileLabel ?? fileName) : fileName}
 					{lineStats !== undefined &&
 						item._tag === "Change" &&
 						(item.change.status.type !== "Modification" || lineStats === null) && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -1,3 +1,5 @@
+import { DiffStats } from "#ui/components/DiffStats.tsx";
+import type { LineStats } from "./lineStats.ts";
 import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { FileIcon } from "#ui/components/FileIcon.tsx";
 import { FileStatusBadge } from "#ui/components/FileStatusBadge.tsx";
@@ -31,6 +33,7 @@ const FRESH_CHANGE_MAX_AGE_MS = 60_000;
 const AGE_TOOLTIP_MIN_AGE_MS = 60 * 60_000;
 
 type FileRowProps = {
+	lineStats?: LineStats | null;
 	item: FileRowItem;
 	projectId: string;
 	fileParent: FileParent;
@@ -102,6 +105,7 @@ export const FileRow: FC<FileRowProps> = ({ canUncommit, uncommit, ...props }) =
 
 export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 	item,
+	lineStats,
 	projectId,
 	fileParent,
 	branchNameByCommitId,
@@ -228,6 +232,15 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 						<span className={classes(styles.pathLead, rowStyles.fadedText)}>{directoryPath}/</span>
 					)}
 					{fileName}
+					{lineStats !== undefined &&
+						item._tag === "Change" &&
+						(item.change.status.type !== "Modification" || lineStats === null) && (
+							<FileStatusBadge
+								status={item.change.status.type}
+								fontSize={9}
+								className={styles.inlineStatus}
+							/>
+						)}
 					{directoryPath !== null && pathDisplay === "trail" && (
 						<span className={classes(styles.pathInit, rowStyles.fadedText)}>{directoryPath}</span>
 					)}
@@ -292,7 +305,7 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 					</Toolbar.Root>
 				))}
 
-			{item._tag === "Change" && (
+			{lineStats === undefined && item._tag === "Change" && (
 				<Tooltip.Trigger
 					handle={tooltipHandle}
 					payload={{ content: isReviewed ? "Reviewed" : item.change.status.type }}
@@ -311,6 +324,18 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 						)
 					}
 				/>
+			)}
+			{lineStats != null && (
+				<DiffStats
+					added={lineStats.linesAdded}
+					removed={lineStats.linesRemoved}
+					className={styles.lineStats}
+				/>
+			)}
+			{lineStats !== undefined && isReviewed && (
+				<span aria-label="Reviewed" className={styles.reviewedMark}>
+					<Icon size={11} name="tick" />
+				</span>
 			)}
 		</Row>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -16,7 +16,7 @@
 
 .steps {
 	display: flex;
-	column-gap: 4px;
+	column-gap: 0;
 	flex-shrink: 0;
 	align-self: stretch;
 }
@@ -38,7 +38,7 @@
 	position: absolute;
 	width: 1px;
 	inset-block: 0;
-	background-color: color-mix(in srgb, var(--text-2) 20%, transparent);
+	background-color: var(--border-3);
 	content: "";
 }
 
@@ -75,6 +75,7 @@
 .fileCount {
 	flex-shrink: 0;
 	align-self: center;
+	font-family: "Geist Mono", monospace;
 	font-variant-numeric: tabular-nums;
 }
 
@@ -94,4 +95,9 @@
 	&[data-disabled] {
 		display: none;
 	}
+}
+
+.lineStats {
+	font-size: 10.5px;
+	font-family: "Geist Mono", monospace;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -1,3 +1,4 @@
+import type { LineStats } from "./lineStats.ts";
 import rowStyles from "./Row.module.css";
 import { startAbsorb } from "#ui/use-cursor.ts";
 import {
@@ -382,6 +383,7 @@ const DirectoryOperationSource: FC<
  * stable: the bundle only changes identity when one of its members does.
  */
 type RowShared = {
+	lineStatsByPath?: ReadonlyMap<string, LineStats | null>;
 	projectId: string;
 	fileParent: FileParent;
 	focusScope: FocusScope;
@@ -537,6 +539,7 @@ const FilesTreeRow: FC<{
 						render={
 							<FileRow
 								item={item}
+								lineStats={shared.lineStatsByPath?.get(row.path)}
 								depth={row.depth}
 								pathDisplay={pathDisplay}
 								inert={inert}
@@ -562,6 +565,7 @@ const FilesTreeRow: FC<{
 				) : (
 					<FileRowPresentational
 						item={item}
+						lineStats={shared.lineStatsByPath?.get(row.path)}
 						depth={row.depth}
 						pathDisplay={pathDisplay}
 						inert={inert}
@@ -717,6 +721,7 @@ export const FilesTree: FC<
 	{
 		projectId: string;
 		rows: Array<FileTreeRow<FileRowItem>>;
+		lineStatsByPath?: ReadonlyMap<string, LineStats | null>;
 		canUncommit: boolean;
 		uncommit?: (change: TreeChange, extendToCheckedFiles: boolean) => void;
 		collapsedDirectories: Record<string, true>;
@@ -751,6 +756,7 @@ export const FilesTree: FC<
 	} & ComponentProps<"div">
 > = ({
 	rows,
+	lineStatsByPath,
 	canUncommit,
 	uncommit,
 	collapsedDirectories,
@@ -999,6 +1005,7 @@ export const FilesTree: FC<
 	});
 
 	const shared: RowShared = {
+		lineStatsByPath,
 		projectId,
 		fileParent,
 		focusScope,

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -456,15 +456,34 @@ const FilesTreeRow: FC<{
 		branchNameByCommitId,
 		rail,
 	} = shared;
-	const virtStyle: CSSProperties = { position: "absolute", top: 0, left: 0, width: "100%", height };
+	const virtStyle: CSSProperties = {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		width: "100%",
+		height: shared.lineStatsByPath === undefined ? height : undefined,
+	};
 
 	if (row._tag === "Directory") {
+		const lineStats =
+			shared.lineStatsByPath === undefined
+				? undefined
+				: row.filePaths.reduce<LineStats>(
+						(total, path) => {
+							const stats = shared.lineStatsByPath?.get(path);
+							total.linesAdded += stats?.linesAdded ?? 0;
+							total.linesRemoved += stats?.linesRemoved ?? 0;
+							return total;
+						},
+						{ linesAdded: 0, linesRemoved: 0 },
+					);
 		const directoryRow = (
 			<DirectoryRow
 				projectId={projectId}
 				path={row.path}
 				name={row.name}
 				fileCount={row.filePaths.length}
+				lineStats={lineStats}
 				depth={row.depth}
 				isCollapsed={isCollapsed}
 				scrollSelectedIntoView={false}
@@ -540,6 +559,7 @@ const FilesTreeRow: FC<{
 							<FileRow
 								item={item}
 								lineStats={shared.lineStatsByPath?.get(row.path)}
+								fileLabel={row.name}
 								depth={row.depth}
 								pathDisplay={pathDisplay}
 								inert={inert}
@@ -566,6 +586,7 @@ const FilesTreeRow: FC<{
 					<FileRowPresentational
 						item={item}
 						lineStats={shared.lineStatsByPath?.get(row.path)}
+						fileLabel={row.name}
 						depth={row.depth}
 						pathDisplay={pathDisplay}
 						inert={inert}
@@ -605,7 +626,6 @@ const FilesTreeVirtualList: FC<{
 	addressSpace: AddressSpace<string>;
 	selection: string | null;
 	hasPendingOperationSources: boolean;
-	collapsedDirectories: Record<string, true>;
 	reviewedPaths: ReadonlySet<string>;
 	isFileChecked: (path: string) => boolean;
 	directoryCheckedState: (filePaths: Array<string>) => DirectoryCheckedState;
@@ -619,7 +639,6 @@ const FilesTreeVirtualList: FC<{
 	addressSpace,
 	selection,
 	hasPendingOperationSources,
-	collapsedDirectories,
 	reviewedPaths,
 	isFileChecked,
 	directoryCheckedState,
@@ -703,7 +722,7 @@ const FilesTreeVirtualList: FC<{
 						isReviewed={
 							!isDirectory && row.item._tag === "Change" && reviewedPaths.has(row.item.change.path)
 						}
-						isCollapsed={isDirectory && collapsedDirectories[row.path] === true}
+						isCollapsed={row._tag === "Directory" && row.collapsed}
 						holdsSelection={
 							isDirectory &&
 							selection !== null &&
@@ -722,9 +741,9 @@ export const FilesTree: FC<
 		projectId: string;
 		rows: Array<FileTreeRow<FileRowItem>>;
 		lineStatsByPath?: ReadonlyMap<string, LineStats | null>;
+		collapsedDirectories?: Record<string, boolean>;
 		canUncommit: boolean;
 		uncommit?: (change: TreeChange, extendToCheckedFiles: boolean) => void;
-		collapsedDirectories: Record<string, true>;
 		onToggleDirectoryCollapsed: (path: string) => void;
 		selection: string | null;
 		onRowSelection: (selection: string) => void;
@@ -757,9 +776,9 @@ export const FilesTree: FC<
 > = ({
 	rows,
 	lineStatsByPath,
+	collapsedDirectories: _collapsedDirectories,
 	canUncommit,
 	uncommit,
-	collapsedDirectories,
 	onToggleDirectoryCollapsed,
 	selection,
 	onRowSelection,
@@ -1052,7 +1071,6 @@ export const FilesTree: FC<
 					addressSpace={addressSpace}
 					selection={selection}
 					hasPendingOperationSources={hasPendingOperationSources}
-					collapsedDirectories={collapsedDirectories}
 					reviewedPaths={reviewedPaths}
 					isFileChecked={isFileChecked}
 					directoryCheckedState={directoryCheckedState}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -110,6 +110,7 @@
 }
 
 .header {
+	font-family: "Geist Mono", monospace;
 	--row-label-offset: calc(-3px + var(--row-fold-chevron-offset, 0px));
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -509,3 +509,31 @@
 	background: var(--bg-safe);
 	color: var(--text-safe);
 }
+
+.compactToggle {
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-2);
+	font: inherit;
+	text-decoration: underline dotted var(--text-3);
+	text-underline-position: from-font;
+}
+.compactToggle[aria-pressed="true"] {
+	color: var(--text-1);
+	font-weight: 600;
+}
+.activityHeader > div {
+	margin-left: auto;
+}
+.commentList[data-compact="true"] .cardBody {
+	padding: 8px;
+	gap: 4px;
+}
+.commentList[data-compact="true"] .cardFooter {
+	padding: 6px 8px;
+}
+.commentList[data-compact="true"] .avatar {
+	width: 14px;
+	height: 14px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -95,6 +95,7 @@
 
 .cardTime {
 	flex-shrink: 0;
+	margin-left: auto;
 	color: var(--text-2);
 }
 
@@ -494,4 +495,17 @@
 		flex: 1;
 		min-width: 0;
 	}
+}
+
+.verdictBadge[data-verdict="warn"] {
+	background: var(--bg-warn);
+	color: var(--text-warn);
+}
+.verdictBadge[data-verdict="pop"] {
+	background: var(--bg-pop);
+	color: var(--text-pop);
+}
+.verdictBadge[data-verdict="safe"] {
+	background: var(--bg-safe);
+	color: var(--text-safe);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -1189,11 +1189,9 @@ const Composer: FC<{
 };
 
 /**
- * Which of the activity the reader is looking at: what people wrote, what
- * agents wrote, or the whole timeline — every comment and review plus the
- * happenings around them (opened, commits, review requests).
+ * Audience applies to comments, reviews, threads and timeline actors.
  */
-type ActivityFeed = "human" | "agents" | "timeline";
+type ActivityFeed = "all" | "human" | "agents";
 
 /**
  * The activity, newest first: the composer, then comment, review and thread
@@ -1204,7 +1202,8 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 	review,
 }) => {
 	const reviewId = review.number;
-	const [feed, setFeed] = useState<ActivityFeed>("timeline");
+	const [feed, setFeed] = useState<ActivityFeed>("all");
+	const [compact, setCompact] = useState(false);
 	const { data: allComments, isPending } = useQuery(
 		listReviewCommentsQueryOptions({ projectId, reviewId }),
 	);
@@ -1223,12 +1222,27 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 	// thread goes with whoever started it. Everything downstream — the fresh
 	// registration included — sees only what the feed shows, so a hidden
 	// comment is never counted as looked at.
-	const inFeed = (author: ForgeReviewUser | null) =>
-		feed === "timeline" || (author?.isBot ?? false) === (feed === "agents");
-	const comments = allComments?.filter((comment) => inFeed(comment.author));
-	const submissions = allSubmissions?.filter((submission) => inFeed(submission.author));
-	const threads = allThreads?.filter((thread) => inFeed(thread.comments[0]?.author ?? null));
-	const shownEvents = feed === "timeline" ? events : undefined;
+	const inFeed = useCallback(
+		(author: ForgeReviewUser | null) =>
+			feed === "all" || (author?.isBot ?? false) === (feed === "agents"),
+		[feed],
+	);
+	const comments = useMemo(
+		() => allComments?.filter((comment) => inFeed(comment.author)),
+		[allComments, inFeed],
+	);
+	const submissions = useMemo(
+		() => allSubmissions?.filter((submission) => inFeed(submission.author)),
+		[allSubmissions, inFeed],
+	);
+	const threads = useMemo(
+		() => allThreads?.filter((thread) => inFeed(thread.comments[0]?.author ?? null)),
+		[allThreads, inFeed],
+	);
+	const shownEvents = useMemo(
+		() => events?.filter((event) => inFeed(event.actor)),
+		[events, inFeed],
+	);
 	const { data: currentLogin } = useQuery(currentForgeLoginQueryOptions(projectId));
 	// Whether the review's branch is in the workspace; its threads only check
 	// themselves against the working file when it is.
@@ -1315,9 +1329,9 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 	const items = useMemo(
 		() =>
 			timelineItems(review, comments, submissions, loose, shownEvents).filter(
-				(item) => shownEvents !== undefined || item.kind !== "opened",
+				(item) => item.kind !== "opened" || inFeed(item.review.author),
 			),
-		[review, comments, submissions, loose, shownEvents],
+		[review, comments, submissions, loose, shownEvents, inFeed],
 	);
 
 	// A notification named a comment: scroll to it once it is on the page.
@@ -1371,24 +1385,32 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 			<div className={styles.activityHeader}>
 				<h3 className={classes("text-15", "text-semibold")}>Activity</h3>
 				<ToggleGroup
-					render={<ToggleGroupStyles />}
+					render={<ToggleGroupStyles segmented />}
 					value={[feed]}
 					onValueChange={(value: Array<ActivityFeed>) => {
 						const head = value[0];
 						if (head !== undefined) setFeed(head);
 					}}
-					aria-label="Activity feed"
+					aria-label="Activity audience"
 				>
+					<Toggle render={<ToggleStyles />} value={"all" satisfies ActivityFeed}>
+						All
+					</Toggle>
 					<Toggle render={<ToggleStyles />} value={"human" satisfies ActivityFeed}>
 						Humans
 					</Toggle>
 					<Toggle render={<ToggleStyles />} value={"agents" satisfies ActivityFeed}>
 						Agents
 					</Toggle>
-					<Toggle render={<ToggleStyles />} value={"timeline" satisfies ActivityFeed}>
-						Timeline
-					</Toggle>
 				</ToggleGroup>
+				<button
+					type="button"
+					className={styles.compactToggle}
+					aria-pressed={compact}
+					onClick={() => setCompact(!compact)}
+				>
+					Compact
+				</button>
 			</div>
 			<Composer
 				avatarUrl={ownForgeAvatar(items, currentLogin) ?? profile?.picture}
@@ -1405,7 +1427,7 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 					{feed === "agents" ? "No comments from agents yet" : "No comments yet"}
 				</div>
 			) : (
-				<div className={styles.commentList}>
+				<div className={styles.commentList} data-compact={compact}>
 					{items.map((item) =>
 						item.kind === "comment" ? (
 							<Comment

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -1,3 +1,4 @@
+import { reviewVerdictBody } from "#ui/pr.ts";
 import {
 	useSetReviewThreadResolved,
 	useAddCommentReaction,
@@ -151,7 +152,15 @@ const Card: FC<{
 			<div className={styles.cardHeader}>
 				<div className={styles.cardIdentity}>
 					{author !== null && <Author user={author} />}
-					{badge !== undefined && <Badge variant={badge.variant}>{badge.label}</Badge>}
+					{badge !== undefined && (
+						<Badge
+							variant={badge.variant}
+							className={styles.verdictBadge}
+							data-verdict={badge.variant}
+						>
+							{badge.label}
+						</Badge>
+					)}
 					{pendingLabel !== undefined ? (
 						<span className={classes("text-12", styles.cardTime)}>{pendingLabel}</span>
 					) : (
@@ -236,6 +245,7 @@ const Comment: FC<{
 	/** Quote this comment into the composer. */
 	onReply: (comment: Quotable) => void;
 }> = ({ projectId, reviewId, comment, currentLogin, onReply }) => {
+	const presentation = reviewVerdictBody(comment.body);
 	const createdAtMs = comment.createdAt === null ? null : Date.parse(comment.createdAt);
 	const isOwn = currentLogin != null && comment.author?.login === currentLogin;
 	// An optimistic comment awaiting its forge id; nothing can act on it yet.
@@ -311,6 +321,7 @@ const Comment: FC<{
 	return (
 		<Card
 			author={comment.author}
+			badge={presentation.badge}
 			id={comment.id > 0 ? commentAnchorId(comment.id) : undefined}
 			className={isSending ? styles.cardSending : undefined}
 			timestamp={createdAtMs}
@@ -354,7 +365,7 @@ const Comment: FC<{
 				/>
 			) : (
 				<Clamped maxHeight="240px">
-					<Markdown>{comment.body}</Markdown>
+					<Markdown>{presentation.body}</Markdown>
 				</Clamped>
 			)}
 		</Card>
@@ -393,6 +404,7 @@ export const ThreadComment: FC<{ comment: ForgeReviewThreadComment; compact?: bo
 	comment,
 	compact = false,
 }) => {
+	const { body, badge } = reviewVerdictBody(comment.body);
 	const createdAtMs = comment.createdAt === null ? null : Date.parse(comment.createdAt);
 
 	return (
@@ -402,6 +414,15 @@ export const ThreadComment: FC<{ comment: ForgeReviewThreadComment; compact?: bo
 		>
 			<div className={styles.cardIdentity}>
 				{comment.author !== null && <Author user={comment.author} />}
+				{badge !== undefined && (
+					<Badge
+						variant={badge.variant}
+						className={styles.verdictBadge}
+						data-verdict={badge.variant}
+					>
+						{badge.label}
+					</Badge>
+				)}
 				{createdAtMs !== null && (
 					<RelativeTime timestamp={createdAtMs} className={classes("text-12", styles.cardTime)} />
 				)}
@@ -412,7 +433,7 @@ export const ThreadComment: FC<{ comment: ForgeReviewThreadComment; compact?: bo
 				/>
 			</div>
 			<Clamped maxHeight="200px">
-				<Markdown>{comment.body}</Markdown>
+				<Markdown>{body}</Markdown>
 			</Clamped>
 		</div>
 	);
@@ -741,8 +762,8 @@ const submissionBadge: Record<
 	ForgeReviewSubmission["state"],
 	{ variant: BadgeVariant; label: string }
 > = {
-	approved: { variant: "safe", label: "Approved changes" },
-	changesRequested: { variant: "danger", label: "Requested changes" },
+	approved: { variant: "safe", label: "Approved" },
+	changesRequested: { variant: "warn", label: "Changes recommended" },
 	commented: { variant: "lightGray", label: "Reviewed" },
 	dismissed: { variant: "lightGray", label: "Review dismissed" },
 };
@@ -759,7 +780,8 @@ const Submission: FC<{
 	onReply: (submission: Quotable) => void;
 }> = ({ projectId, reviewId, submission, threads, branchApplied, currentLogin, onReply }) => {
 	const submittedAtMs = submission.submittedAt === null ? null : Date.parse(submission.submittedAt);
-	const body = submission.body?.trim() === "" ? null : submission.body;
+	const presentation = reviewVerdictBody(submission.body ?? "");
+	const body = presentation.body.trim() === "" ? null : presentation.body;
 
 	// The listing carries every reaction with who left it, so unlike a
 	// comment there is no second request before the chips can toggle.
@@ -778,7 +800,7 @@ const Submission: FC<{
 	return (
 		<Card
 			author={submission.author}
-			badge={submissionBadge[submission.state]}
+			badge={presentation.badge ?? submissionBadge[submission.state]}
 			timestamp={submittedAtMs}
 			freshKey={`s:${submission.id}`}
 			id={submission.id > 0 ? commentAnchorId(submission.id) : undefined}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -1,5 +1,6 @@
 .prActions {
 	display: flex;
+	align-items: flex-start;
 	gap: 7px;
 }
 
@@ -198,4 +199,18 @@
 	&:hover {
 		color: var(--text-1);
 	}
+}
+
+.mergeControl {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 4px;
+}
+.mergeBlocker {
+	max-width: 270px;
+	color: var(--text-warn);
+	font-weight: 600;
+	font-size: 11px;
+	text-align: end;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -214,3 +214,16 @@
 	font-size: 11px;
 	text-align: end;
 }
+
+.descriptionBody {
+	background: var(--bg-1);
+}
+.descriptionBody .descriptionMarkdown {
+	font-size: 14px;
+	line-height: 1.6;
+}
+.descriptionBody button {
+	color: var(--text-2);
+	text-decoration-color: var(--text-3);
+	opacity: 1;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -649,13 +649,11 @@ export const PullRequestDescription: FC<{
 			{meta}
 
 			{body !== null && body.trim() !== "" ? (
-				// A long description opens as a four-line card so the conversation
-				// below is in reach: four rather than three because a body that opens
-				// with a heading spends a line and a half on it. The slack means a
-				// fold always hides at least a few lines, never just one.
-				<Clamped maxHeight="4lh" foldOver="6lh" variant="card">
-					<Markdown>{body}</Markdown>
-				</Clamped>
+				<div className={styles.descriptionBody}>
+					<Clamped maxHeight="12lh">
+						<Markdown className={styles.descriptionMarkdown}>{body}</Markdown>
+					</Clamped>
+				</div>
 			) : (
 				<p className={classes("text-14", "text-body", styles.prViewEmptyBody)}>
 					No description

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -1,3 +1,4 @@
+import { useMergeReadiness } from "#ui/pr.ts";
 import {
 	type PushBeforePublish,
 	useAddReviewReaction,
@@ -15,7 +16,6 @@ import {
 	branchDetailsQueryOptions,
 	currentForgeLoginQueryOptions,
 	forgeInfoOptions,
-	getReviewMergeStatusQueryOptions,
 	listReviewReactionsQueryOptions,
 	listReviewTimelineEventsQueryOptions,
 } from "#ui/api/queries.ts";
@@ -54,7 +54,7 @@ import {
 } from "#ui/pr.ts";
 import { type FocusScope, useAutofocusScope } from "#ui/focus-scopes.ts";
 import { Button, Field, Tooltip } from "@base-ui/react";
-import type { ForgeReview, ReviewMergeMethod, ReviewMergeStatus } from "@gitbutler/but-sdk";
+import type { ForgeReview, ReviewMergeMethod } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
@@ -689,29 +689,6 @@ export const PullRequestDescription: FC<{
 	);
 };
 
-/** Why the Merge button is disabled, or null when merging is possible. */
-const mergeBlockedReason = (mergeStatus: ReviewMergeStatus | undefined): string | null => {
-	if (mergeStatus === undefined) return "Checking mergeability…";
-	if (mergeStatus.isMergeable) return null;
-
-	switch (mergeStatus.mergeableState) {
-		case "blocked":
-			return "Blocked: required approvals or checks are not satisfied";
-		case "behind":
-			return "Behind the base branch; update the branch first";
-		case "dirty":
-			return "Merge conflicts with the base branch";
-		case "draft":
-			return "Draft pull requests cannot be merged";
-		case "unknown":
-		case "checking":
-		case null:
-			return "Mergeability not yet determined by the forge";
-		default:
-			return `Not mergeable (state: ${mergeStatus.mergeableState})`;
-	}
-};
-
 /** The choice persists per project (see mergeMethodQueryOptions). */
 const mergeMethods = [
 	"merge",
@@ -742,11 +719,7 @@ export const PullRequestPrimaryAction: FC<{
 	const isMerged = review.mergedAt !== null;
 	const isClosed = !isMerged && review.closedAt !== null;
 
-	const { data: mergeStatus } = useQuery({
-		...getReviewMergeStatusQueryOptions({ projectId, reviewId }),
-		// Minimise API calls.
-		enabled: !isDraft,
-	});
+	const readiness = useMergeReadiness(projectId, review);
 	const { data: storedMergeMethod } = useQuery(mergeMethodQueryOptions(projectId));
 	const mergeMethod = storedMergeMethod ?? "merge";
 	const { mutate: persistMergeMethod } = usePersistMergeMethod();
@@ -764,7 +737,7 @@ export const PullRequestPrimaryAction: FC<{
 		isSetReviewDraftinessPending ||
 		isSetReviewAutoMergePending;
 
-	const blockedReason = mergeBlockedReason(mergeStatus);
+	const blockedReason = readiness.blocker;
 
 	// A merged review can be neither drafted nor reopened, so its menu is the
 	// browser link alone; `nativeMenuItemsFromGroups` would otherwise trail a
@@ -832,29 +805,32 @@ export const PullRequestPrimaryAction: FC<{
 						onCheckedChange={(enable) => setReviewAutoMerge({ projectId, reviewId, enable })}
 					/>
 
-					<DropdownButton
-						variant="pop"
-						disabled={isAnyPending || blockedReason !== null}
-						onClick={() => mergeReview({ projectId, reviewId, mergeMethod })}
-						actionTooltip={!isAnyPending && blockedReason !== null ? blockedReason : undefined}
-						menuLabel="Merge method"
-						menuDisabled={isAnyPending}
-						onMenuTrigger={(trigger) =>
-							void showNativeMenuFromTrigger(
-								trigger,
-								mergeMethods.map((method) =>
-									nativeMenuItem({
-										label: mergeMethodLabels[method],
-										checked: method === mergeMethod,
-										onSelect: () => persistMergeMethod({ projectId, method }),
-									}),
-								),
-							)
-						}
-					>
-						{isMergeReviewPending && <Icon name="spinner" />}
-						{mergeMethodLabels[mergeMethod]}
-					</DropdownButton>
+					<div className={styles.mergeControl}>
+						<DropdownButton
+							variant="pop"
+							disabled={isAnyPending || blockedReason !== null}
+							onClick={() => mergeReview({ projectId, reviewId, mergeMethod })}
+							actionTooltip={!isAnyPending && blockedReason !== null ? blockedReason : undefined}
+							menuLabel="Merge method"
+							menuDisabled={isAnyPending}
+							onMenuTrigger={(trigger) =>
+								void showNativeMenuFromTrigger(
+									trigger,
+									mergeMethods.map((method) =>
+										nativeMenuItem({
+											label: mergeMethodLabels[method],
+											checked: method === mergeMethod,
+											onSelect: () => persistMergeMethod({ projectId, method }),
+										}),
+									),
+								)
+							}
+						>
+							{isMergeReviewPending && <Icon name="spinner" />}
+							{mergeMethodLabels[mergeMethod]}
+						</DropdownButton>
+						{blockedReason !== null && <span className={styles.mergeBlocker}>{blockedReason}</span>}
+					</div>
 				</>
 			)}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -41,6 +41,11 @@
 	display: flex;
 	align-items: center;
 	color: var(--text-2);
+	font:
+		10px "Geist Mono",
+		monospace;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
 }
 
 .sectionToggle {
@@ -348,6 +353,7 @@
 	flex-wrap: wrap;
 	align-items: center;
 	gap: 6px;
+	font-family: "Geist Mono", monospace;
 }
 
 /* Dotted underline is the app's copy-a-reference affordance, as on the commit
@@ -390,10 +396,6 @@
 	color: var(--text-2);
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-
-.created {
-	color: var(--text-2);
 }
 
 .readiness {
@@ -447,4 +449,92 @@
 }
 .readinessDot[data-tone="pending"] {
 	border: 1px solid var(--border-1);
+}
+
+.reviewPanel {
+	height: calc(100cqh - 40px);
+	min-height: 400px;
+	overflow: hidden;
+}
+.panelTop {
+	flex: none;
+	max-height: calc(100% - 120px);
+	overflow-y: auto;
+}
+.owners {
+	color: var(--text-2);
+	font:
+		12px "Geist Mono",
+		monospace;
+	overflow-wrap: anywhere;
+}
+.filesSection {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-height: 0;
+	padding: 12px 14px;
+	gap: 10px;
+	border-top: 1px solid var(--border-section);
+}
+.filesList {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	color: var(--text-2);
+	font-size: 12px;
+}
+.file {
+	display: flex;
+	align-items: baseline;
+	padding-block: 5px;
+	gap: 6px;
+	color: var(--text-1);
+}
+.file > i {
+	flex: none;
+	align-self: center;
+}
+.fileName {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.file > [data-status-type] {
+	flex: none;
+	font-weight: 700;
+	font-family: "Geist Mono", monospace;
+}
+.moreFiles {
+	margin-top: 8px;
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-2);
+	font: inherit;
+	text-decoration: underline dotted var(--text-3);
+	text-underline-position: from-font;
+}
+@container (max-width: 720px) {
+	.reviewPanel {
+		height: auto;
+		min-height: 0;
+	}
+	.panelTop {
+		max-height: none;
+		overflow: visible;
+	}
+	.filesList {
+		max-height: 220px;
+	}
+}
+
+.readinessHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 8px;
+	gap: 8px;
+}
+.readinessHeader h4 {
+	margin: 0;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -395,3 +395,56 @@
 .created {
 	color: var(--text-2);
 }
+
+.readiness {
+	padding: 14px;
+	border-radius: var(--radius-card) var(--radius-card) 0 0;
+	background: var(--bg-warn);
+}
+.readiness[data-ready="true"] {
+	background: var(--bg-safe);
+}
+.readiness h4 {
+	margin: 0 0 8px;
+	color: var(--text-warn);
+	font:
+		10px "Geist Mono",
+		monospace;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+.readiness[data-ready="true"] h4 {
+	color: var(--text-safe);
+}
+.readiness strong {
+	display: block;
+	margin-bottom: 10px;
+	color: var(--text-1);
+	font-weight: 600;
+	font-size: 14px;
+}
+.readinessRow {
+	display: flex;
+	align-items: center;
+	margin-top: 6px;
+	gap: 8px;
+	font-size: 12px;
+}
+.readinessDot {
+	flex: none;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+}
+.readinessDot[data-tone="safe"] {
+	background: var(--fill-safe-bg);
+}
+.readinessDot[data-tone="warn"] {
+	background: var(--fill-warn-bg);
+}
+.readinessDot[data-tone="danger"] {
+	background: var(--fill-danger-bg);
+}
+.readinessDot[data-tone="pending"] {
+	border: 1px solid var(--border-1);
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -1,3 +1,5 @@
+import { FileIcon } from "#ui/components/FileIcon.tsx";
+import { FileStatusBadge } from "#ui/components/FileStatusBadge.tsx";
 import { reportError } from "#ui/error-reporting.ts";
 import {
 	useAddReviewLabels,
@@ -8,6 +10,7 @@ import {
 	useWithdrawReviewRequest,
 } from "#ui/api/mutations.ts";
 import {
+	branchDiffQueryOptions,
 	currentForgeLoginQueryOptions,
 	forgeInfoOptions,
 	listCIChecksQueryOptions,
@@ -37,9 +40,9 @@ import {
 	reviewerRows,
 	useMergeReadiness,
 } from "#ui/pr.ts";
-import { formatAbsoluteTime, formatCompactDuration, formatRelativeTime } from "#ui/time.ts";
+import { formatCompactDuration } from "#ui/time.ts";
 import { useCopied } from "#ui/routes/project/$id/workspace/useCopied.ts";
-import { loginKey, sameLogin } from "#ui/review-users.ts";
+import { sameLogin } from "#ui/review-users.ts";
 import type { CiCheck, ForgeReview, ForgeReviewUser } from "@gitbutler/but-sdk";
 import { Tooltip } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
@@ -568,6 +571,51 @@ const verdictBits = (verdict: ReviewerVerdict): [IconName, string, string] =>
 		Match.exhaustive,
 	);
 
+const ReviewFiles: FC<{ projectId: string; sourceBranch: string }> = ({
+	projectId,
+	sourceBranch,
+}) => {
+	const [showAll, setShowAll] = useState(false);
+	const {
+		data: changes,
+		isPending,
+		isError,
+	} = useQuery({
+		...branchDiffQueryOptions({ projectId, branch: `refs/heads/${sourceBranch}` }),
+		select: (diff) => diff.changes,
+	});
+	const visible = showAll ? changes : changes?.slice(0, 8);
+	return (
+		<section className={styles.filesSection} aria-label="Files changed">
+			<h4 className={styles.heading}>Files changed{changes && <span> · {changes.length}</span>}</h4>
+			<div className={styles.filesList}>
+				{isPending ? (
+					<span>Loading files…</span>
+				) : isError ? (
+					<span>Files unavailable locally</span>
+				) : changes.length === 0 ? (
+					<span>No changed files</span>
+				) : (
+					visible?.map((change) => (
+						<div className={styles.file} key={change.path} title={change.path}>
+							<FileIcon fileName={change.path} />
+							<span className={styles.fileName}>{change.path}</span>
+							{change.status.type !== "Modification" && (
+								<FileStatusBadge status={change.status.type} fontSize={9} />
+							)}
+						</div>
+					))
+				)}
+				{!showAll && changes && changes.length > 8 && (
+					<button type="button" className={styles.moreFiles} onClick={() => setShowAll(true)}>
+						{changes.length - 8} more
+					</button>
+				)}
+			</div>
+		</section>
+	);
+};
+
 export const PullRequestPanel: FC<{
 	projectId: string;
 	review: ForgeReview;
@@ -601,6 +649,8 @@ export const PullRequestPanel: FC<{
 		useSetReviewDraftiness(projectId);
 	const { isPending: isUpdateReviewPending, mutate: updateReview } = useUpdateReview(projectId);
 
+	const topics = review.labels.filter((label) => !label.name.startsWith("@gitbutler/"));
+	const owners = review.labels.filter((label) => label.name.startsWith("@gitbutler/"));
 	const status = reviewStatus(review);
 	// A merged review is final; anything else can move between open, draft and
 	// closed from the status badge.
@@ -720,132 +770,130 @@ export const PullRequestPanel: FC<{
 		</Badge>
 	);
 
-	const createdAtMs = review.createdAt === null ? null : Date.parse(review.createdAt);
-
 	const handleOpen = (evt: MouseEvent<HTMLAnchorElement>): void => {
 		evt.preventDefault();
 		window.lite.openInWebBrowser(review.htmlUrl).catch(reportError);
 	};
 
 	return (
-		<aside className={styles.panel}>
-			<section
-				className={styles.readiness}
-				data-ready={readiness.ready}
-				aria-label="Merge readiness"
-			>
-				<h4>Merge readiness</h4>
-				<strong>{readiness.headline}</strong>
-				{readiness.rows.map((row) => (
-					<div key={row.label} className={styles.readinessRow}>
-						<span className={styles.readinessDot} data-tone={row.tone} />
-						{row.label}
-					</div>
-				))}
-			</section>
-			<Section
-				heading="Status"
-				action={
-					<div className={styles.statusActions}>
-						{canSwitchStatus ? (
-							<button
-								aria-label="Change status"
-								className={styles.statusTrigger}
-								disabled={isStatusPending}
-								onClick={openStatusMenu}
-								type="button"
+		<aside className={classes(styles.panel, styles.reviewPanel)}>
+			<div className={styles.panelTop}>
+				<section
+					className={styles.readiness}
+					data-ready={readiness.ready}
+					aria-label="Merge readiness"
+				>
+					<div className={styles.readinessHeader}>
+						<h4>Merge readiness</h4>
+						<div className={styles.statusActions}>
+							{canSwitchStatus ? (
+								<button
+									aria-label="Change status"
+									className={styles.statusTrigger}
+									disabled={isStatusPending}
+									onClick={openStatusMenu}
+									type="button"
+								>
+									{statusBadge}
+								</button>
+							) : (
+								statusBadge
+							)}
+							<a
+								href={review.htmlUrl}
+								onClick={handleOpen}
+								className={classes("text-12", styles.link, styles.prLink)}
 							>
-								{statusBadge}
-							</button>
-						) : (
-							statusBadge
-						)}
-						<a
-							href={review.htmlUrl}
-							onClick={handleOpen}
-							className={classes("text-12", styles.link, styles.prLink)}
-						>
-							{review.unitSymbol}
-							{review.number}
-							<Icon name="arrow-up-right" size={12} />
-						</a>
+								{review.unitSymbol}
+								{review.number}
+								<Icon name="arrow-up-right" size={12} />
+							</a>
+						</div>
 					</div>
-				}
-			>
-				{null}
-			</Section>
+					<strong>{readiness.headline}</strong>
+					{readiness.rows.map((row) => (
+						<div key={row.label} className={styles.readinessRow}>
+							<span className={styles.readinessDot} data-tone={row.tone} />
+							{row.label}
+						</div>
+					))}
+				</section>
 
-			{forgeInfo?.capabilities.checks === true && (
-				<ChecksSection projectId={projectId} reference={review.sourceBranch} />
-			)}
-
-			<Section
-				heading="Reviewers"
-				collapsible={reviewerList.length > 0}
-				action={
-					canPickReviewers &&
-					pickerButton({
-						label: "Add reviewers",
-						icon: "user",
-						empty: reviewerList.length === 0,
-						onClick: openReviewerMenu,
-					})
-				}
-			>
-				{reviewerList.map(({ user, verdict }) => (
-					<ReviewerRow
-						key={user.id}
-						user={user}
-						verdict={verdict}
-						onWithdraw={
-							canManage && verdict === "awaiting"
-								? () =>
-										withdrawReviewRequest({
-											projectId,
-											reviewId: review.number,
-											logins: [user.login],
-										})
-								: null
-						}
-					/>
-				))}
-			</Section>
-
-			<Section
-				heading="Labels"
-				action={
-					canPickLabels &&
-					pickerButton({
-						label: "Add labels",
-						icon: "tag",
-						empty: review.labels.length === 0,
-						onClick: openLabelMenu,
-					})
-				}
-			>
-				{review.labels.length > 0 && (
-					<div className={styles.labels}>
-						{review.labels.map((label) => (
-							<ForgeLabel key={label.name} label={label} />
-						))}
-					</div>
+				{forgeInfo?.capabilities.checks === true && (
+					<ChecksSection projectId={projectId} reference={review.sourceBranch} />
 				)}
-			</Section>
 
-			<Section heading="Branches">
-				<div className={classes("text-13", styles.branches)}>
-					<CopyableBranch name={review.sourceBranch} />
-					<TargetBranch name={review.targetBranch} />
-				</div>
-			</Section>
+				<Section
+					heading="Reviewers"
+					collapsible={reviewerList.length > 0}
+					action={
+						canPickReviewers &&
+						pickerButton({
+							label: "Add reviewers",
+							icon: "user",
+							empty: reviewerList.length === 0,
+							onClick: openReviewerMenu,
+						})
+					}
+				>
+					{reviewerList.map(({ user, verdict }) => (
+						<ReviewerRow
+							key={user.id}
+							user={user}
+							verdict={verdict}
+							onWithdraw={
+								canManage && verdict === "awaiting"
+									? () =>
+											withdrawReviewRequest({
+												projectId,
+												reviewId: review.number,
+												logins: [user.login],
+											})
+									: null
+							}
+						/>
+					))}
+				</Section>
 
-			{createdAtMs !== null && (
-				<Section heading="Created">
-					<span className={classes("text-13", styles.created)}>
-						{formatRelativeTime(createdAtMs)}, {formatAbsoluteTime(createdAtMs)}
+				<Section
+					heading="Topics"
+					action={
+						canPickLabels &&
+						pickerButton({
+							label: "Add labels",
+							icon: "tag",
+							empty: topics.length === 0,
+							onClick: openLabelMenu,
+						})
+					}
+				>
+					{topics.length > 0 && (
+						<div className={styles.labels}>
+							{topics.map((label) => (
+								<ForgeLabel key={label.name} label={label} />
+							))}
+						</div>
+					)}
+				</Section>
+
+				<Section heading="Owners">
+					<span className={styles.owners}>
+						{owners.length === 0 ? "No owners" : owners.map((label) => label.name).join(" · ")}
 					</span>
 				</Section>
-			)}
+
+				<Section heading="Branches">
+					<div className={classes("text-13", styles.branches)}>
+						<CopyableBranch name={review.sourceBranch} />
+						<TargetBranch name={review.targetBranch} />
+					</div>
+				</Section>
+			</div>
+			<ReviewFiles
+				key={review.sourceBranch}
+				projectId={projectId}
+				sourceBranch={review.sourceBranch}
+			/>
 		</aside>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -30,16 +30,17 @@ import {
 	showNativeMenuFromTrigger,
 } from "#ui/native-menu.ts";
 import { openLinkExternally } from "#ui/external-link.ts";
-import type { DraftPRExtras } from "#ui/pr.ts";
+import {
+	type DraftPRExtras,
+	type ReviewerVerdict,
+	type ReviewerRow,
+	reviewerRows,
+	useMergeReadiness,
+} from "#ui/pr.ts";
 import { formatAbsoluteTime, formatCompactDuration, formatRelativeTime } from "#ui/time.ts";
 import { useCopied } from "#ui/routes/project/$id/workspace/useCopied.ts";
 import { loginKey, sameLogin } from "#ui/review-users.ts";
-import type {
-	CiCheck,
-	ForgeReview,
-	ForgeReviewSubmission,
-	ForgeReviewUser,
-} from "@gitbutler/but-sdk";
+import type { CiCheck, ForgeReview, ForgeReviewUser } from "@gitbutler/but-sdk";
 import { Tooltip } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -553,42 +554,6 @@ const ChecksSection: FC<{ projectId: string; reference: string }> = ({ projectId
 	);
 };
 
-/** Dismissals collapse to "commented", so they never appear as a verdict. */
-type ReviewerVerdict = "approved" | "changesRequested" | "commented" | "awaiting";
-
-type ReviewerRow = { user: ForgeReviewUser; verdict: ReviewerVerdict };
-
-/**
- * One row per reviewer: everyone still requested (awaiting) plus everyone
- * who submitted a review, carrying their effective verdict. A comment-only
- * submission never overrides an earlier approval or change request, and a
- * dismissal drops the verdict back to commented.
- */
-const reviewerRows = (
-	requested: Array<ForgeReviewUser>,
-	submissions: Array<ForgeReviewSubmission>,
-): Array<ReviewerRow> => {
-	const byLogin = new Map<string, ReviewerRow>();
-	for (const submission of submissions) {
-		if (submission.author === null) continue;
-		const existing = byLogin.get(loginKey(submission.author.login));
-		const verdict = Match.value(submission.state).pipe(
-			Match.withReturnType<ReviewerVerdict>(),
-			Match.when("approved", () => "approved"),
-			Match.when("changesRequested", () => "changesRequested"),
-			Match.when("commented", () => existing?.verdict ?? "commented"),
-			Match.when("dismissed", () => "commented"),
-			Match.exhaustive,
-		);
-		byLogin.set(loginKey(submission.author.login), { user: submission.author, verdict });
-	}
-	for (const user of requested) {
-		const key = loginKey(user.login);
-		if (!byLogin.has(key)) byLogin.set(key, { user, verdict: "awaiting" });
-	}
-	return [...byLogin.values()];
-};
-
 const verdictBits = (verdict: ReviewerVerdict): [IconName, string, string] =>
 	Match.value(verdict).pipe(
 		Match.withReturnType<[IconName, string, string]>(),
@@ -607,6 +572,7 @@ export const PullRequestPanel: FC<{
 	projectId: string;
 	review: ForgeReview;
 }> = ({ projectId, review }) => {
+	const readiness = useMergeReadiness(projectId, review);
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const { data: reviewers } = useQuery({
 		...listReviewSubmissionsQueryOptions({ projectId, reviewId: review.number }),
@@ -763,6 +729,20 @@ export const PullRequestPanel: FC<{
 
 	return (
 		<aside className={styles.panel}>
+			<section
+				className={styles.readiness}
+				data-ready={readiness.ready}
+				aria-label="Merge readiness"
+			>
+				<h4>Merge readiness</h4>
+				<strong>{readiness.headline}</strong>
+				{readiness.rows.map((row) => (
+					<div key={row.label} className={styles.readinessRow}>
+						<span className={styles.readinessDot} data-tone={row.tone} />
+						{row.label}
+					</div>
+				))}
+			</section>
 			<Section
 				heading="Status"
 				action={

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
@@ -1,9 +1,6 @@
 import { type ButtonSize, type ButtonVariant, getButtonClassName } from "#ui/components/Button.tsx";
-import { classes } from "#ui/components/classes.ts";
 import { addressIdentityKey, type Address } from "#ui/addresses.ts";
 import { useCursorMatches } from "#ui/use-cursor.ts";
-import { Match } from "effect";
-import styles from "./Row.module.css";
 
 export const treeItemId = (address: Address): string =>
 	`sidebar-treeitem-${encodeURIComponent(addressIdentityKey(address))}`;
@@ -26,23 +23,7 @@ export const getRowButtonClassName = ({
 	variant?: Extract<ButtonVariant, "ghost" | "outline">;
 	size?: ButtonSize;
 	iconOnly?: boolean;
-}) =>
-	classes(
-		getButtonClassName({
-			variant,
-			size,
-			iconOnly,
-			// On selection/focus change we change the button variant. This
-			// transition would clash with other selection/focus style changes
-			// which are instant (e.g. the row background).
-			disableTransition: true,
-		}),
-		Match.value(variant).pipe(
-			Match.when("ghost", () => styles.buttonGhost),
-			Match.when("outline", () => styles.buttonOutline),
-			Match.exhaustive,
-		),
-	);
+}) => getButtonClassName({ variant, size, iconOnly });
 
 /** One title line plus a metadata line; shared by both commit list virtualizers. */
 export const COMMIT_ROW_HEIGHT = 54;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -50,56 +50,15 @@
 	}
 }
 
-/* Three tiers, because a row can be selected in three different senses. Every
-   selected row keeps a fill: the lists are navigated with the keyboard, so
-   where each one's cursor sits has to stay legible from the other one. What
-   separates them is the rail below and the focused fill further down. */
+/* A selected row keeps the same treatment as focus moves between panels. */
 .containerSelected {
-	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
-
-	/* Only one row in the window is the source of what the details pane shows.
-	   A rail on its leading edge says so even when focus has moved away — into
-	   the other list, or into the pane itself — so two tinted rows never read
-	   as equals. */
-	&:is([data-preview-source="true"] *) {
-		position: relative;
-
-		&::before {
-			position: absolute;
-			width: 4px;
-			inset-block: 0;
-			inset-inline-start: 0;
-			background-color: var(--fill-gray-bg);
-			content: "";
-		}
-	}
-
-	&:has(:is(textarea, input):focus),
-	[data-selection-focus-styles="true"] [data-focus-scope][data-selection-focused="true"] & {
-		background-color: var(--fill-gray-bg);
-		color: var(--fill-gray-fg);
-	}
+	background-color: color-mix(in srgb, var(--fill-pop-bg) 10%, transparent);
 }
 
 /* Answers a hovered dependency indicator. */
 .containerHighlighted {
-	background-color: color-mix(var(--fill-pop-bg) 20%, transparent);
+	background-color: color-mix(in srgb, var(--fill-pop-bg) 20%, transparent);
 	color: var(--text-1);
-
-	/* The row pointed at is often the selected one, and when that selection is
-	   focused its solid fill out-specifies the tint above — leaving a hover that
-	   changes nothing. It deepens instead of going solid: enough over the tint
-	   to separate the selected row from its fellow dependencies, not so much
-	   that a passing hover repaints the panel. */
-	&.containerSelected:has(:is(textarea, input):focus),
-	[data-selection-focus-styles="true"]
-		[data-focus-scope][data-selection-focused="true"]
-		&.containerSelected {
-		background-color: color-mix(var(--fill-pop-bg) 30%, transparent);
-		/* Restated because the selection's own rule ties this one and would
-		   otherwise leave its inverted text on a fill no longer dark enough. */
-		color: var(--text-1);
-	}
 }
 
 .toolbar {
@@ -237,17 +196,6 @@
 .rowCheckbox {
 	--checkbox-height: 14px;
 	margin-block-start: calc((var(--single-line-row-height) - var(--checkbox-height)) / 2);
-
-	/* On the focused selection's solid fill, an unchecked box painted in --bg-1
-	   reads as a light chip punched out of the row. It takes the fill instead, so
-	   only its border marks it out. */
-	[data-selection-focus-styles="true"]
-		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected:not(.containerHighlighted)
-		&,
-	.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) & {
-		--checkbox-bg: var(--fill-gray-bg);
-	}
 }
 
 .labelContainer {
@@ -337,47 +285,9 @@
 
 .fadedText {
 	color: var(--text-2);
-
-	[data-selection-focus-styles="true"]
-		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected:not(.containerHighlighted)
-		& {
-		color: var(--text-2-invert);
-	}
 }
-
-.buttonGhost {
-	[data-selection-focus-styles="true"]
-		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected:not(.containerHighlighted)
-		&,
-	.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) & {
-		/* Duplicated styles for ghost-inverted button variant. This is necessary to
-		make the variant responsive to selection/focus changes purely with CSS. */
-
-		--button-border: none;
-		--button-bg: transparent;
-		--button-fg: color-mix(in srgb, var(--text-1-invert) 90%, transparent);
-		--button-hover-fg: var(--text-1-invert);
-		--button-hover-bg: color-mix(in srgb, var(--scale-gray-100) 5%, transparent);
-	}
-}
-
-.buttonOutline {
-	[data-selection-focus-styles="true"]
-		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected:not(.containerHighlighted)
-		&,
-	.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) & {
-		/* Duplicated styles for outline-inverted button variant. This is necessary to
-		make the variant responsive to selection/focus changes purely with CSS. */
-
-		--button-border: 1px solid color-mix(in srgb, var(--fill-gray-fg) 30%, transparent);
-		--button-bg: transparent;
-		--button-fg: color-mix(in srgb, var(--text-1-invert) 90%, transparent);
-		--button-hover-fg: var(--text-1-invert);
-		--button-hover-bg: color-mix(in srgb, var(--scale-gray-100) 5%, transparent);
-	}
+.gitRef {
+	font-family: "Geist Mono", monospace;
 }
 
 .bubbleGroup {
@@ -392,18 +302,4 @@
 		border-start-end-radius: 0;
 		border-end-end-radius: 0;
 	}
-}
-
-/* Flag consumed via `@container style()` by the components that sit in a row —
-   badges and graph segments — so they can restyle themselves for the selected
-   state without cross-module class references. Raised for both states that give
-   the row its solid inverted fill: a focused selection, and a row carrying an
-   inline editor — but not for a highlighted row, whose dependency fill is light
-   enough that its contents stay in the normal palette. The same exclusion runs
-   through the inverted text and button rules above. */
-[data-selection-focus-styles="true"]
-	[data-focus-scope][data-selection-focused="true"]
-	.containerSelected:not(.containerHighlighted),
-.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) {
-	--selection-inverted: true;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -67,7 +67,7 @@ import { toggleFoldedSegment } from "./fold.ts";
 import { InlineEditor } from "./InlineEditor.tsx";
 import { insertBlankCommitMenuItem } from "./insertBlankCommitMenuItem.ts";
 import { ItemRow } from "./ItemRow.tsx";
-import { BranchRowHeadline } from "../BranchRowHeadline.tsx";
+import { BranchRowHeadline, BranchReviewTag, BranchTopics } from "../BranchRowHeadline.tsx";
 import { useStackMenuItems } from "./useStackMenuItems.ts";
 import { ciChecksSummaryUrl, type AggregateCIChecks } from "#ui/ci.ts";
 import {
@@ -540,12 +540,18 @@ export const BranchRow: FC<
 						<BranchRowHeadline title={openReview.title} labels={openReview.labels} />
 					) : (
 						<RowLabelContainer>
-							<RowLabel heading singleLine title={optimisticBranchDisplayName}>
+							<RowLabel
+								heading
+								singleLine
+								className={rowStyles.gitRef}
+								title={optimisticBranchDisplayName}
+							>
 								{optimisticBranchDisplayName}
 							</RowLabel>
 						</RowLabelContainer>
 					)}
 
+					{openReview && <BranchReviewTag title={openReview.title} labels={openReview.labels} />}
 					<RowMeta>
 						{openReview !== undefined && (
 							<>
@@ -557,7 +563,10 @@ export const BranchRow: FC<
 									)}
 								>
 									<Icon name="branch" size={12} />
-									<span className={rowStyles.metaItemText} title={optimisticBranchDisplayName}>
+									<span
+										className={classes(rowStyles.metaItemText, rowStyles.gitRef)}
+										title={optimisticBranchDisplayName}
+									>
 										{optimisticBranchDisplayName}
 									</span>
 								</span>
@@ -712,6 +721,11 @@ export const BranchRow: FC<
 							</Button>
 						)}
 					</RowMeta>
+					{openReview && (
+						<RowMeta>
+							<BranchTopics labels={openReview.labels} />
+						</RowMeta>
+					)}
 				</RowLabelGroup>
 			)}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
@@ -359,7 +359,7 @@ const WorktreeBranchRow: FC<
 		>
 			<GraphSegment glyph="joinRight" status="LocalOnly" behind={behind} />
 			<RowLabelContainer>
-				<RowLabel heading singleLine>
+				<RowLabel heading singleLine className={rowStyles.gitRef}>
 					{refName.displayName}
 				</RowLabel>
 			</RowLabelContainer>

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.test.tsx
@@ -2,7 +2,7 @@
 
 import { hunkAddress, type HunkAddress } from "#ui/addresses.ts";
 import { store } from "#ui/store.ts";
-import type { CodeViewDiffItem } from "@pierre/diffs";
+import { processFile, type CodeViewDiffItem } from "@pierre/diffs";
 import { act, createRef, forwardRef, type RefObject, useImperativeHandle } from "react";
 import { Provider } from "react-redux";
 import { createRoot, type Root } from "react-dom/client";
@@ -68,7 +68,10 @@ const pointerOver = (element: HTMLElement) =>
 		element.dispatchEvent(new Event("pointerover", { bubbles: true, composed: true }));
 	});
 
-type ColumnLine = { number: number; type?: "change-addition" | "context" };
+type ColumnLine = {
+	number: number;
+	type?: "change-addition" | "change-deletion" | "context" | "context-expanded";
+};
 
 /**
  * A column of number cells laid out the way Pierre renders one: a code element holding a gutter
@@ -99,6 +102,10 @@ const createColumn = (
 			cell.setAttribute("data-column-number", `${number}`);
 			cell.setAttribute("data-line-type", type);
 			cell.setAttribute("data-line-index", `${index},${index}`);
+			const numberContent = document.createElement("span");
+			numberContent.setAttribute("data-line-number-content", "");
+			numberContent.textContent = String(number);
+			cell.append(numberContent);
 			return cell;
 		});
 	const cells = build();
@@ -148,6 +155,52 @@ describe("useDiffGutterCheckboxes", () => {
 	afterEach(() => {
 		act(() => root.unmount());
 		container.remove();
+	});
+
+	it("keeps old and new numbers distinct across a replacement and expanded context", async () => {
+		const fileDiff = processFile(
+			"diff --git a/file.ts b/file.ts\n--- a/file.ts\n+++ b/file.ts\n@@ -100,3 +100,4 @@\n before\n-old\n+new\n+extra\n after\n",
+		);
+		if (!fileDiff) throw new Error("expected parsed diff");
+		const item = { ...ITEM, fileDiff };
+		const { host, cells, rerender } = createColumn([
+			{ number: 99, type: "context-expanded" },
+			{ number: 100, type: "context" },
+			{ number: 101, type: "change-deletion" },
+			{ number: 101 },
+			{ number: 102 },
+			{ number: 103, type: "context" },
+			{ number: 104, type: "context-expanded" },
+		]);
+		const render = async () => {
+			await act(async () => {
+				Reflect.apply(handle().onPostRender, undefined, [
+					host,
+					{},
+					"mount",
+					{ type: "diff", item, element: host, version: item.version },
+				]);
+			});
+		};
+		const pairs = (rows: Array<HTMLElement>) =>
+			rows.map((row) => [
+				row.querySelector('[data-gitbutler-line-number="old"]')?.textContent,
+				row.querySelector('[data-gitbutler-line-number="new"]')?.textContent,
+			]);
+		await render();
+		const expected = [
+			["99", "99"],
+			["100", "100"],
+			["101", "·"],
+			["·", "101"],
+			["·", "102"],
+			["102", "103"],
+			["103", "104"],
+		];
+		expect(pairs(cells)).toEqual(expected);
+		const fresh = rerender();
+		await render();
+		expect(pairs(fresh)).toEqual(expected);
 	});
 
 	it("takes the actions card back when the pointer moves off the numbers onto the code", async () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -1,4 +1,4 @@
-import type { CodeViewOptions } from "@pierre/diffs";
+import type { CodeViewOptions, FileDiffMetadata } from "@pierre/diffs";
 import { createElement, type ReactElement, useLayoutEffect, useRef } from "react";
 import {
 	hunkAddress,
@@ -36,6 +36,27 @@ const OPERATION_SOURCE_ATTRIBUTE = "data-gitbutler-operation-source";
 const CHECK_DRAG_ATTRIBUTE = "data-gitbutler-diff-check-drag";
 
 export const diffGutterUnsafeCSS = `
+	[data-gitbutler-line-numbers] {
+		display: inline-flex;
+		font-family: "Geist Mono", monospace;
+		color: var(--text-3);
+	}
+	[data-gitbutler-line-number] {
+		box-sizing: border-box;
+		width: calc(max(2ch, var(--diffs-min-number-column-width-default, 2ch)) + 4px);
+		padding-inline-end: 4px;
+		text-align: right;
+	}
+	[data-gitbutler-line-number][data-empty] { color: var(--border-1); }
+	[data-unified] [data-column-number] { padding-left: var(--gitbutler-diff-gutter-width); }
+	[data-indicators="classic"] [data-line-type="change-addition"][data-line]::before {
+		color: var(--change-status-addition);
+	}
+	[data-indicators="classic"] [data-line-type="change-deletion"][data-line]::before {
+		content: "−";
+		color: var(--change-status-deletion);
+	}
+
 	/* While a press is painting checkboxes, the lines it crosses are the gesture's, not text. */
 	:host([${CHECK_DRAG_ATTRIBUTE}]) {
 		user-select: none;
@@ -398,6 +419,73 @@ const ensureHunkBand = (
 	return band;
 };
 
+// Pierre keeps both offsets in each hunk, but displays the new number for unified context.
+const oldContextLine = (line: number, diff: FileDiffMetadata): number => {
+	let offset = 0;
+	for (const hunk of diff.hunks) {
+		if (line < hunk.additionStart) return line + offset;
+		let oldLine = hunk.deletionStart;
+		let newLine = hunk.additionStart;
+		for (const content of hunk.hunkContent) {
+			if (content.type === "context") {
+				if (line < newLine + content.lines) return oldLine + line - newLine;
+				oldLine += content.lines;
+				newLine += content.lines;
+			} else {
+				oldLine += content.deletions;
+				newLine += content.additions;
+			}
+		}
+		offset = oldLine - newLine;
+	}
+	return line + offset;
+};
+
+const renderLineNumbers = (
+	cell: HTMLElement,
+	target: DiffLineTarget,
+	diff: FileDiffMetadata,
+): void => {
+	const content = cell.querySelector<HTMLElement>("[data-line-number-content]");
+	if (!content) return;
+	if (!cell.closest("[data-unified]")) {
+		if (content.hasAttribute("data-gitbutler-line-numbers")) {
+			content.removeAttribute("data-gitbutler-line-numbers");
+			content.textContent = String(target.lineNumber);
+		}
+		return;
+	}
+	const oldLine =
+		target.lineType === "context"
+			? oldContextLine(target.lineNumber, diff)
+			: target.side === "deletions"
+				? target.lineNumber
+				: null;
+	const newLine =
+		target.lineType === "context" || target.side === "additions" ? target.lineNumber : null;
+	const signature = `${String(oldLine)}:${String(newLine)}`;
+	if (content.getAttribute("data-gitbutler-line-numbers") === signature) return;
+	content.setAttribute("data-gitbutler-line-numbers", signature);
+	content.replaceChildren(
+		...(
+			[
+				["old", oldLine],
+				["new", newLine],
+			] as const
+		).map(([side, number]) => {
+			const span = document.createElement("span");
+			span.setAttribute("data-gitbutler-line-number", side);
+			span.setAttribute(
+				"aria-label",
+				`${side === "old" ? "Old" : "New"} line ${number ?? "absent"}`,
+			);
+			if (number === null) span.setAttribute("data-empty", "");
+			span.textContent = number === null ? "·" : String(number);
+			return span;
+		}),
+	);
+};
+
 const createGutterStore = <T>(
 	getOnPostRender: () => OnPostRender<T>,
 	getLineAddress: () => GetHunkAddress,
@@ -417,6 +505,7 @@ const createGutterStore = <T>(
 	const controlsByGroupByHost = new Map<HTMLElement, Map<string, Array<HTMLElement>>>();
 	const removeHoverListenersByHost = new Map<HTMLElement, () => void>();
 	const itemIdsByHost = new Map<HTMLElement, string>();
+	const fileDiffsByHost = new WeakMap<HTMLElement, FileDiffMetadata>();
 	const actionCardsByHost = new Map<HTMLElement, ActionsCard>();
 	const bandsByGroupByHost = new Map<HTMLElement, Map<string, Array<HTMLElement>>>();
 	const checkedGroupsByHost = new Map<HTMLElement, Set<string>>();
@@ -793,6 +882,8 @@ const createGutterStore = <T>(
 
 		for (const [index, cell] of cells.entries()) {
 			const target = diffLineTargetFromElement({ element: cell, itemId });
+			const fileDiff = fileDiffsByHost.get(host);
+			if (target && fileDiff) renderLineNumbers(cell, target, fileDiff);
 			if (target?.lineType !== "change") continue;
 
 			const lineAddress = getLineAddress()(target);
@@ -923,8 +1014,12 @@ const createGutterStore = <T>(
 		setGroupChecked,
 		setGroupCheckable,
 		onPostRender: (host, instance, phase, context) => {
-			if (phase === "unmount" || context.type !== "diff") removeTarget(host);
-			else syncTarget(host, context.item.id);
+			if (phase === "unmount" || context.type !== "diff") {
+				removeTarget(host);
+			} else {
+				fileDiffsByHost.set(host, context.item.fileDiff);
+				syncTarget(host, context.item.id);
+			}
 			// CodeView exposes this callback as file/diff overloads; forward the exact invocation.
 			Reflect.apply(getOnPostRender(), undefined, [host, instance, phase, context]);
 		},

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.test.ts
@@ -31,11 +31,9 @@ describe("buildFileTreeRows", () => {
 		const rows = tree(["readme.md", "src/app.ts", "src/ui/row.ts", "docs/guide.md"]);
 
 		expect(layout(rows)).toEqual([
-			"docs/",
-			"  docs/guide.md",
+			"docs/guide.md",
 			"src/",
-			"  ui/",
-			"    src/ui/row.ts",
+			"  src/ui/row.ts",
 			"  src/app.ts",
 			"readme.md",
 		]);
@@ -45,11 +43,9 @@ describe("buildFileTreeRows", () => {
 		const rows = tree(["readme.md", "src/app.ts", "src/ui/row.ts", "docs/guide.md"]);
 
 		expect(rows.map(({ path, positionInSet, setSize }) => [path, positionInSet, setSize])).toEqual([
-			["docs", 1, 3],
-			["docs/guide.md", 1, 1],
+			["docs/guide.md", 1, 3],
 			["src", 2, 3],
-			["src/ui", 1, 2],
-			["src/ui/row.ts", 1, 1],
+			["src/ui/row.ts", 1, 2],
 			["src/app.ts", 2, 2],
 			["readme.md", 3, 3],
 		]);
@@ -69,7 +65,35 @@ describe("buildFileTreeRows", () => {
 	test("stops folding where a directory holds files of its own", () => {
 		const rows = tree(["src/lib/row.ts", "src/app.ts"]);
 
-		expect(layout(rows)).toEqual(["src/", "  lib/", "    src/lib/row.ts", "  src/app.ts"]);
+		expect(layout(rows)).toEqual(["src/", "  src/lib/row.ts", "  src/app.ts"]);
+	});
+
+	test("folds a single-file chain into the file row", () => {
+		expect(tree(["apps/lite/Graph/usePlan.ts"])).toMatchObject([
+			{
+				_tag: "File",
+				path: "apps/lite/Graph/usePlan.ts",
+				name: "apps/lite/Graph/usePlan.ts",
+				depth: 0,
+			},
+		]);
+	});
+
+	test("collapses reviewed directories by default but respects an explicit expansion", () => {
+		const input = {
+			items: items("reviewed/a.ts", "reviewed/b.ts", "pending/a.ts", "pending/b.ts"),
+			mode: "tree" as const,
+			reviewedPaths: new Set(["reviewed/a.ts", "reviewed/b.ts"]),
+		};
+		const rows = buildFileTreeRows({ ...input, collapsedDirectories: {} });
+		expect(rows.find((row) => row.path === "reviewed")).toMatchObject({ collapsed: true });
+		expect(rows.find((row) => row.path === "pending")).toMatchObject({ collapsed: false });
+		expect(rows.some((row) => row.path === "reviewed/a.ts")).toBe(false);
+		expect(
+			buildFileTreeRows({ ...input, collapsedDirectories: { reviewed: false } }).some(
+				(row) => row.path === "reviewed/a.ts",
+			),
+		).toBe(true);
 	});
 
 	test("sorts names naturally, case only breaking ties", () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
@@ -26,20 +26,31 @@ export type FileTreeRow<T> = {
 			name: string;
 			/** Every file below this directory, in the order expanding it would reveal them. */
 			filePaths: Array<string>;
+			collapsed: boolean;
 	  }
-	| { _tag: "File"; item: T }
+	| { _tag: "File"; item: T; name?: string }
 );
 
 type Directory<T> = {
 	directories: Map<string, Directory<T>>;
 	items: Array<T>;
+	hasUnreviewed: boolean;
 };
 
-const emptyDirectory = <T>(): Directory<T> => ({ directories: new Map(), items: [] });
+const emptyDirectory = <T>(): Directory<T> => ({
+	directories: new Map(),
+	items: [],
+	hasUnreviewed: false,
+});
 
-const insert = <T extends { path: string }>(root: Directory<T>, item: T): void => {
+const insert = <T extends { path: string }>(
+	root: Directory<T>,
+	item: T,
+	reviewed: boolean,
+): void => {
 	const segments = item.path.split("/");
 	let directory = root;
+	if (!reviewed) directory.hasUnreviewed = true;
 
 	for (const segment of segments.slice(0, -1)) {
 		let child = directory.directories.get(segment);
@@ -48,6 +59,7 @@ const insert = <T extends { path: string }>(root: Directory<T>, item: T): void =
 			directory.directories.set(segment, child);
 		}
 		directory = child;
+		if (!reviewed) directory.hasUnreviewed = true;
 	}
 
 	directory.items.push(item);
@@ -97,7 +109,7 @@ const collectRows = <T extends { path: string }>({
 	directory: Directory<T>;
 	prefix: string;
 	depth: number;
-	collapsedDirectories: Record<string, true>;
+	collapsedDirectories: Record<string, boolean>;
 }): Collected<T> => {
 	const rows: Array<FileTreeRow<T>> = [];
 	const filePaths: Array<string> = [];
@@ -108,7 +120,25 @@ const collectRows = <T extends { path: string }>({
 		const folded = foldSoleChildren(name, child);
 		const { name: foldedName, directory: foldedDirectory } = folded;
 		const path = prefix === "" ? foldedName : `${prefix}/${foldedName}`;
-		const collapsed = collapsedDirectories[path] === true;
+		const onlyFile =
+			foldedDirectory.directories.size === 0 && foldedDirectory.items.length === 1
+				? foldedDirectory.items[0]
+				: undefined;
+		if (onlyFile !== undefined) {
+			rows.push({
+				_tag: "File",
+				path: onlyFile.path,
+				name: `${foldedName}/${onlyFile.path.split("/").at(-1) ?? onlyFile.path}`,
+				item: onlyFile,
+				depth,
+				positionInSet,
+				setSize,
+			});
+			positionInSet++;
+			filePaths.push(onlyFile.path);
+			continue;
+		}
+		const collapsed = collapsedDirectories[path] ?? !foldedDirectory.hasUnreviewed;
 		let below: Collected<T>;
 		if (collapsed) {
 			const filePaths: Array<string> = [];
@@ -131,6 +161,7 @@ const collectRows = <T extends { path: string }>({
 			positionInSet,
 			setSize,
 			filePaths: below.filePaths,
+			collapsed,
 		});
 		positionInSet++;
 		if (!collapsed) for (const row of below.rows) rows.push(row);
@@ -151,12 +182,14 @@ export const buildFileTreeRows = <T extends { path: string }>({
 	mode,
 	collapsedDirectories,
 	compare,
+	reviewedPaths,
 }: {
 	items: Array<T>;
 	mode: FileDisplayMode;
-	collapsedDirectories: Record<string, true>;
+	collapsedDirectories: Record<string, boolean>;
 	/** Row order; path order when absent. Tree mode still groups by directory around it. */
 	compare?: (a: T, b: T) => number;
+	reviewedPaths?: ReadonlySet<string>;
 }): Array<FileTreeRow<T>> => {
 	const orderedItems = items.toSorted(compare ?? ((a, b) => compareFilePaths(a.path, b.path)));
 
@@ -172,7 +205,7 @@ export const buildFileTreeRows = <T extends { path: string }>({
 	}
 
 	const root = emptyDirectory<T>();
-	for (const item of orderedItems) insert(root, item);
+	for (const item of orderedItems) insert(root, item, reviewedPaths?.has(item.path) ?? false);
 
 	return collectRows({ directory: root, prefix: "", depth: 0, collapsedDirectories }).rows;
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
@@ -1,8 +1,15 @@
-import { branchDetailsQueryOptions, branchListQueryOptions } from "#ui/api/queries.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import {
+	branchDetailsQueryOptions,
+	branchListQueryOptions,
+	guiSettingsQueryOptions,
+} from "#ui/api/queries.ts";
 import { usePage } from "#ui/use-cursor.ts";
 import { encodeBytes } from "#ui/api/bytes.ts";
 import {
 	branchDetailsParams,
+	branchListSections,
+	type BranchListGroup,
 	branchIsEmpty,
 	branchOwnCommits,
 	searchStacks,
@@ -17,6 +24,8 @@ import { useQueries, useQuery, type UseQueryResult } from "@tanstack/react-query
 import { useDeferredValue } from "react";
 
 type BranchesListBranch = {
+	isTopBranch: boolean;
+	isStacked: boolean;
 	branch: ListedBranch;
 	addressIndex: number;
 	/**
@@ -27,6 +36,9 @@ type BranchesListBranch = {
 };
 
 type BranchesListStack = {
+	key: string;
+	group?: BranchListGroup;
+	grouped: boolean;
 	branches: Array<BranchesListBranch>;
 	commitCount: number;
 	reviewCount: number;
@@ -66,6 +78,14 @@ export const useBranchesList = (projectId: string): UseQueryResult<BranchesListC
 		projectSlice.selectors.selectUnfoldedBranches(state, projectId),
 	);
 
+	const { data: grouping = defaultSettings.branchGrouping } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => cfg.branchGrouping ?? defaultSettings.branchGrouping,
+	});
+	const collapsedGroups = useAppSelector((state) =>
+		projectSlice.selectors.selectCollapsedBranchGroups(state, projectId),
+	);
+
 	const unfoldedBranchRefs = Object.keys(unfoldedBranches);
 	const commitsByRef = useQueries({
 		queries: unfoldedBranchRefs.map((refName) => ({
@@ -87,38 +107,51 @@ export const useBranchesList = (projectId: string): UseQueryResult<BranchesListC
 		...branchListQueryOptions(projectId),
 		enabled: active,
 		select: (listedStacks): BranchesListContent => {
-			const unapplied = searchStacks(unappliedStacks(listedStacks, filters), search);
+			const unapplied = branchListSections(
+				searchStacks(unappliedStacks(listedStacks, filters), search),
+				grouping,
+				collapsedGroups,
+			);
 			const items: Array<Address> = [];
 			const stackIndexByAddressIndex: Array<number> = [];
 			const stacks = unapplied.map((stack, stackIndex): BranchesListStack => {
 				let commitCount = 0;
 				let reviewCount = 0;
-				const branches = stack.branches.map((branch): BranchesListBranch => {
-					if (branch.review !== null) reviewCount += 1;
-					const addressIndex = items.length;
-					items.push(branchAddress({ branchRef: encodeBytes(branch.refName.full) }));
-					stackIndexByAddressIndex.push(stackIndex);
+				const branches = stack.branches.map(
+					({ branch, isTopBranch, isStacked }): BranchesListBranch => {
+						if (branch.review !== null) reviewCount += 1;
+						const addressIndex = items.length;
+						items.push(branchAddress({ branchRef: encodeBytes(branch.refName.full) }));
+						stackIndexByAddressIndex.push(stackIndex);
 
-					const branchCommits = commitsByRef.get(branch.refName.full);
-					const commits =
-						unfoldedBranches[branch.refName.full] &&
-						!branchIsEmpty(branch) &&
-						branchCommits !== undefined
-							? branchOwnCommits(branch, branchCommits)
-							: undefined;
+						const branchCommits = commitsByRef.get(branch.refName.full);
+						const commits =
+							unfoldedBranches[branch.refName.full] &&
+							!branchIsEmpty(branch) &&
+							branchCommits !== undefined
+								? branchOwnCommits(branch, branchCommits)
+								: undefined;
 
-					if (commits !== undefined) {
-						commitCount += commits.length;
-						for (const commit of commits) {
-							items.push(commitAddress({ commitId: commit.id, changeId: commit.changeId }));
-							stackIndexByAddressIndex.push(stackIndex);
+						if (commits !== undefined) {
+							commitCount += commits.length;
+							for (const commit of commits) {
+								items.push(commitAddress({ commitId: commit.id, changeId: commit.changeId }));
+								stackIndexByAddressIndex.push(stackIndex);
+							}
 						}
-					}
 
-					return { branch, addressIndex, commits };
-				});
+						return { branch, addressIndex, commits, isTopBranch, isStacked };
+					},
+				);
 
-				return { branches, commitCount, reviewCount };
+				return {
+					key: stack.key,
+					group: stack.group,
+					grouped: stack.grouped,
+					branches,
+					commitCount,
+					reviewCount,
+				};
 			});
 
 			return {

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -13,6 +13,7 @@ export const defaultSettings = {
 	diffFontFamily: "Geist Mono, Menlo, monospace",
 	diffFontSize: 12,
 	diffLigatures: false,
+	branchGrouping: "state",
 	diffOverflow: "wrap",
 	diffStyle: "split",
 	diffTabSize: 4,

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -13,7 +13,7 @@ export const defaultSettings = {
 	diffFontFamily: "Geist Mono, Menlo, monospace",
 	diffFontSize: 12,
 	diffLigatures: false,
-	diffOverflow: "scroll",
+	diffOverflow: "wrap",
 	diffStyle: "split",
 	diffTabSize: 4,
 	// Previewing while dragging runs a dry run for every target the pointer crosses, and


### PR DESCRIPTION
Makes review state and change volume easier to read across Lite. Implements the nine UI review prompts and the follow-up to restore colorful tags, scoped to `apps/lite`.

## Diff

- Show independent old/new line numbers and +/− markers. Size the number columns to the file with compact padding, following the follow-up request to remove the 44px minimum.
- Wrap long lines by default, persist Wrap/Scroll, and separate review progress from labeled view controls.
- Show per-file/folder change counts, compress single-child paths, and collapse reviewed folders by default. Persist labeled Tree/Flat controls.

## Branches

- Separate single-line bare branches from PR rows. Default to State grouping with Merged collapsed; retain Author and Recent.
- Use mono refs, distinct PR titles, colored topic chips, and PR status tags. Keep one actionable tag per row.
- Apply the same light selection tint in the workspace and branches panels.

## PR detail

- Put merge readiness first in the rail and display the disabled Merge control's blocker. Keep forge mergeability authoritative.
- Move recognized verdict headings into byline tags. Include ordinary agent comments in readiness and let newer verdicts supersede older ones from the same author.
- Expand descriptions, fill the lower rail with Files changed, separate audience from Compact, and split Topics from Owners.

## Validation

- `pnpm -F @gitbutler/lite check`
- `pnpm -F @gitbutler/lite test`: 590 passed (544 UI, 46 harness).
- `pnpm -F @gitbutler/lite test:e2e`: 45 passed, 9 opt-in screenshot tests skipped on the nine-step pass.
- Tag follow-up: typecheck and 4 targeted branch/workspace e2e tests passed, including colored chips, PR states, hover stability, and visibility with 27 merged branches collapsed.
- Oxlint, both Knip checks, Oxfmt, and Prettier passed.
- Inspected React Compiler output for cached diff, file, branch, readiness, and activity derivations.
- Captured and visually checked the diff in greyscale, the 34-file rail, and the grouped branch list.

Existing tests updated:

- `diff-gutter.test.tsx`: Pierre content wrappers, independent offsets, expanded context, and split restoration.
- `file-tree.test.ts`: compressed paths/parents/siblings and review-based collapse defaults.
- `branch.test.ts`: grouping, preserved stack metadata, title prefixes, and actionable tags.
- `branches-list.spec.ts`: author/group presentation, colored topics and PR state tags, metadata order, selection tint, and merged-group collapse.
- `workspace-reviews.spec.ts`: matching workspace/branch selection.
- `workspace-focus.spec.ts`: replace two inversion expectations with stable tint and actual focus assertions.

New tests cover replacement rows, wrapping/scrolling and persistence, review progress, 34-file rail counts and binary files, verdict parsing/effective verdicts, merge authorization, visible blockers, description/rail layout, files, audience, and density.

## Scope notes

- No P3 work was intentionally included. `RECOMMENDATIONS.md`, the HTML mock, and the supplied `../design-core` checkout were unavailable; followed the detailed prompts and installed design-core 3.17.1, which contains all named tokens.
- Title-prefix parsing stands in for a real per-PR flag for the separate follow-up issue.
- Added a collapsed Closed group so closed PRs remain accessible.
- A generic blocked forge state does not prove the absence of conflicts; the UI reports unknown when needed. Draft, behind-base, checking/unknown, branch protection, and other forge-specific blockers retain their existing explanation.
- Files changed uses the existing local branch-diff API and reports unavailability when the branch is not local.
- PR-detail screenshot coverage is pending the choice between permanent mocked-review catalogue coverage and a one-off capture. The existing catalogue covers the diff and branches; no screenshot-complete label is claimed.
- **Emoji grep remains unresolved:** nightly heart, reaction choices, conflict warning, Markdown emoji support, and emoji in comments/stories/tests remain unchanged. The Settings external-link arrow also matches the scan. Verdict-parser fixtures intentionally retain emoji input.